### PR TITLE
Fixed serialize bug that showed up in round trip test

### DIFF
--- a/tests/cookbook_class1_test.cpp
+++ b/tests/cookbook_class1_test.cpp
@@ -60,6 +60,10 @@ namespace daw::cookbook_class1 {
 		return std::forward_as_tuple( value.member_0, value.member_1,
 		                              value.member_2 );
 	}
+
+	bool operator==( MyClass1 const &lhs, MyClass1 const &rhs ) {
+		return to_json_data( lhs ) == to_json_data( rhs );
+	}
 } // namespace daw::cookbook_class1
 
 int main( int argc, char **argv ) {
@@ -69,13 +73,18 @@ int main( int argc, char **argv ) {
 	}
 	auto data = daw::memory_mapped_file<>( argv[1] );
 
-	auto cls = daw::json::from_json<daw::cookbook_class1::MyClass1>(
+	auto const cls = daw::json::from_json<daw::cookbook_class1::MyClass1>(
 	  std::string_view( data.data( ), data.size( ) ) );
 
 	daw::json::json_assert( cls.member_0 == "this is a test",
 	                        "Unexpected value" );
 	daw::json::json_assert( cls.member_1 == 314159, "Unexpected value" );
 	daw::json::json_assert( cls.member_2 == true, "Unexpected value" );
-	auto str = daw::json::to_json( cls );
+	auto const str = daw::json::to_json( cls );
 	puts( str.c_str( ) );
+
+	auto const cls2 = daw::json::from_json<daw::cookbook_class1::MyClass1>(
+	  std::string_view( str.data( ), str.size( ) ) );
+
+	daw::json::json_assert( cls == cls2, "Unexpected round trip error" );
 }

--- a/tests/cookbook_kv1_test.cpp
+++ b/tests/cookbook_kv1_test.cpp
@@ -54,6 +54,10 @@ namespace daw::cookbook_kv1 {
 	auto to_json_data( MyKeyValue1 const &value ) {
 		return std::forward_as_tuple( value.kv );
 	}
+
+	bool operator==( MyKeyValue1 const & lhs, MyKeyValue1 const & rhs ) {
+		return lhs.kv == rhs.kv;
+	}
 } // namespace daw::cookbook_kv1
 
 int main( int argc, char **argv ) {
@@ -69,6 +73,10 @@ int main( int argc, char **argv ) {
 	daw::json::json_assert( kv.kv.size( ) == 2, "Expected data to have 2 items" );
 	daw::json::json_assert( kv.kv["key0"] == 353434, "Unexpected value" );
 	daw::json::json_assert( kv.kv["key1"] == 314159, "Unexpected value" );
-	auto str = daw::json::to_json( kv );
+	auto const str = daw::json::to_json( kv );
 	puts( str.c_str( ) );
+	auto const kv2 = daw::json::from_json<daw::cookbook_kv1::MyKeyValue1>(
+	  std::string_view( str.data( ), str.size( ) ) );
+
+	daw::json::json_assert( kv == kv2, "Unexpected round trip error" );
 }

--- a/tests/cookbook_kv2_test.cpp
+++ b/tests/cookbook_kv2_test.cpp
@@ -59,6 +59,10 @@ namespace daw::cookbook_kv2 {
 	auto to_json_data( MyKeyValue2 const &value ) {
 		return std::forward_as_tuple( value.kv );
 	}
+
+	bool operator==( MyKeyValue2 const &lhs, MyKeyValue2 const &rhs ) {
+		return lhs.kv == rhs.kv;
+	}
 } // namespace daw::cookbook_kv2
 
 int main( int argc, char **argv ) {
@@ -74,6 +78,10 @@ int main( int argc, char **argv ) {
 	daw::json::json_assert( kv.kv.size( ) == 2, "Expected data to have 2 items" );
 	daw::json::json_assert( kv.kv[0] == "test_001", "Unexpected value" );
 	daw::json::json_assert( kv.kv[1] == "test_002", "Unexpected value" );
-	auto str = daw::json::to_json( kv );
+	auto const str = daw::json::to_json( kv );
 	puts( str.c_str( ) );
+
+	auto const kv2 = daw::json::from_json<daw::cookbook_kv2::MyKeyValue2>(
+	  std::string_view( str.data( ), str.size( ) ) );
+	daw::json::json_assert( kv == kv2, "Unexpected round trip error" );
 }


### PR DESCRIPTION
Was not outputting member names in key_value_array, fixed that while adding round trip testing