### PR TITLE
Using newer/cleaner building daw-header-libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project("daw-json-link"
-        VERSION "2.10.1"
+        VERSION "2.10.2"
         DESCRIPTION "Static JSON parsing in C++"
         HOMEPAGE_URL "https://github.com/beached/daw_json_link"
         LANGUAGES C CXX)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -18,7 +18,7 @@ set( FETCHCONTENT_UPDATES_DISCONNECTED ON )
 FetchContent_Declare(
 	daw_header_libraries
 	GIT_REPOSITORY https://github.com/beached/header_libraries.git
-	GIT_TAG v1.29.1
+	GIT_TAG v1.29.7
 )
 
 FetchContent_Declare(


### PR DESCRIPTION
* Using v1.29.7 from header_libraries.  It's a cleaner build