### PR TITLE
Fixed class/struct mismatch and reduced symbol sizes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-         VERSION "3.0.3"
+         VERSION "3.0.4"
          DESCRIPTION "Static JSON parsing in C++"
          HOMEPAGE_URL "https://github.com/beached/daw_json_link"
          LANGUAGES C CXX )

--- a/include/daw/json/impl/daw_json_parse_class.h
+++ b/include/daw/json/impl/daw_json_parse_class.h
@@ -254,8 +254,13 @@ namespace daw::json {
 					using NeedClassPositions = std::bool_constant<(
 					  ( JsonMembers::must_be_class_member or ... ) )>;
 
+#if not defined( _MSC_VER ) or defined( __clang__ )
+					auto known_locations = DAW_AS_CONSTANT(
+					  ( make_locations_info<ParseState, JsonMembers...>( ) ) );
+#else
 					auto known_locations =
-					 DAW_AS_CONSTANT( (make_locations_info<ParseState, JsonMembers...>( )) );
+					  make_locations_info<ParseState, JsonMembers...>( );
+#endif
 
 					if constexpr( use_direct_construction_v<ParseState, JsonClass> ) {
 						auto const run_after_parse = class_cleanup<

--- a/include/daw/json/impl/daw_json_parse_class.h
+++ b/include/daw/json/impl/daw_json_parse_class.h
@@ -204,12 +204,6 @@ namespace daw::json {
 				}
 			};
 
-#if not defined( _MSC_VER ) or defined( __clang__ )
-			template<typename ParseState, typename... JsonMembers>
-			inline constexpr auto
-			  known_locations_v = make_locations_info<ParseState, JsonMembers...>( );
-#endif
-
 			///
 			/// @brief Parse to the user supplied class.  The parser will run
 			/// left->right if it can when the JSON document's order matches that of
@@ -260,12 +254,8 @@ namespace daw::json {
 					using NeedClassPositions = std::bool_constant<(
 					  ( JsonMembers::must_be_class_member or ... ) )>;
 
-#if defined( _MSC_VER ) and not defined( __clang__ )
 					auto known_locations =
-					  make_locations_info<ParseState, JsonMembers...>( );
-#else
-					auto known_locations = known_locations_v<ParseState, JsonMembers...>;
-#endif
+					 DAW_AS_CONSTANT( (make_locations_info<ParseState, JsonMembers...>( )) );
 
 					if constexpr( use_direct_construction_v<ParseState, JsonClass> ) {
 						auto const run_after_parse = class_cleanup<

--- a/include/daw/json/impl/daw_json_value_fwd.h
+++ b/include/daw/json/impl/daw_json_value_fwd.h
@@ -19,7 +19,7 @@ namespace daw::json {
 		/// @tparam ParseState see IteratorRange
 		template<json_options_t PolicyFlags = json_details::default_policy_flag,
 		         typename Allocator = json_details::NoAllocator>
-		class basic_json_value;
+		struct basic_json_value;
 
 		/// @brief An untyped JSON value
 		using json_value = basic_json_value<>;

--- a/include/daw/json/impl/version.h
+++ b/include/daw/json/impl/version.h
@@ -12,7 +12,7 @@
 /// name.
 #if not defined( DAW_JSON_VER_OVERRIDE )
 // Should be updated when a potential ABI break is anticipated
-#define DAW_JSON_VER v3_0_0
+#define DAW_JSON_VER v3_0_4
 #else
 #define DAW_JSON_VER DAW_JSON_VER_OVERRIDE
 #endif


### PR DESCRIPTION
Removed global symbol known_locations_v as it can be private and is still constant constructed.  Could not hide it otherwise and it's not needed globally.