### PR TITLE
Added base class example and loosened over constraints on some types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-         VERSION "3.12.0"
+         VERSION "3.13.0"
          DESCRIPTION "Static JSON parsing in C++"
          HOMEPAGE_URL "https://github.com/beached/daw_json_link"
          LANGUAGES C CXX )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-         VERSION "3.13.0"
+         VERSION "3.14.0"
          DESCRIPTION "Static JSON parsing in C++"
          HOMEPAGE_URL "https://github.com/beached/daw_json_link"
          LANGUAGES C CXX )

--- a/docs/cookbook/json_value.md
+++ b/docs/cookbook/json_value.md
@@ -3,7 +3,7 @@
  The `json_value` type is a lazy pull parser. It provides lookup and extraction mechanisms for when the regular mappings cannot work or doing data exploration.  One such example is the [variant_on_members.cpp](../../tests/src/variant_on_members.cpp) where the structure of the member is used to determine which parser to use.  For types that use a tag or member to discriminate this isn't necessary as there are `json_variant_...` mappings for that.  The use of `json_value` is not encouraged except when in conjunction with the mappings such as the `json_raw` mapping when existing mappings do not work, or data discovery.
 
 
-The general interface to `json_value` is via `operator[]`.  This can be used with a JSON Path to extract a new `json_value`.  e.g 
+The general query interface to `json_value` is via `operator[]`.  This can be used with a JSON Path to extract a new `json_value`.  e.g 
 
 ```cpp
 auto type_jv = jv["value.type"];
@@ -13,12 +13,14 @@ auto type = as<int>( type_jv );
 
 The example extracts the "type" member of "value" and returns a new `json_value`.  If it is not found, the `operator bool` will evaluate to false.  It is also false if the "type" member had a value of `null`.  If one wants to know if it was found or not, `has_more( )` will return false as the return is a default constructed `json_value`.  Following that, one can use the `as` function to parse the value.  `from_json` will, also, work here.
 
+There are several ways to parse from a `json_value`.  The most succinct is the `T as<T>( json_value )` free function, but there is an `json_value::as<T>( ) const` member function too.  The `from_json` interface used for parsing from string data works too.  Finally, one can cast to their desired type.
+
 One can also check the type of the current value via several members such as `is_class`, `is_null`, `is_array`, `is_number`, `is_string`, and `is_bool`.  There is also `type( )` member that returns an enum of the basic JSON types that can be switched over.
 
 The `json_value` type is a range and one can iterate over classes or arrays.  The value_type is a `json_pair` type that has a `name` and a `value` member.  The name is an `optional<string_view>`.  When iterating over an array, the name will be `nullopt`.  The value member is a `json_value`.  The `json_pair`, also, fulfills the tuple protocol and can get used with structured bindings.
 
 ```cpp
-for( auto [name,value] jp: my_jv_of_class ) {
+for( auto [name,value]: my_jv_of_class ) {
     std::cout << "name:" << *name << " value: " << value.get_string_view( ) << '\n';
 }
 ```

--- a/docs/cookbook/json_value.md
+++ b/docs/cookbook/json_value.md
@@ -1,0 +1,34 @@
+# Json Value
+
+ The `json_value` type is a lazy pull parser. It provides lookup and extraction mechanisms for when the regular mappings cannot work or doing data exploration.  One such example is the [variant_on_members.cpp](../../tests/src/variant_on_members.cpp) where the structure of the member is used to determine which parser to use.  For types that use a tag or member to discriminate this isn't necessary as there are `json_variant_...` mappings for that.  The use of `json_value` is not encouraged except when in conjunction with the mappings such as the `json_raw` mapping when existing mappings do not work, or data discovery.
+
+
+The general interface to `json_value` is via `operator[]`.  This can be used with a JSON Path to extract a new `json_value`.  e.g 
+
+```cpp
+auto type_jv = jv["value.type"];
+assert( type_kv );
+auto type = as<int>( type_jv );
+```
+
+The example extracts the "type" member of "value" and returns a new `json_value`.  If it is not found, the `operator bool` will evaluate to false.  It is also false if the "type" member had a value of `null`.  If one wants to know if it was found or not, `has_more( )` will return false as the return is a default constructed `json_value`.  Following that, one can use the `as` function to parse the value.  `from_json` will, also, work here.
+
+One can also check the type of the current value via several members such as `is_class`, `is_null`, `is_array`, `is_number`, `is_string`, and `is_bool`.  There is also `type( )` member that returns an enum of the basic JSON types that can be switched over.
+
+The `json_value` type is a range and one can iterate over classes or arrays.  The value_type is a `json_pair` type that has a `name` and a `value` member.  The name is an `optional<string_view>`.  When iterating over an array, the name will be `nullopt`.  The value member is a `json_value`.  The `json_pair`, also, fulfills the tuple protocol and can get used with structured bindings.
+
+```cpp
+for( auto [name,value] jp: my_jv_of_class ) {
+    std::cout << "name:" << *name << " value: " << value.get_string_view( ) << '\n';
+}
+```
+
+The following is equivalent 
+
+```cpp
+auto jv = other_jv[5]["a"]["b"][2];
+```
+
+```cpp
+auto jv = other_jv["[5].a.b[2]"];
+```

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -17,7 +17,7 @@ include( FetchContent )
 FetchContent_Declare(
         daw_header_libraries
         GIT_REPOSITORY https://github.com/beached/header_libraries.git
-        GIT_TAG v2.76.3
+        GIT_TAG v2.77.0
 )
 
 FetchContent_Declare(

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -17,7 +17,7 @@ include( FetchContent )
 FetchContent_Declare(
         daw_header_libraries
         GIT_REPOSITORY https://github.com/beached/header_libraries.git
-        GIT_TAG v2.79.0
+        GIT_TAG v2.80.0
 )
 
 FetchContent_Declare(

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -17,7 +17,7 @@ include( FetchContent )
 FetchContent_Declare(
         daw_header_libraries
         GIT_REPOSITORY https://github.com/beached/header_libraries.git
-        GIT_TAG v2.78.0
+        GIT_TAG v2.79.0
 )
 
 FetchContent_Declare(

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -17,7 +17,7 @@ include( FetchContent )
 FetchContent_Declare(
         daw_header_libraries
         GIT_REPOSITORY https://github.com/beached/header_libraries.git
-        GIT_TAG v2.80.0
+        GIT_TAG v2.84.1
 )
 
 FetchContent_Declare(

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -17,7 +17,7 @@ include( FetchContent )
 FetchContent_Declare(
         daw_header_libraries
         GIT_REPOSITORY https://github.com/beached/header_libraries.git
-        GIT_TAG v2.77.1
+        GIT_TAG v2.78.0
 )
 
 FetchContent_Declare(

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -17,7 +17,7 @@ include( FetchContent )
 FetchContent_Declare(
         daw_header_libraries
         GIT_REPOSITORY https://github.com/beached/header_libraries.git
-        GIT_TAG v2.77.0
+        GIT_TAG v2.77.1
 )
 
 FetchContent_Declare(

--- a/include/daw/json/concepts/daw_nullable_value.h
+++ b/include/daw/json/concepts/daw_nullable_value.h
@@ -128,6 +128,12 @@ namespace daw::json {
 #endif
 				}
 
+				constexpr nullable_type DAW_JSON_CPP23_STATIC_CALL_OP operator( )(
+				  construct_nullable_with_pointer_t,
+				  value_type *ptr ) DAW_JSON_CPP23_STATIC_CALL_OP_CONST noexcept {
+					return nullable_type( ptr );
+				}
+
 				constexpr nullable_type DAW_JSON_CPP23_STATIC_CALL_OP
 				operator( )( construct_nullable_with_empty_t )
 				  DAW_JSON_CPP23_STATIC_CALL_OP_CONST noexcept {
@@ -187,6 +193,12 @@ namespace daw::json {
 #endif
 				}
 
+				constexpr nullable_type DAW_JSON_CPP23_STATIC_CALL_OP operator( )(
+				  construct_nullable_with_pointer_t,
+				  value_type *ptr ) DAW_JSON_CPP23_STATIC_CALL_OP_CONST noexcept {
+					return nullable_type( ptr );
+				}
+
 				constexpr nullable_type DAW_JSON_CPP23_STATIC_CALL_OP
 				operator( )( construct_nullable_with_empty_t )
 				  DAW_JSON_CPP23_STATIC_CALL_OP_CONST noexcept {
@@ -234,6 +246,12 @@ namespace daw::json {
 #if not defined( DAW_HAS_AGG_PAREN_INIT )
 					}
 #endif
+				}
+
+				constexpr nullable_type DAW_JSON_CPP23_STATIC_CALL_OP operator( )(
+				  construct_nullable_with_pointer_t,
+				  value_type *ptr ) DAW_JSON_CPP23_STATIC_CALL_OP_CONST noexcept {
+					return ptr;
 				}
 
 				DAW_JSON_CPP23_STATIC_CALL_OP constexpr nullable_type

--- a/include/daw/json/concepts/daw_nullable_value_fwd.h
+++ b/include/daw/json/concepts/daw_nullable_value_fwd.h
@@ -35,12 +35,21 @@ namespace daw::json {
 
 			} // namespace nullable_impl
 
-			struct construct_nullable_with_value_t {};
-
+			struct construct_nullable_with_value_t {
+				explicit construct_nullable_with_value_t( ) = default;
+			};
 			inline constexpr auto construct_nullable_with_value =
 			  construct_nullable_with_value_t{ };
 
-			struct construct_nullable_with_empty_t {};
+			struct construct_nullable_with_pointer_t {
+				explicit construct_nullable_with_pointer_t( ) = default;
+			};
+			inline constexpr auto construct_nullable_with_pointer =
+			  construct_nullable_with_pointer_t{ };
+
+			struct construct_nullable_with_empty_t {
+				explicit construct_nullable_with_empty_t( ) = default;
+			};
 			inline constexpr auto construct_nullable_with_empty =
 			  construct_nullable_with_empty_t{ };
 
@@ -121,6 +130,12 @@ namespace daw::json {
 			  is_nullable_value_v<T> and
 			  std::is_invocable_v<nullable_value_traits<T>,
 			                      construct_nullable_with_value_t, Args...>;
+
+			template<typename T, typename... Args>
+			inline constexpr bool is_nullable_pointer_constructible_v =
+			  is_nullable_value_v<T> and
+			  std::is_invocable_v<nullable_value_traits<T>,
+			                      construct_nullable_with_pointer_t, Args...>;
 
 			template<typename T, typename... Args>
 			inline constexpr bool is_nullable_value_nothrow_constructible_v =

--- a/include/daw/json/daw_from_json_fwd.h
+++ b/include/daw/json/daw_from_json_fwd.h
@@ -14,7 +14,6 @@
 #include "impl/daw_json_parse_policy.h"
 #include "impl/daw_json_traits.h"
 
-#include <ciso646>
 #include <string_view>
 
 namespace daw::json {

--- a/include/daw/json/daw_json_event_parser.h
+++ b/include/daw/json/daw_json_event_parser.h
@@ -17,7 +17,6 @@
 #include <daw/daw_move.h>
 #include <daw/daw_string_view.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <string>
 #include <utility>

--- a/include/daw/json/daw_json_exception.h
+++ b/include/daw/json/daw_json_exception.h
@@ -272,7 +272,7 @@ namespace daw::json {
 			}
 
 			DAW_ATTRIB_NOINLINE [[nodiscard]] inline std::string reason( ) const {
-#if defined( DAW_JSON_COMPILER_CLANG_COMPAT )
+#if defined( DAW_HAS_CLANG )
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wswitch-enum"
 #endif
@@ -289,7 +289,7 @@ namespace daw::json {
 				default:
 					return std::string( ( reason_message( m_reason ) ) );
 				}
-#if defined( DAW_JSON_COMPILER_CLANG_COMPAT )
+#if defined( DAW_HAS_CLANG )
 #pragma clang diagnostic pop
 #endif
 			}

--- a/include/daw/json/daw_json_exception.h
+++ b/include/daw/json/daw_json_exception.h
@@ -15,7 +15,6 @@
 #include <daw/daw_unreachable.h>
 
 #include <algorithm>
-#include <ciso646>
 #include <cstdio>
 #include <cstdlib>
 #include <exception>

--- a/include/daw/json/daw_json_iostream.h
+++ b/include/daw/json/daw_json_iostream.h
@@ -14,7 +14,6 @@
 
 #include <daw/daw_traits.h>
 
-#include <ciso646>
 #include <iostream>
 #include <type_traits>
 

--- a/include/daw/json/daw_json_switches.h
+++ b/include/daw/json/daw_json_switches.h
@@ -14,26 +14,9 @@
 #include <daw/daw_consteval.h>
 #include <daw/daw_cpp_feature_check.h>
 
-#if defined( DAW_HAS_MSVC )
-#define DAW_JSON_COMPILER_MSVC
-#define DAW_JSON_COMPILER_MSVC_COMPAT
-#elif defined( _MSC_VER ) and defined( __clang__ )
-#define DAW_JSON_COMPILER_CLANG
-#define DAW_JSON_COMPILER_CLANGCL
-#define DAW_JSON_COMPILER_MSVC_COMPAT
-#define DAW_JSON_COMPILER_CLANG_COMPAT
-#elif defined( DAW_HAS_GCC )
-#define DAW_JSON_COMPILER_GCC
-#define DAW_JSON_COMPILER_GCC_COMPAT
-#elif defined( DAW_HAS_CLANG )
-#define DAW_JSON_COMPILER_CLANG
-#define DAW_JSON_COMPILER_CLANG_COMPAT
-#define DAW_JSON_COMPILER_GCC_COMPAT
-#endif
-
 /// DAW_NO_FLATTEN disables any flatten attributes in code.  This is disabled in
 /// GCC by default as it cannot handle it
-#if defined( DAW_JSON_COMPILER_GCC ) and not defined( DAW_JSON_FLATTEN )
+#if defined( DAW_HAS_GCC ) and not defined( DAW_JSON_FLATTEN )
 #if not defined( DAW_NO_FLATTEN )
 #define DAW_NO_FLATTEN
 #endif
@@ -76,7 +59,7 @@
 // by defining DAW_JSON_PARSER_DIAGNOSTICS
 
 // DAW_CAN_CONSTANT_EVAL is used to test if we are in a constant expression
-#if defined( DAW_JSON_COMPILER_GCC_COMPAT )
+#if defined( DAW_HAS_GCC_LIKE )
 #define DAW_CAN_CONSTANT_EVAL( ... ) \
 	( __builtin_constant_p( __VA_ARGS__ ) == 1 )
 #else
@@ -117,7 +100,7 @@
 #endif
 
 // Fix bug in MSVC
-#if defined( DAW_JSON_COMPILER_MSVC )
+#if defined( DAW_HAS_MSVC )
 #define DAW_JSON_MAKE_LOC_INFO_CONSTEVAL constexpr
 #else
 #define DAW_JSON_MAKE_LOC_INFO_CONSTEVAL DAW_CONSTEVAL
@@ -136,7 +119,7 @@
 // size is known up front.  This is playing to the implementations prior to
 // C++23 when range constructors are added to containers.  It is disabled on
 // MSVC as that impl does not work with it
-#if defined( DAW_JSON_COMPILER_MSVC )
+#if defined( DAW_HAS_MSVC )
 #if not defined( DAW_JSON_DISABLE_RANDOM )
 #define DAW_JSON_DISABLE_RANDOM
 #endif
@@ -144,16 +127,16 @@
 
 // DAW_JSON_HAS_BUILTIN_UADD is used to switch to a constexpr method of overflow
 // addition when available
-#if( defined( __GNUC__ ) and __GNUC__ >= 8 ) or defined( __clang__ ) or \
-  ( DAW_HAS_BUILTIN( __builtin_uadd_overflow ) and                      \
-    DAW_HAS_BUILTIN( __builtin_uaddl_overflow ) and                     \
+#if DAW_HAS_GCC_VER( 8, 0 ) or defined( DAW_HAS_CLANG ) or \
+  ( DAW_HAS_BUILTIN( __builtin_uadd_overflow ) and         \
+    DAW_HAS_BUILTIN( __builtin_uaddl_overflow ) and        \
     DAW_HAS_BUILTIN( __builtin_uaddll_overflow ) )
 #define DAW_JSON_HAS_BUILTIN_UADD
 #endif
 
 // DAW_JSON_BUGFIX_FROM_JSON_001
 // Defined for MSVC as it has been ICE'ing on daw_json_ensure in from_json
-#if defined( DAW_JSON_COMPILER_MSVC )
+#if defined( DAW_HAS_MSVC )
 #define DAW_JSON_BUGFIX_FROM_JSON_001
 #endif
 
@@ -162,13 +145,13 @@
 // JSON Link uses the left->right guarantees in places like constructors so that
 // less state is needed.  In MSVC one must keep more state in places like
 // parse_tuple_value
-#if defined( DAW_JSON_COMPILER_MSVC )
+#if defined( DAW_HAS_MSVC )
 #define DAW_JSON_BUGFIX_MSVC_EVAL_ORDER_002
 #endif
 
 // DAW_JSON_BUGFIX_MSVC_KNOWN_LOC_ICE_003
 // MSVC in C++20 mode will ICE when known locations is evaluated at compile time
-#if( defined( DAW_JSON_COMPILER_MSVC ) and __cpp_constexpr > 201700L )
+#if( defined( DAW_HAS_MSVC ) and __cpp_constexpr > 201700L )
 #define DAW_JSON_BUGFIX_MSVC_KNOWN_LOC_ICE_003
 #endif
 
@@ -176,7 +159,7 @@
 /// instead of sometimes relying on the hash.  This was enabled in MSVC due to
 /// an issue that should be rechecked
 #if not defined( NDEBUG ) or defined( DEBUG ) or \
-  defined( DAW_JSON_PARSER_DIAGNOSTICS ) or defined( DAW_JSON_COMPILER_MSVC )
+  defined( DAW_JSON_PARSER_DIAGNOSTICS ) or defined( DAW_HAS_MSVC )
 #if not defined( DAW_JSON_ALWAYS_FULL_NAME_MATCH )
 #define DAW_JSON_ALWAYS_FULL_NAME_MATCH
 #endif

--- a/include/daw/json/daw_json_switches.h
+++ b/include/daw/json/daw_json_switches.h
@@ -83,7 +83,7 @@
 #endif
 #endif
 #endif
-#if DAW_HAS_CLANG_VER( 12, 0 ) and __cplusplus >= 202002L
+#if DAW_HAS_CLANG_VER_GTE( 12, 0 ) and DAW_CPP_VERSION >= 202002L
 // Clang 12 supports enough of CNTTP string literals and compiles the tests
 // successfully, but does not define the feature macro
 #if not defined( DAW_JSON_CNTTP_JSON_NAME )
@@ -127,7 +127,7 @@
 
 // DAW_JSON_HAS_BUILTIN_UADD is used to switch to a constexpr method of overflow
 // addition when available
-#if DAW_HAS_GCC_VER( 8, 0 ) or defined( DAW_HAS_CLANG ) or \
+#if DAW_HAS_GCC_VER_GTE( 8, 0 ) or defined( DAW_HAS_CLANG ) or \
   ( DAW_HAS_BUILTIN( __builtin_uadd_overflow ) and         \
     DAW_HAS_BUILTIN( __builtin_uaddl_overflow ) and        \
     DAW_HAS_BUILTIN( __builtin_uaddll_overflow ) )

--- a/include/daw/json/daw_json_switches.h
+++ b/include/daw/json/daw_json_switches.h
@@ -14,7 +14,7 @@
 #include <daw/daw_consteval.h>
 #include <daw/daw_cpp_feature_check.h>
 
-#if defined( _MSC_VER ) and not defined( __clang__ )
+#if defined( DAW_HAS_MSVC )
 #define DAW_JSON_COMPILER_MSVC
 #define DAW_JSON_COMPILER_MSVC_COMPAT
 #elif defined( _MSC_VER ) and defined( __clang__ )
@@ -22,10 +22,10 @@
 #define DAW_JSON_COMPILER_CLANGCL
 #define DAW_JSON_COMPILER_MSVC_COMPAT
 #define DAW_JSON_COMPILER_CLANG_COMPAT
-#elif defined( __GNUC__ ) and not defined( __clang__ )
+#elif defined( DAW_HAS_GCC )
 #define DAW_JSON_COMPILER_GCC
 #define DAW_JSON_COMPILER_GCC_COMPAT
-#elif defined( __clang__ )
+#elif defined( DAW_HAS_CLANG )
 #define DAW_JSON_COMPILER_CLANG
 #define DAW_JSON_COMPILER_CLANG_COMPAT
 #define DAW_JSON_COMPILER_GCC_COMPAT
@@ -100,13 +100,11 @@
 #endif
 #endif
 #endif
-#if defined( __clang_major__ ) and __cplusplus >= 202002L
-#if __clang_major__ >= 12
+#if DAW_HAS_CLANG_VER( 12, 0 ) and __cplusplus >= 202002L
 // Clang 12 supports enough of CNTTP string literals and compiles the tests
 // successfully, but does not define the feature macro
 #if not defined( DAW_JSON_CNTTP_JSON_NAME )
 #define DAW_JSON_CNTTP_JSON_NAME
-#endif
 #endif
 #endif
 #endif

--- a/include/daw/json/daw_json_value_state.h
+++ b/include/daw/json/daw_json_value_state.h
@@ -20,7 +20,6 @@
 #include <daw/daw_string_view.h>
 #include <daw/daw_uint_buffer.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <string_view>
 #include <utility>

--- a/include/daw/json/impl/daw_json_assert.h
+++ b/include/daw/json/impl/daw_json_assert.h
@@ -20,7 +20,6 @@
 #include <daw/daw_string_view.h>
 
 #include <algorithm>
-#include <ciso646>
 #include <cstdio>
 #include <cstdlib>
 #include <memory>

--- a/include/daw/json/impl/daw_json_default_constuctor.h
+++ b/include/daw/json/impl/daw_json_default_constuctor.h
@@ -257,6 +257,19 @@ namespace daw::json {
 				return rtraits_t{ }( concepts::construct_nullable_with_value,
 				                     DAW_FWD( args )... );
 			}
+
+			template<typename Pointer,
+			         std::enable_if_t<
+			           concepts::is_nullable_pointer_constructible_v<T, Pointer *>,
+			           std::nullptr_t> = nullptr>
+			[[nodiscard]] DAW_ATTRIB_INLINE
+			  DAW_JSON_CPP23_STATIC_CALL_OP constexpr auto
+			  operator( )( concepts::construct_nullable_with_pointer_t,
+			               Pointer *ptr ) DAW_JSON_CPP23_STATIC_CALL_OP_CONST
+			  noexcept(
+			    concepts::is_nullable_value_nothrow_constructible_v<T, Pointer> ) {
+				return rtraits_t{ }( concepts::construct_nullable_with_pointer, ptr );
+			}
 		};
 	} // namespace DAW_JSON_VER
 } // namespace daw::json

--- a/include/daw/json/impl/daw_json_link_types_fwd.h
+++ b/include/daw/json/impl/daw_json_link_types_fwd.h
@@ -26,7 +26,6 @@
 #include <daw/daw_utility.h>
 
 #include <chrono>
-#include <ciso646>
 #include <optional>
 #include <string>
 

--- a/include/daw/json/impl/daw_json_link_types_iso8601.h
+++ b/include/daw/json/impl/daw_json_link_types_iso8601.h
@@ -15,7 +15,6 @@
 #include <daw/daw_string_view.h>
 
 #include <chrono>
-#include <ciso646>
 
 namespace daw::json {
 	inline namespace DAW_JSON_VER {

--- a/include/daw/json/impl/daw_json_location_info.h
+++ b/include/daw/json/impl/daw_json_location_info.h
@@ -23,7 +23,6 @@
 #include <daw/daw_uint_buffer.h>
 #include <daw/daw_utility.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <iterator>
 #include <utility>

--- a/include/daw/json/impl/daw_json_parse_array_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_array_iterator.h
@@ -16,7 +16,6 @@
 
 #include <daw/daw_attributes.h>
 
-#include <ciso646>
 #include <type_traits>
 
 namespace daw::json {

--- a/include/daw/json/impl/daw_json_parse_class.h
+++ b/include/daw/json/impl/daw_json_parse_class.h
@@ -24,7 +24,6 @@
 #include <daw/daw_likely.h>
 #include <daw/daw_traits.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <exception>
 #include <type_traits>

--- a/include/daw/json/impl/daw_json_parse_class.h
+++ b/include/daw/json/impl/daw_json_parse_class.h
@@ -230,6 +230,9 @@ namespace daw::json {
 #endif
 
 					if constexpr( is_pinned_type_v<typename JsonClass::parse_to_t> ) {
+						/// Because the return type is pinned(no copy/move).  We cannot rely
+						/// on NRVO. This requires on_exit_success that on some platforms
+						/// can cost a bunch because it checks std::uncaught_exceptions
 						auto const run_after_parse = daw::on_exit_success( [&] {
 							class_cleanup_now<
 							  json_details::all_json_members_must_exist_v<T, ParseState>>(
@@ -237,10 +240,6 @@ namespace daw::json {
 						} );
 						(void)run_after_parse;
 
-						/*
-						 * Rather than call directly use apply/tuple to evaluate
-						 * left->right
-						 */
 						if constexpr( should_construct_explicitly_v<Constructor, T,
 						                                            ParseState> ) {
 							return T{ parse_class_member<

--- a/include/daw/json/impl/daw_json_parse_common.h
+++ b/include/daw/json/impl/daw_json_parse_common.h
@@ -32,7 +32,6 @@
 #include <daw/daw_traits.h>
 
 #include <array>
-#include <ciso646>
 #include <cstddef>
 #include <iterator>
 #include <optional>

--- a/include/daw/json/impl/daw_json_parse_element_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_element_iterator.h
@@ -16,7 +16,6 @@
 
 #include <daw/daw_attributes.h>
 
-#include <ciso646>
 #include <type_traits>
 
 namespace daw::json {

--- a/include/daw/json/impl/daw_json_parse_iso8601_utils.h
+++ b/include/daw/json/impl/daw_json_parse_iso8601_utils.h
@@ -20,7 +20,6 @@
 #include <daw/daw_uint_buffer.h>
 
 #include <chrono>
-#include <ciso646>
 #include <cstdint>
 
 namespace daw::json {

--- a/include/daw/json/impl/daw_json_parse_kv_array_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_kv_array_iterator.h
@@ -18,8 +18,6 @@
 #include <daw/daw_attributes.h>
 #include <daw/daw_move.h>
 
-#include <ciso646>
-
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
 		namespace json_details {

--- a/include/daw/json/impl/daw_json_parse_kv_class_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_kv_class_iterator.h
@@ -18,7 +18,6 @@
 
 #include <daw/daw_move.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <iterator>
 

--- a/include/daw/json/impl/daw_json_parse_name.h
+++ b/include/daw/json/impl/daw_json_parse_name.h
@@ -16,8 +16,6 @@
 
 #include <daw/daw_string_view.h>
 
-#include <ciso646>
-
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
 		namespace json_details {

--- a/include/daw/json/impl/daw_json_parse_options_impl.h
+++ b/include/daw/json/impl/daw_json_parse_options_impl.h
@@ -19,7 +19,6 @@
 #include <daw/daw_traits.h>
 #include <daw/daw_unreachable.h>
 
-#include <ciso646>
 #include <climits>
 #include <cstddef>
 #include <cstdint>

--- a/include/daw/json/impl/daw_json_parse_policy.h
+++ b/include/daw/json/impl/daw_json_parse_policy.h
@@ -26,7 +26,6 @@
 #include <daw/daw_traits.h>
 
 #include <cassert>
-#include <ciso646>
 #include <cstddef>
 #include <iterator>
 #include <type_traits>

--- a/include/daw/json/impl/daw_json_parse_policy_cpp_comments.h
+++ b/include/daw/json/impl/daw_json_parse_policy_cpp_comments.h
@@ -19,8 +19,6 @@
 #include <daw/daw_likely.h>
 #include <daw/daw_traits.h>
 
-#include <ciso646>
-
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
 		/***

--- a/include/daw/json/impl/daw_json_parse_policy_hash_comments.h
+++ b/include/daw/json/impl/daw_json_parse_policy_hash_comments.h
@@ -19,7 +19,6 @@
 #include <daw/daw_likely.h>
 #include <daw/daw_traits.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>

--- a/include/daw/json/impl/daw_json_parse_policy_no_comments.h
+++ b/include/daw/json/impl/daw_json_parse_policy_no_comments.h
@@ -21,7 +21,6 @@
 #include <daw/daw_likely.h>
 #include <daw/daw_traits.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>

--- a/include/daw/json/impl/daw_json_parse_real.h
+++ b/include/daw/json/impl/daw_json_parse_real.h
@@ -23,7 +23,6 @@
 #include <daw/daw_restrict.h>
 #include <daw/daw_utility.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <cstdint>
 #include <limits>

--- a/include/daw/json/impl/daw_json_parse_std_string.h
+++ b/include/daw/json/impl/daw_json_parse_std_string.h
@@ -16,7 +16,6 @@
 
 #include <daw/daw_likely.h>
 
-#include <ciso646>
 #include <string>
 #include <type_traits>
 

--- a/include/daw/json/impl/daw_json_parse_string_quote.h
+++ b/include/daw/json/impl/daw_json_parse_string_quote.h
@@ -16,7 +16,6 @@
 #include <daw/daw_traits.h>
 #include <daw/daw_uint_buffer.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <type_traits>
 

--- a/include/daw/json/impl/daw_json_parse_unsigned_int.h
+++ b/include/daw/json/impl/daw_json_parse_unsigned_int.h
@@ -30,7 +30,7 @@
 #include <smmintrin.h>
 #include <tmmintrin.h>
 #include <xmmintrin.h>
-#if defined( DAW_JSON_COMPILER_MSVC_COMPAT )
+#if defined( DAW_HAS_MSVC_LIKE )
 #include <intrin.h>
 #endif
 #endif

--- a/include/daw/json/impl/daw_json_parse_unsigned_int.h
+++ b/include/daw/json/impl/daw_json_parse_unsigned_int.h
@@ -20,7 +20,6 @@
 #include <daw/daw_cxmath.h>
 #include <daw/daw_uint_buffer.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <cstdint>
 #include <utility>

--- a/include/daw/json/impl/daw_json_parse_value.h
+++ b/include/daw/json/impl/daw_json_parse_value.h
@@ -349,10 +349,24 @@ namespace daw::json {
 						parse_state.trim_left_checked( );
 						return construct_empty( );
 					}
-					return construct_value(
-					  template_args<base_member_type, constructor_t>, parse_state,
-					  parse_value<base_member_type>(
-					    parse_state, ParseTag<base_member_type::expected_type>{ } ) );
+					using parse_to_t = typename base_member_type::parse_to_t;
+					if constexpr( not std::is_move_constructible_v<parse_to_t> and
+					              not std::is_copy_constructible_v<parse_to_t> ) {
+						static_assert(
+						  std::is_invocable_v<
+						    concepts::nullable_value_traits<json_result<JsonMember>>,
+						    concepts::construct_nullable_with_pointer_t, parse_to_t *> );
+						return construct_value(
+						  template_args<base_member_type, constructor_t>, parse_state,
+						  concepts::construct_nullable_with_pointer,
+						  new parse_to_t{ parse_value<base_member_type>(
+						    parse_state, ParseTag<base_member_type::expected_type>{ } ) } );
+					} else {
+						return construct_value(
+						  template_args<base_member_type, constructor_t>, parse_state,
+						  parse_value<base_member_type>(
+						    parse_state, ParseTag<base_member_type::expected_type>{ } ) );
+					}
 				}
 			}
 
@@ -752,7 +766,7 @@ namespace daw::json {
 					return parse_value<JsonMember, KnownBounds>(
 					  parse_state, ParseTag<JsonMember::expected_type>{ } );
 				} else {
-						daw_json_error( ErrorReason::UnexpectedJSONVariantType );
+					daw_json_error( ErrorReason::UnexpectedJSONVariantType );
 				}
 			}
 

--- a/include/daw/json/impl/daw_json_parse_value.h
+++ b/include/daw/json/impl/daw_json_parse_value.h
@@ -29,7 +29,6 @@
 #include <daw/daw_traits.h>
 #include <daw/daw_utility.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>

--- a/include/daw/json/impl/daw_json_parse_value_fwd.h
+++ b/include/daw/json/impl/daw_json_parse_value_fwd.h
@@ -12,8 +12,6 @@
 
 #include "daw_json_parse_common.h"
 
-#include <ciso646>
-
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
 		namespace json_details {

--- a/include/daw/json/impl/daw_json_serialize_impl.h
+++ b/include/daw/json/impl/daw_json_serialize_impl.h
@@ -15,7 +15,6 @@
 #include <daw/daw_utility.h>
 
 #include <array>
-#include <ciso646>
 #include <cstddef>
 #include <utility>
 

--- a/include/daw/json/impl/daw_json_skip.h
+++ b/include/daw/json/impl/daw_json_skip.h
@@ -26,7 +26,6 @@
 #include "daw_count_digits.h"
 #endif
 
-#include <ciso646>
 #include <iterator>
 
 namespace daw::json {

--- a/include/daw/json/impl/daw_json_value.h
+++ b/include/daw/json/impl/daw_json_value.h
@@ -26,7 +26,6 @@
 #include <daw/daw_utility.h>
 
 #include <cassert>
-#include <ciso646>
 #include <cstddef>
 #include <optional>
 #include <string_view>

--- a/include/daw/json/impl/daw_json_value.h
+++ b/include/daw/json/impl/daw_json_value.h
@@ -117,7 +117,7 @@ namespace daw::json {
 			using mapped_type = basic_json_value<PolicyFlags, Allocator>;
 
 			using json_pair = basic_json_pair<PolicyFlags, Allocator>;
-			using value_type = basic_json_pair<PolicyFlags, Allocator>;
+			using value_type = json_pair;
 			using reference = value_type;
 			using pointer = json_details::arrow_proxy<value_type>;
 			using difference_type = std::ptrdiff_t;

--- a/include/daw/json/impl/daw_murmur3.h
+++ b/include/daw/json/impl/daw_murmur3.h
@@ -51,12 +51,12 @@ namespace daw {
 		auto *ptr = std::data( key );
 		auto hash = 0x811c'9dc5_u32;
 		if constexpr( expect_long_strings ) {
-			while( len >= 8 ) {
+			while( DAW_UNLIKELY( len >= 8 ) ) {
 				hash = fnv1a_32_N<8>( ptr, hash );
 				len -= 8;
 				ptr += 8;
 			}
-			while( len >= 4 ) {
+			if( len >= 4 ) {
 				hash = fnv1a_32_N<4>( ptr, hash );
 				len -= 4;
 				ptr += 4;
@@ -80,7 +80,7 @@ namespace daw {
 				result <<= 8U;
 				result |= static_cast<unsigned char>( ptr[n] );
 			}
-			return result;
+			return result * 0xCC9E'2d51UL; // mix it up with an fnv1a prime
 		}
 		return fnv1a_32<expect_long_strings>( key );
 	}

--- a/include/daw/json/impl/daw_murmur3.h
+++ b/include/daw/json/impl/daw_murmur3.h
@@ -15,7 +15,6 @@
 #include <daw/daw_string_view.h>
 #include <daw/daw_uint_buffer.h>
 
-#include <ciso646>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>

--- a/include/daw/json/impl/daw_not_const_ex_functions.h
+++ b/include/daw/json/impl/daw_not_const_ex_functions.h
@@ -28,7 +28,7 @@
 #include <tmmintrin.h>
 #include <wmmintrin.h>
 #include <xmmintrin.h>
-#if defined( DAW_JSON_COMPILER_MSVC_COMPAT )
+#if defined( DAW_HAS_MSVC_LIKE )
 #include <intrin.h>
 #endif
 #endif
@@ -72,7 +72,7 @@ namespace daw::json {
 			inline std::ptrdiff_t find_lsb_set( runtime_exec_tag, UInt32 value ) {
 #if DAW_HAS_BUILTIN( __builtin_ffs )
 				return __builtin_ffs( static_cast<int>( value ) ) - 1;
-#elif defined( DAW_JSON_COMPILER_MSVC_COMPAT )
+#elif defined( DAW_HAS_MSVC_LIKE )
 				unsigned long index;
 				_BitScanForward( &index, static_cast<int>( value ) );
 				return static_cast<std::ptrdiff_t>( index );

--- a/include/daw/json/impl/daw_not_const_ex_functions.h
+++ b/include/daw/json/impl/daw_not_const_ex_functions.h
@@ -33,7 +33,6 @@
 #endif
 #endif
 
-#include <ciso646>
 #include <cstddef>
 #include <cstring>
 

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -933,7 +933,8 @@ namespace daw::json {
 			to_json_string_class( WriteableType it, parse_to_t const &value ) {
 
 				static_assert(
-				  std::is_convertible_v<parse_to_t, typename JsonMember::parse_to_t>,
+				  std::is_convertible_v<parse_to_t, typename JsonMember::parse_to_t> or
+				    std::is_same_v<parse_to_t, typename JsonMember::parse_to_t>, // This is for not-copy/movable types
 				  "value must be convertible to specified type in class contract" );
 
 				if constexpr( has_json_to_json_data_v<parse_to_t> ) {

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -30,7 +30,6 @@
 #include <daw/utf8/unchecked.h>
 
 #include <array>
-#include <ciso646>
 #include <optional>
 #include <sstream>
 #include <string>

--- a/include/daw/json/impl/version.h
+++ b/include/daw/json/impl/version.h
@@ -10,6 +10,8 @@
 
 #include "../daw_json_switches.h"
 
+#include <daw/ciso646.h>
+
 /// The version string used in namespace definitions.  Must be a valid namespace
 /// name.
 #if not defined( DAW_JSON_VER_OVERRIDE )

--- a/include/daw/third_party/dragonbox/dragonbox_to_decimal.h
+++ b/include/daw/third_party/dragonbox/dragonbox_to_decimal.h
@@ -26,7 +26,6 @@
 #include <daw/daw_likely.h>
 
 #include <cassert>
-#include <ciso646>
 #include <climits>
 #include <cstdint>
 #include <cstring>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -932,6 +932,12 @@ add_test( NAME carray_test_test COMMAND carray_test )
 add_dependencies( ci_tests carray_test )
 add_dependencies( full carray_test )
 
+add_executable( base_child_class_test src/base_child_class_test.cpp )
+target_link_libraries( base_child_class_test json_test )
+add_test( NAME base_child_class_test_test COMMAND base_child_class_test )
+add_dependencies( ci_tests base_child_class_test )
+add_dependencies( full base_child_class_test )
+
 add_executable( json_bench_viewer src/json_bench_viewer.cpp )
 target_link_libraries( json_bench_viewer json_test )
 

--- a/tests/src/base_child_class_test.cpp
+++ b/tests/src/base_child_class_test.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+
+#include <daw/json/daw_json_link.h>
+
+#include <cassert>
+#include <memory>
+#include <string_view>
+
+struct Base {
+	explicit Base( ) = default;
+	virtual ~Base( ) = default;
+	Base( Base const & ) = delete;
+	Base( Base && ) = delete;
+	Base &operator=( Base const & ) = delete;
+	Base &operator=( Base && ) = delete;
+
+	[[nodiscard]] virtual int type( ) const = 0;
+	[[nodiscard]] virtual int value( ) const = 0;
+};
+
+struct Child0 : Base {
+	int v;
+
+	explicit Child0( int V ) noexcept
+	  : v( V ) {}
+
+	[[nodiscard]] int type( ) const override {
+		return 0;
+	}
+
+	[[nodiscard]] int value( ) const override {
+		return v;
+	}
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<Child0> {
+		static constexpr char const v[] = "v";
+		using type = json_member_list<json_number<v, int>>;
+
+		static constexpr auto to_json_data( Child0 const &c0 ) {
+			return std::forward_as_tuple( c0.v );
+		}
+	};
+} // namespace daw::json
+
+struct Child1 : Base {
+	int d;
+
+	explicit Child1( int D ) noexcept
+	  : d( D ) {}
+
+	[[nodiscard]] int type( ) const override {
+		return 1;
+	}
+
+	[[nodiscard]] int value( ) const override {
+		return d;
+	}
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<Child1> {
+		static constexpr char const d[] = "d";
+		using type = json_member_list<json_number<d, int>>;
+
+		static constexpr auto to_json_data( Child1 const &c1 ) {
+			return std::forward_as_tuple( c1.d );
+		}
+	};
+} // namespace daw::json
+
+struct Switcher {
+	// Convert JSON tag member to type index
+	constexpr size_t operator( )( int type ) const {
+		return static_cast<std::size_t>( type );
+	}
+	// Get value for Tag from class value
+	int operator( )( Base const &b ) const {
+		return static_cast<int>( b.type( ) );
+	}
+};
+
+struct Foo {
+	std::unique_ptr<Base> value;
+};
+
+struct FooMaker {
+	std::unique_ptr<Base> operator( )( char const *str, std::size_t sz ) const {
+		using namespace daw::json;
+		auto jv = json_value( daw::string_view( str, sz ) );
+		(void)jv;
+		switch( as<std::size_t>( jv["type"] ) ) {
+		case 0:
+			return from_json<std::unique_ptr<Child0>>( jv );
+		case 1:
+			return from_json<std::unique_ptr<Child1>>( jv );
+		default:
+			std::terminate( );
+		}
+	}
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<Foo> {
+		static constexpr char const value[] = "value";
+		using type =
+		  json_member_list<json_raw<value, std::unique_ptr<Base>, FooMaker>>;
+	};
+} // namespace daw::json
+
+constexpr std::string_view json_doc = R"json(
+[
+  {"value":{ "type": 0, "v": 42 }},
+	{"value":{ "type": 1, "d": 66 }},
+	{"value":{ "type": 0, "v": 77 }}
+]
+)json";
+
+int main( ) {
+	auto foo = daw::json::from_json<std::vector<Foo>>( json_doc );
+	assert( foo[0].value->type( ) == 0 );
+	assert( foo[0].value->value( ) == 42 );
+	assert( foo[1].value->type( ) == 1 );
+	assert( foo[1].value->value( ) == 66 );
+	assert( foo[2].value->type( ) == 0 );
+	assert( foo[2].value->value( ) == 77 );
+}


### PR DESCRIPTION
* Added base class example 
* Loosened over constraints on some types where they are not movable/copyable and will be in pointer like nullable types
* Fixed constraint on to_json where it looked for convertible_to but that doesn't allow non-copy/move types.  Added same_as