### PR TITLE
Fixed bug in to_string and literals as strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,11 @@ add_dependencies(int_sanity_test_bin dependency_stub)
 add_test(NAME int_sanity_test COMMAND int_sanity_test_bin )
 add_dependencies(full int_sanity_test_bin)
 
+add_executable(nativejson_roundtrip_bin EXCLUDE_FROM_ALL ${HEADER_FILES} ${TEST_FOLDER}/twitter_test.h ${TEST_FOLDER}/citm_test.h ${TEST_FOLDER}/geojson.h ${TEST_FOLDER}/nativejson_roundtrip.cpp)
+add_dependencies(nativejson_roundtrip_bin dependency_stub)
+target_link_libraries(nativejson_roundtrip_bin ${COMPILER_SPECIFIC_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+add_test(NAME nativejson_roundtrip COMMAND nativejson_roundtrip_bin ./twitter.json ./citm_catalog.json ./canada.json WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test_data/")
+add_dependencies(full nativejson_roundtrip_bin)
 
 
 install(DIRECTORY ${HEADER_FOLDER}/daw/json/ DESTINATION include/daw/json/)

--- a/tests/nativejson_roundtrip.cpp
+++ b/tests/nativejson_roundtrip.cpp
@@ -1,0 +1,94 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Darrell Wright
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files( the "Software" ), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and / or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "citm_test.h"
+#include "geojson.h"
+#include "twitter_test.h"
+
+#include <daw/json/daw_json_iterator.h>
+#include <daw/json/daw_json_link.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string_view>
+#include <unistd.h>
+
+std::string read_file( std::string const &filename ) {
+	std::ifstream f( filename );
+	if( !f ) {
+		return {};
+	}
+	return std::string( std::istreambuf_iterator<char>( f ),
+	                    std::istreambuf_iterator<char>( ) );
+}
+
+int main( int argc, char *argv[] ) {
+#if defined( NDEBUG ) and not defined( DEBUG )
+	std::cout << "release run\n";
+#else
+	std::cout << "debug run\n";
+#endif
+	if( argc < 4 ) {
+		std::cerr << "Must supply a filenames to open\n";
+		std::cerr << "twitter citm canada\n";
+		exit( 1 );
+	}
+
+	std::string const twitter_data = read_file( argv[1] );
+	std::string const citm_data = read_file( argv[2] );
+	std::string const canada_data = read_file( argv[3] );
+
+	std::cout << "C++ DAW JSON Link\t" << getpid( );
+	auto const canada_obj =
+	  daw::json::from_json<daw::geojson::FeatureCollection>( canada_data );
+	auto const twitter_obj =
+	  daw::json::from_json<daw::twitter::twitter_object_t>( twitter_data );
+	auto const citm_obj =
+	  daw::json::from_json<daw::citm::citm_object_t>( citm_data );
+
+	auto const canada_out = daw::json::to_json( canada_obj );
+	auto const twitter_out = daw::json::to_json( twitter_obj );
+	auto const citm_out = daw::json::to_json( citm_obj );
+
+	auto const canada_obj2 =
+	  daw::json::from_json<daw::geojson::FeatureCollection>( canada_out );
+	auto const twitter_obj2 =
+	  daw::json::from_json<daw::twitter::twitter_object_t>( twitter_out );
+	auto const citm_obj2 =
+	  daw::json::from_json<daw::citm::citm_object_t>( citm_out );
+
+	auto const canada_out2 = daw::json::to_json( canada_obj2 );
+	auto const twitter_out2 = daw::json::to_json( twitter_obj2 );
+	auto const citm_out2 = daw::json::to_json( citm_obj2 );
+
+	std::cout << "canada roundtrip: "
+	          << ( canada_out == canada_out2 ? "good" : "bad" ) << '\n';
+	std::cout << "twitter roundtrip: "
+	          << ( twitter_out == twitter_out2 ? "good" : "bad" ) << '\n';
+	std::cout << "citm roundtrip: " << ( citm_out == citm_out2 ? "good" : "bad" )
+	          << '\n';
+
+	std::cout << "stop";
+
+	return EXIT_SUCCESS;
+}

--- a/tests/nativejson_roundtrip.cpp
+++ b/tests/nativejson_roundtrip.cpp
@@ -31,7 +31,6 @@
 #include <iostream>
 #include <sstream>
 #include <string_view>
-#include <unistd.h>
 
 std::string read_file( std::string const &filename ) {
 	std::ifstream f( filename );
@@ -58,7 +57,7 @@ int main( int argc, char *argv[] ) {
 	std::string const citm_data = read_file( argv[2] );
 	std::string const canada_data = read_file( argv[3] );
 
-	std::cout << "C++ DAW JSON Link\t" << getpid( );
+	std::cout << "C++ DAW JSON Link\n";
 	auto const canada_obj =
 	  daw::json::from_json<daw::geojson::FeatureCollection>( canada_data );
 	auto const twitter_obj =


### PR DESCRIPTION
Did not check that literal_as_string was set to always when serializing
in order to output quotes surrounding value