### PR TITLE
BUGFIX: nullable tagged variant types would access empty values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 project("json_link"
-        VERSION "2.9.4"
+        VERSION "2.9.5"
         DESCRIPTION "Static JSON parsing in C++"
         HOMEPAGE_URL "https://github.com/beached/daw_json_link"
         LANGUAGES C CXX)

--- a/include/daw/json/impl/daw_json_serialize_impl.h
+++ b/include/daw/json/impl/daw_json_serialize_impl.h
@@ -40,7 +40,7 @@ namespace daw::json::json_details {
 		// in the future
 		(void)( ( tags_to_json_str<Is,
 		                           daw::traits::nth_element<Is, JsonMembers...>>(
-		            is_first, it, value, visited_members ),
+		            is_first, it, args, value, visited_members ),
 		          ... ),
 		        0 );
 		// Regular Members


### PR DESCRIPTION
When serializing the tag, no check or empty was done when querying the index in use during serialization