### PR TITLE
Cleaned up code that uses scope_guard like code to run after return.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-         VERSION "3.4.2"
+         VERSION "3.5.0"
          DESCRIPTION "Static JSON parsing in C++"
          HOMEPAGE_URL "https://github.com/beached/daw_json_link"
          LANGUAGES C CXX )

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,3 @@
-Copyright (c) Darrell Wright
-
-Official repository: https://github.com/beached/daw_json_link
-
 Boost Software License - Version 1.0 - August 17th, 2003
 
 Permission is hereby granted, free of charge, to any person or organization

--- a/include/daw/json/daw_json_iterator.h
+++ b/include/daw/json/daw_json_iterator.h
@@ -134,8 +134,7 @@ namespace daw::json {
 
 				auto tmp = m_state;
 
-				if constexpr( json_details::use_direct_construction_v<ParseState,
-				                                                      JsonElement> ) {
+				if constexpr( is_pinned_type_v<typename element_type::parse_to_t> ) {
 					auto const run_after_parse =
 					  json_array_iterator_details::op_star_cleanup<CharT, ParseState>{
 					    m_can_skip, tmp };

--- a/include/daw/json/daw_json_lines_iterator.h
+++ b/include/daw/json/daw_json_lines_iterator.h
@@ -107,9 +107,7 @@ namespace daw::json {
 				                      ErrorReason::UnexpectedEndOfData, m_state );
 
 				auto tmp = m_state;
-
-				if constexpr( json_details::use_direct_construction_v<ParsePolicy,
-				                                                      JsonElement> ) {
+				if constexpr( is_pinned_type_v<typename element_type::parse_to_t> ) {
 					auto const run_after_parse =
 					  json_lines_details::op_star_cleanup<CharT, ParseState>{ m_can_skip,
 					                                                          tmp };
@@ -198,7 +196,7 @@ namespace daw::json {
 				return std::string_view( m_state.first, m_state.size( ) );
 			}
 		};
-		json_lines_iterator( daw::string_view )->json_lines_iterator<>;
+		json_lines_iterator( daw::string_view ) -> json_lines_iterator<>;
 
 		/// @brief A range of json_lines_iterators
 		/// @tparam JsonElement Type of each element in array
@@ -241,7 +239,7 @@ namespace daw::json {
 				return m_first == m_last;
 			}
 		};
-		json_lines_range( daw::string_view )->json_lines_range<>;
+		json_lines_range( daw::string_view ) -> json_lines_range<>;
 
 		template<typename JsonElement, auto... PolicyFlags>
 		json_lines_range( json_lines_iterator<JsonElement, PolicyFlags...>,

--- a/include/daw/json/impl/daw_json_exec_modes.h
+++ b/include/daw/json/impl/daw_json_exec_modes.h
@@ -18,30 +18,15 @@ namespace daw::json {
 	inline namespace DAW_JSON_VER {
 		struct constexpr_exec_tag {
 			static constexpr std::string_view name = "constexpr";
-#if defined( DAW_HAS_CONSTEXPR_SCOPE_GUARD )
-			static constexpr bool always_rvo = true;
-#else
-			static constexpr bool always_rvo = false;
-#endif
 			static constexpr bool can_constexpr = true;
 		};
 		struct runtime_exec_tag : constexpr_exec_tag {
 			static constexpr std::string_view name = "runtime";
-#if defined( DAW_JSON_ENABLE_FULL_RVO )
-			static constexpr bool always_rvo = true;
-#else
-			static constexpr bool always_rvo = false; 
-#endif
 			static constexpr bool can_constexpr = false;
 		};
 #if defined( DAW_ALLOW_SSE42 )
 		struct sse42_exec_tag : runtime_exec_tag {
 			static constexpr std::string_view name = "sse4.2";
-#if defined( DAW_JSON_ENABLE_FULL_RVO )
-			static constexpr bool always_rvo = true;
-#else
-			static constexpr bool always_rvo = false; 
-#endif
 			static constexpr bool can_constexpr = false;
 		};
 		using simd_exec_tag = sse42_exec_tag;

--- a/include/daw/json/impl/daw_json_parse_common.h
+++ b/include/daw/json/impl/daw_json_parse_common.h
@@ -778,18 +778,6 @@ namespace daw::json {
 			using json_deduced_type =
 			  typename DAW_TYPEOF( json_deduced_type_impl<T>( ) )::type;
 
-			/***
-			 * Some types cannot use construct_value or dont needed it.
-			 */
-			template<typename ParsePolicy, typename JsonMember>
-			inline constexpr bool use_direct_construction_v =
-			  ParsePolicy::exec_tag_t::always_rvo;
-			// TODO DAW implement this so that it work
-			/* or
-			  ( not ParsePolicy::has_allocator and
-			    is_default_constructor_v<
-			      typename json_deduced_type<JsonMember>::constructor_t> );*/
-
 			template<typename T>
 			inline constexpr bool has_json_deduced_type_v =
 			  not std::is_same_v<json_deduced_type<T>,

--- a/include/daw/json/impl/daw_json_traits.h
+++ b/include/daw/json/impl/daw_json_traits.h
@@ -347,6 +347,11 @@ namespace daw::json {
 			}
 		};
 
+		template<typename T>
+		inline constexpr bool is_pinned_type_v = not(
+		  (std::is_copy_constructible_v<T> and std::is_copy_assignable_v<T>) or
+		  ( std::is_move_constructible_v<T> and std::is_move_assignable_v<T> ) );
+
 		namespace json_details {
 			template<typename T>
 			using tuple_test = typename tuple_elements_pack<T>::type;

--- a/include/daw/json/impl/version.h
+++ b/include/daw/json/impl/version.h
@@ -14,7 +14,7 @@
 /// name.
 #if not defined( DAW_JSON_VER_OVERRIDE )
 // Should be updated when a potential ABI break is anticipated
-#define DAW_JSON_VER v3_3_1
+#define DAW_JSON_VER v3_5_0
 #else
 #define DAW_JSON_VER DAW_JSON_VER_OVERRIDE
 #endif

--- a/tests/src/no_move_or_copy_cls_test.cpp
+++ b/tests/src/no_move_or_copy_cls_test.cpp
@@ -28,6 +28,8 @@ struct A {
 	A &operator=( A && ) = delete;
 };
 
+static_assert( daw::json::is_pinned_type_v<A> );
+
 struct B {
 	A a;
 };


### PR DESCRIPTION
Cleaned up code that uses scope_guard like code to run after return. This is useful for types without move or copy that require rvo to be used.