### PR TITLE
Using if constexpr/static asserts in place of enable_if's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-         VERSION "3.5.0"
+         VERSION "3.6.0"
          DESCRIPTION "Static JSON parsing in C++"
          HOMEPAGE_URL "https://github.com/beached/daw_json_link"
          LANGUAGES C CXX )

--- a/include/daw/json/daw_from_json.h
+++ b/include/daw/json/daw_from_json.h
@@ -486,11 +486,9 @@ namespace daw::json {
 		/// @throws daw::json::json_exception
 		template<typename JsonElement, typename Container, typename Constructor,
 		         bool KnownBounds, typename String, auto... PolicyFlags>
-		[[nodiscard]] constexpr auto
+		[[nodiscard]] constexpr Container
 		from_json_array( String &&json_data,
-		                 options::parse_flags_t<PolicyFlags...> )
-		  -> std::enable_if_t<json_details::is_string_view_like_v<String>,
-		                      Container> {
+		                 options::parse_flags_t<PolicyFlags...> ) {
 			static_assert(
 			  json_details::is_string_view_like_v<String>,
 			  "String type must have a be a contiguous range of Characters" );
@@ -561,10 +559,10 @@ namespace daw::json {
 		/// @throws daw::json::json_exception
 		template<typename JsonElement, typename Container, typename Constructor,
 		         bool KnownBounds, typename String>
-		[[nodiscard]] constexpr auto from_json_array( String &&json_data )
-		  -> std::enable_if_t<json_details::is_string_view_like_v<String>,
-		                      Container> {
-
+		[[nodiscard]] constexpr Container from_json_array( String &&json_data ) {
+			static_assert(
+			  json_details::is_string_view_like_v<String>,
+			  "String type must have a be a contiguous range of Characters" );
 			return from_json_array<JsonElement, Container, Constructor, KnownBounds>(
 			  DAW_FWD( json_data ), options::parse_flags<> );
 		}
@@ -584,11 +582,9 @@ namespace daw::json {
 		/// @throws daw::json::json_exception
 		template<typename JsonElement, typename Container, typename Constructor,
 		         bool KnownBounds, typename String, auto... PolicyFlags>
-		[[nodiscard]] constexpr auto
+		[[nodiscard]] constexpr Container
 		from_json_array( String &&json_data, std::string_view member_path,
-		                 options::parse_flags_t<PolicyFlags...> )
-		  -> std::enable_if_t<json_details::is_string_view_like_v<String>,
-		                      Container> {
+		                 options::parse_flags_t<PolicyFlags...> ) {
 			static_assert(
 			  json_details::is_string_view_like_v<String>,
 			  "String type must have a be a contiguous range of Characters" );
@@ -674,10 +670,8 @@ namespace daw::json {
 		/// @throws daw::json::json_exception
 		template<typename JsonElement, typename Container, typename Constructor,
 		         bool KnownBounds, typename String>
-		[[nodiscard]] constexpr auto from_json_array( String &&json_data,
-		                                              std::string_view member_path )
-		  -> std::enable_if_t<json_details::is_string_view_like_v<String>,
-		                      Container> {
+		[[nodiscard]] constexpr Container
+		from_json_array( String &&json_data, std::string_view member_path ) {
 			static_assert(
 			  json_details::is_string_view_like_v<String>,
 			  "String type must have a be a contiguous range of Characters" );

--- a/include/daw/json/daw_from_json_fwd.h
+++ b/include/daw/json/daw_from_json_fwd.h
@@ -212,11 +212,9 @@ namespace daw::json {
 		           std::vector<json_details::from_json_result_t<JsonElement>>,
 		         typename Constructor = use_default, bool KnownBounds = false,
 		         typename String, auto... PolicyFlags>
-		[[nodiscard]] constexpr auto
+		[[nodiscard]] constexpr Container
 		from_json_array( String &&json_data, std::string_view member_path,
-		                 options::parse_flags_t<PolicyFlags...> )
-		  -> std::enable_if_t<json_details::is_string_view_like_v<String>,
-		                      Container>;
+		                 options::parse_flags_t<PolicyFlags...> );
 
 		/// @brief Parse JSON data where the root item is an array
 		/// @tparam JsonElement The type of each element in array.  Must be one of
@@ -236,10 +234,8 @@ namespace daw::json {
 		           std::vector<json_details::from_json_result_t<JsonElement>>,
 		         typename Constructor = use_default, bool KnownBounds = false,
 		         typename String>
-		[[nodiscard]] constexpr auto from_json_array( String &&json_data,
-		                                              std::string_view member_path )
-		  -> std::enable_if_t<json_details::is_string_view_like_v<String>,
-		                      Container>;
+		[[nodiscard]] constexpr Container
+		from_json_array( String &&json_data, std::string_view member_path );
 
 		/// @brief Parse JSON data where the root item is an array
 		/// @tparam JsonElement The type of each element in array.  Must be one of
@@ -256,11 +252,9 @@ namespace daw::json {
 		           std::vector<json_details::from_json_result_t<JsonElement>>,
 		         typename Constructor = use_default, bool KnownBounds = false,
 		         typename String, auto... PolicyFlags>
-		[[nodiscard]] constexpr auto
+		[[nodiscard]] constexpr Container
 		from_json_array( String &&json_data,
-		                 options::parse_flags_t<PolicyFlags...> )
-		  -> std::enable_if_t<json_details::is_string_view_like_v<String>,
-		                      Container>;
+		                 options::parse_flags_t<PolicyFlags...> );
 
 		/// @brief Parse JSON data where the root item is an array
 		/// @tparam JsonElement The type of each element in array.  Must be one of
@@ -277,8 +271,6 @@ namespace daw::json {
 		           std::vector<json_details::from_json_result_t<JsonElement>>,
 		         typename Constructor = use_default, bool KnownBounds = false,
 		         typename String>
-		[[nodiscard]] constexpr auto from_json_array( String &&json_data )
-		  -> std::enable_if_t<json_details::is_string_view_like_v<String>,
-		                      Container>;
+		[[nodiscard]] constexpr Container from_json_array( String &&json_data );
 	} // namespace DAW_JSON_VER
 } // namespace daw::json

--- a/include/daw/json/daw_json_value_state.h
+++ b/include/daw/json/daw_json_value_state.h
@@ -288,9 +288,10 @@ namespace daw::json {
 			 * from one past last, e.g. -1 is last item
 			 * @return The name of the member or an empty optional
 			 */
-			template<typename Integer, std::enable_if_t<std::is_integral_v<Integer>,
-			                                            std::nullptr_t> = nullptr>
+			template<typename Integer>
 			[[nodiscard]] std::optional<std::string_view> name_of( Integer index ) {
+				static_assert( std::is_integral_v<Integer>,
+				               "Only integer indices are allowed" );
 				if constexpr( std::is_signed_v<Integer> ) {
 					if( index < 0 ) {
 						index = -index;
@@ -378,13 +379,14 @@ namespace daw::json {
 			}
 		};
 
-		basic_stateful_json_value( )->basic_stateful_json_value<>;
+		basic_stateful_json_value( ) -> basic_stateful_json_value<>;
 
 		template<json_options_t PolicyFlags, typename Allocator>
 		basic_stateful_json_value( basic_json_value<PolicyFlags, Allocator> )
 		  -> basic_stateful_json_value<PolicyFlags, Allocator>;
 
-		basic_stateful_json_value( daw::string_view )->basic_stateful_json_value<>;
+		basic_stateful_json_value( daw::string_view )
+		  -> basic_stateful_json_value<>;
 
 		using json_value_state = basic_stateful_json_value<>;
 	} // namespace DAW_JSON_VER

--- a/include/daw/json/impl/daw_fp_fallback.h
+++ b/include/daw/json/impl/daw_fp_fallback.h
@@ -22,11 +22,14 @@
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
 		namespace json_details {
-
+			/// @brief When normal FP parsing cannot handle the value, this method
+			/// used as a fallback for std floating point types.  For others, it
+			/// provides either a customization point or will call the overload found
+			/// via ADL
 			template<typename Real, std::enable_if_t<std::is_floating_point_v<Real>,
 			                                         std::nullptr_t> = nullptr>
-			DAW_ATTRIB_NOINLINE Real parse_with_strtod( char const *first,
-			                                            char const *last ) {
+			DAW_ATTRIB_NOINLINE [[nodiscard]] Real
+			parse_with_strtod( char const *first, char const *last ) {
 #if not defined( DAW_JSON_USE_STRTOD ) and defined( __cpp_lib_to_chars )
 				Real result;
 				std::from_chars_result fc_res = std::from_chars( first, last, result );

--- a/include/daw/json/impl/daw_json_parse_common.h
+++ b/include/daw/json/impl/daw_json_parse_common.h
@@ -376,20 +376,12 @@ namespace daw::json {
 			}
 
 			template<typename T>
-			inline constexpr JsonParseTypes number_parse_type_impl_v =
-			  number_parse_type_impl_test<T>( );
-
-			template<typename T>
-			constexpr auto number_parse_type_test( )
-			  -> std::enable_if_t<std::is_enum_v<T>, JsonParseTypes> {
-
-				return number_parse_type_impl_v<std::underlying_type_t<T>>;
-			}
-			template<typename T>
-			constexpr auto number_parse_type_test( )
-			  -> std::enable_if_t<not std::is_enum_v<T>, JsonParseTypes> {
-
-				return number_parse_type_impl_v<T>;
+			DAW_ATTRIB_INLINE DAW_CONSTEVAL JsonParseTypes number_parse_type_test( ) {
+				if constexpr( std::is_enum_v<T> ) {
+					return number_parse_type_impl_test<std::underlying_type_t<T>>( );
+				} else {
+					return number_parse_type_impl_test<T>( );
+				}
 			}
 
 			template<typename T>

--- a/include/daw/json/impl/daw_json_parse_policy.h
+++ b/include/daw/json/impl/daw_json_parse_policy.h
@@ -427,7 +427,7 @@ namespace daw::json {
 				return DAW_LIKELY( first < last ) and *first == '"';
 			}
 
-			inline constexpr void trim_left( ) {
+			DAW_ATTRIB_INLINE constexpr void trim_left( ) {
 				if constexpr( is_unchecked_input ) {
 					trim_left_unchecked( );
 				} else {

--- a/include/daw/json/impl/daw_json_parse_string_quote.h
+++ b/include/daw/json/impl/daw_json_parse_string_quote.h
@@ -90,11 +90,10 @@ namespace daw::json {
 				first -= *( first - 1 ) == '\\' ? 1 : 0;
 			}
 
-			struct string_quote_parser {
+			namespace string_quote_parser {
 				template<typename ParseState>
-				[[nodiscard]] static constexpr auto parse_nq( ParseState &parse_state )
-				  -> std::enable_if_t<ParseState::is_unchecked_input, std::size_t> {
-
+				[[nodiscard]] static constexpr std::size_t
+				parse_nq_uncheck( ParseState &parse_state ) {
 					using CharT = typename ParseState::CharT;
 					std::ptrdiff_t need_slow_path = -1;
 					CharT *first = parse_state.first;
@@ -137,8 +136,8 @@ namespace daw::json {
 				}
 
 				template<typename ParseState>
-				[[nodiscard]] static constexpr auto parse_nq( ParseState &parse_state )
-				  -> std::enable_if_t<not ParseState::is_unchecked_input, std::size_t> {
+				[[nodiscard]] static constexpr std::size_t
+				parse_nq_check( ParseState &parse_state ) {
 
 					using CharT = typename ParseState::CharT;
 					std::ptrdiff_t need_slow_path = -1;
@@ -268,7 +267,17 @@ namespace daw::json {
 					parse_state.first = first;
 					return static_cast<std::size_t>( need_slow_path );
 				}
-			};
-		} // namespace json_details::string_quote
-	}   // namespace DAW_JSON_VER
+
+				template<typename ParseState>
+				[[nodiscard]] DAW_ATTRIB_FLATTEN static constexpr std::size_t
+				parse_nq( ParseState &parse_state ) {
+					if constexpr( ParseState::is_unchecked_input ) {
+						return parse_nq_uncheck( parse_state );
+					} else {
+						return parse_nq_check( parse_state );
+					}
+				}
+			} // namespace string_quote_parser
+		}   // namespace json_details::string_quote
+	}     // namespace DAW_JSON_VER
 } // namespace daw::json

--- a/include/daw/json/impl/daw_murmur3.h
+++ b/include/daw/json/impl/daw_murmur3.h
@@ -22,7 +22,7 @@
 
 namespace daw {
 	namespace murmur3_details {
-		[[nodiscard]] DAW_ATTRIB_FLATTEN inline constexpr UInt32
+		[[nodiscard]] DAW_ATTRIB_FLATINLINE inline constexpr UInt32
 		murmur3_32_scramble( UInt32 k ) {
 			using prime1 = daw::constant<0xcc9e'2d51_u32>;
 			using prime2 = daw::constant<0x1b87'3593_u32>;
@@ -37,16 +37,16 @@ namespace daw {
 	[[nodiscard]] DAW_ATTRIB_INLINE constexpr UInt32
 	fnv1a_32_N( CharT *first, UInt32 hash = 0x811c'9dc5_u32 ) {
 		daw::algorithm::do_n_arg<N>( [&]( std::size_t n ) {
-			hash ^= static_cast<UInt32>( first[n] );
+			hash ^= static_cast<UInt32>( static_cast<unsigned char>( first[n] ) );
 			hash *= 0x0100'0193_u32;
 		} );
 		return hash;
 	}
 
 	template<bool expect_long_strings, typename StringView>
-	[[nodiscard]] DAW_ATTRIB_FLATTEN constexpr auto fnv1a_32( StringView key )
-	  -> std::enable_if_t<daw::traits::is_string_view_like_v<StringView>,
-	                      UInt32> {
+	[[nodiscard]] constexpr UInt32 fnv1a_32( StringView key ) {
+		static_assert( daw::traits::is_string_view_like_v<StringView>,
+		               "Can only pass contiguous character ranges to fnv1a" );
 		std::size_t len = std::size( key );
 		auto *ptr = std::data( key );
 		auto hash = 0x811c'9dc5_u32;
@@ -86,10 +86,10 @@ namespace daw {
 	}
 
 	template<typename StringView>
-	[[nodiscard]] DAW_ATTRIB_FLATINLINE inline constexpr auto
-	murmur3_32( StringView key, std::uint32_t seed = 0 )
-	  -> std::enable_if_t<daw::traits::is_string_view_like_v<StringView>,
-	                      UInt32> {
+	[[nodiscard]] constexpr UInt32 murmur3_32( StringView key,
+	                                           std::uint32_t seed = 0 ) {
+		static_assert( daw::traits::is_string_view_like_v<StringView>,
+		               "Can only pass contiguous character ranges to fnv1a" );
 		UInt32 h = to_uint32( seed );
 		UInt32 k = 0_u32;
 		char const *first = std::data( key );

--- a/include/daw/json/impl/daw_not_const_ex_functions.h
+++ b/include/daw/json/impl/daw_not_const_ex_functions.h
@@ -373,20 +373,17 @@ namespace daw::json {
 				}
 			}
 
-			template<bool is_unchecked_input, typename ExecTag, typename CharT,
-			         std::enable_if_t<std::is_base_of_v<runtime_exec_tag, ExecTag>,
-			                          std::nullptr_t> = nullptr>
-			DAW_ATTRIB_INLINE CharT *
-			mem_skip_string( ExecTag const &tag, CharT *first, CharT *const last ) {
+			template<bool is_unchecked_input, typename CharT>
+			DAW_ATTRIB_INLINE CharT *mem_skip_string( runtime_exec_tag const &tag,
+			                                          CharT *first,
+			                                          CharT *const last ) {
 				return mem_move_to_next_of<is_unchecked_input, '"', '\\'>( tag, first,
 				                                                           last );
 			}
 
-			template<bool is_unchecked_input, typename ExecTag, typename CharT,
-			         std::enable_if_t<std::is_base_of_v<runtime_exec_tag, ExecTag>,
-			                          std::nullptr_t> = nullptr>
+			template<bool is_unchecked_input, typename CharT>
 			DAW_ATTRIB_INLINE CharT *
-			mem_skip_until_end_of_string( ExecTag const &tag, CharT *first,
+			mem_skip_until_end_of_string( runtime_exec_tag const &tag, CharT *first,
 			                              CharT *const last ) {
 				if constexpr( not is_unchecked_input ) {
 					daw_json_ensure( first < last, ErrorReason::UnexpectedEndOfData );

--- a/include/daw/json/impl/version.h
+++ b/include/daw/json/impl/version.h
@@ -14,7 +14,7 @@
 /// name.
 #if not defined( DAW_JSON_VER_OVERRIDE )
 // Should be updated when a potential ABI break is anticipated
-#define DAW_JSON_VER v3_5_0
+#define DAW_JSON_VER v3_6_0
 #else
 #define DAW_JSON_VER DAW_JSON_VER_OVERRIDE
 #endif

--- a/tests/src/nativejson_bench.cpp
+++ b/tests/src/nativejson_bench.cpp
@@ -22,7 +22,7 @@
 
 #if not defined( DAW_NUM_RUNS )
 #if not defined( DEBUG ) or defined( NDEBUG )
-static inline constexpr std::size_t DAW_NUM_RUNS = 500;
+static inline constexpr std::size_t DAW_NUM_RUNS = 1000;
 #else
 static inline constexpr std::size_t DAW_NUM_RUNS = 2;
 #endif


### PR DESCRIPTION
Where possible switched enable_if to control overload set, in binary cases, to a proxy method that calls one of two via if constexpr.  This should help with debugging and reduce enable_if costs.  There were also a  few places where a static_assert could work as the overload set would never grow and it was the only method.  