### PR TITLE
BUGFIX for #334: condition had > 0 not == 0 as needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-         VERSION "3.3.0"
+         VERSION "3.3.1"
          DESCRIPTION "Static JSON parsing in C++"
          HOMEPAGE_URL "https://github.com/beached/daw_json_link"
          LANGUAGES C CXX )

--- a/include/daw/json/impl/daw_json_parse_kv_class_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_kv_class_iterator.h
@@ -126,19 +126,17 @@ namespace daw::json {
 #ifndef NDEBUG
 						if constexpr( IsKnown ) {
 							if( base::parse_state ) {
-								daw_json_ensure( base::parse_state->counter > 0,
+								daw_json_ensure( base::parse_state->counter == 0,
 								                 ErrorReason::AttemptToAccessPastEndOfValue,
 								                 *base::parse_state );
 								base::parse_state->counter--;
 							}
 						}
 #endif
-						if constexpr( not IsKnown ) {
-							// Cleanup at end of value
-							base::parse_state->remove_prefix( );
-							base::parse_state->trim_left_checked( );
-							// Ensure we are equal to default
-						}
+						// Cleanup at end of value
+						base::parse_state->remove_prefix( );
+						base::parse_state->trim_left_checked( );
+						// Ensure we are equal to default
 						base::parse_state = nullptr;
 					}
 #ifndef NDEBUG

--- a/include/daw/json/impl/version.h
+++ b/include/daw/json/impl/version.h
@@ -12,7 +12,7 @@
 /// name.
 #if not defined( DAW_JSON_VER_OVERRIDE )
 // Should be updated when a potential ABI break is anticipated
-#define DAW_JSON_VER v3_1_0
+#define DAW_JSON_VER v3_3_1
 #else
 #define DAW_JSON_VER DAW_JSON_VER_OVERRIDE
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -871,6 +871,12 @@ add_test( NAME json_lines_test_test COMMAND json_lines_test )
 add_dependencies( ci_tests json_lines_test )
 add_dependencies( full json_lines_test )
 
+add_executable( issue_334_test src/issue_334_test.cpp )
+target_link_libraries( issue_334_test json_test )
+add_test( NAME issue_334_test_test COMMAND issue_334_test )
+add_dependencies( ci_tests issue_334_test )
+add_dependencies( full issue_334_test )
+
 if( Threads_FOUND )
     add_executable( json_lines_bench_test src/json_lines_bench_test.cpp )
     target_link_libraries( json_lines_bench_test json_test ${CMAKE_THREAD_LIBS_INIT} )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,11 @@
 cmake_policy( SET CMP0065 NEW )
 
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
-set( CMAKE_CXX_EXTENSIONS OFF )
+if( CYGWIN )
+    set( CMAKE_CXX_EXTENSIONS ON )
+else()
+    set( CMAKE_CXX_EXTENSIONS OFF )
+endif()
 
 # 1.71 has MP issues, seting to 1.72 hoping that fixes them.  At the least it prevents compiling on Ubuntu 20.04
 find_package( Boost 1.72.0 COMPONENTS container system )

--- a/tests/src/issue_334_test.cpp
+++ b/tests/src/issue_334_test.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+
+#include <daw/json/daw_json_iterator.h>
+#include <daw/json/daw_json_link.h>
+
+#include <iostream>
+#include <unordered_map>
+
+struct PersonObject {
+	int id{ };
+	std::string name;
+	int age{ };
+	std::unordered_map<std::string, std::string> fields;
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<PersonObject> {
+		static constexpr char const id[] = "id";
+		static constexpr char const name[] = "name";
+		static constexpr char const age[] = "age";
+		static constexpr char const fields[] = "fields";
+		using type = json_member_list<
+		  json_number<id, int>, json_string<name>, json_number_null<age, int>,
+		  json_key_value<fields, std::unordered_map<std::string, std::string>,
+		                 std::string>>;
+	};
+} // namespace daw::json
+
+int main( ) {
+	std::string raw_json{ R"_(
+	{
+		"id": 10,
+		"name": "Jason",
+		"fields": {"city": "Chicago", "Title": "Manager"},
+		}
+	)_" };
+	PersonObject person = daw::json::from_json<PersonObject>( raw_json );
+
+	return 0;
+}

--- a/tests/src/test_details_parse_real.cpp
+++ b/tests/src/test_details_parse_real.cpp
@@ -63,7 +63,7 @@ void test_lots_of_doubles( ) {
 		unsigned long long x2 = rnd( );
 		int x3 = std::uniform_int_distribution<>( -308, +308 )( rnd );
 		char buffer[128];
-		std::sprintf( buffer, "%llu.%llue%d", x1, x2, x3 );
+		std::snprintf( buffer, 128, "%llu.%llue%d", x1, x2, x3 );
 		numbers_str[i] = std::string( buffer );
 		bytes += numbers_str[i].size( );
 		auto rng = num_t( numbers_str[i].data( ),


### PR DESCRIPTION
* BUGFIX for #334: condition had > 0 not == 0 as needed when NDEBUG isn't set
* Fixed deprecation warning for test that uses sprintf
