### PR TITLE
Bugfixes and new describe

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -142,5 +142,5 @@ jobs:
             /var/lib/systemd/coredump/*
             /var/crash/*
             !/var/crash/_usr_bin_do-release*
-            !/var/crash/_usr_lib_systemd*
+            !/var/crash/_usr_lib_*
           if-no-files-found: ignore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-         VERSION "3.14.1"
+         VERSION "3.15.0"
          DESCRIPTION "Static JSON parsing in C++"
          HOMEPAGE_URL "https://github.com/beached/daw_json_link"
          LANGUAGES C CXX )

--- a/include/daw/json/daw_from_json.h
+++ b/include/daw/json/daw_from_json.h
@@ -56,12 +56,6 @@ namespace daw::json {
 			using policy_zstring_t = json_details::apply_zstring_policy_option_t<
 			  ParsePolicy, String, options::ZeroTerminatedString::yes>;
 
-			/// In cases where we own the buffer or when requested and can, allow
-			/// temporarily mutating it to reduce search costs
-			/*using parse_state_mutate_t = json_details::apply_mutable_policy<
-			  policy_zstring_t, std::add_const_t<String>,
-			  options::TemporarilyMutateBuffer::yes,
-			  options::TemporarilyMutateBuffer::no>;*/
 			using ParseState =
 			  std::conditional_t<policy_zstring_t::is_default_parse_policy,
 			                     DefaultParsePolicy, policy_zstring_t>;
@@ -135,14 +129,8 @@ namespace daw::json {
 
 			/// @brief If the string is known to have a trailing zero, allow
 			/// optimization on that
-			using policy_zstring_t = json_details::apply_zstring_policy_option_t<
+			using ParseState = json_details::apply_zstring_policy_option_t<
 			  ParsePolicy, String, options::ZeroTerminatedString::yes>;
-
-			/// @brief In cases where we own the buffer or when requested and can,
-			/// allow temporarily mutating it to reduce search costs
-			using ParseState = json_details::apply_mutable_policy<
-			  policy_zstring_t, String, options::TemporarilyMutateBuffer::yes,
-			  options::TemporarilyMutateBuffer::no>;
 
 			auto parse_state = ParseState::with_allocator( f, l, a );
 			if constexpr( ParseState::must_verify_end_of_data_is_valid ) {
@@ -217,11 +205,6 @@ namespace daw::json {
 			using policy_zstring_t = json_details::apply_zstring_policy_option_t<
 			  ParsePolicy, String, options::ZeroTerminatedString::yes>;
 
-			/// @brief In cases where we own the buffer or when requested and can,
-			/// allow temporarily mutating it to reduce search costs
-			/*			using policy_mutate_t = json_details::apply_mutable_policy<
-			        policy_zstring_t, String, options::TemporarilyMutateBuffer::yes,
-			        options::TemporarilyMutateBuffer::no>;*/
 			using ParseState =
 			  std::conditional_t<policy_zstring_t::is_default_parse_policy,
 			                     DefaultParsePolicy, policy_zstring_t>;
@@ -310,14 +293,8 @@ namespace daw::json {
 
 			/// @brief If the string is known to have a trailing zero, allow
 			/// optimization on that
-			using policy_zstring_t = json_details::apply_zstring_policy_option_t<
+			using ParseState = json_details::apply_zstring_policy_option_t<
 			  ParsePolicy, String, options::ZeroTerminatedString::yes>;
-
-			/// @brief In cases where we own the buffer or when requested and can,
-			/// allow temporarily mutating it to reduce search costs
-			using ParseState = json_details::apply_mutable_policy<
-			  policy_zstring_t, String, options::TemporarilyMutateBuffer::yes,
-			  options::TemporarilyMutateBuffer::no>;
 
 			auto first = std::data( json_data );
 			auto last = daw::data_end( json_data );
@@ -526,11 +503,6 @@ namespace daw::json {
 			using policy_zstring_t = json_details::apply_zstring_policy_option_t<
 			  ParsePolicy, String, options::ZeroTerminatedString::yes>;
 
-			/// @brief In cases where we own the buffer or when requested and can,
-			/// allow temporarily mutating it to reduce search costs
-			/*using policy_mutate_t = json_details::apply_mutable_policy<
-			  policy_zstring_t, String, options::TemporarilyMutateBuffer::yes,
-			  options::TemporarilyMutateBuffer::no>;*/
 			using ParseState =
 			  std::conditional_t<policy_zstring_t::is_default_parse_policy,
 			                     DefaultParsePolicy, policy_zstring_t>;
@@ -625,11 +597,6 @@ namespace daw::json {
 			using policy_zstring_t = json_details::apply_zstring_policy_option_t<
 			  ParsePolicy, String, options::ZeroTerminatedString::yes>;
 
-			/// @brief In cases where we own the buffer or when requested and can,
-			/// allow temporarily mutating it to reduce search costs
-			/*using ParseState = json_details::apply_mutable_policy<
-			  policy_zstring_t, String, options::TemporarilyMutateBuffer::yes,
-			  options::TemporarilyMutateBuffer::no>;*/
 			using ParseState =
 			  std::conditional_t<policy_zstring_t::is_default_parse_policy,
 			                     DefaultParsePolicy, policy_zstring_t>;

--- a/include/daw/json/daw_json_link_describe.h
+++ b/include/daw/json/daw_json_link_describe.h
@@ -1,0 +1,98 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link_describe
+//
+
+#pragma once
+
+#include <daw/daw_consteval.h>
+#include <daw/daw_traits.h>
+#include <daw/json/daw_json_link.h>
+
+#if not __has_include( <boost/describe.hpp> ) and __has_include( <boost/mp11.hpp> )
+#error \
+  "In order to use daw_json_link_describe.h Boost.Describe and Boost.Mp11 must be available"
+#endif
+
+#include <boost/describe.hpp>
+#include <boost/mp11.hpp>
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+namespace daw::json {
+	/// Types that use Boost.Describe need to specialize use_boost_describe_v for
+	/// their type with a bool value of true.  This defaults to on, all described
+	/// structs, but can be opted-out of if one wants to do a custom mapping of a
+	/// Boost.Described struct
+	template<typename, typename = void>
+	inline constexpr bool use_boost_describe_v = true;
+
+	namespace describe_impl {
+		template<typename, typename>
+		struct describe_member_impl;
+
+		/// \brief We must use char arrays to store names for NTTP/CNTTP. Building
+		/// json_link type too \tparam T Class member being mapped
+		template<typename T, std::size_t... Is>
+		struct describe_member_impl<T, std::index_sequence<Is...>> {
+			static constexpr char const name[sizeof...( Is )]{ T::name[Is]... };
+			using type =
+			  json_link<name, traits::member_type_of_t<DAW_TYPEOF( T::pointer )>>;
+		};
+
+		template<typename T>
+		using describe_member =
+		  describe_member_impl<T, std::make_index_sequence<
+		                            std::char_traits<char>::length( T::name ) + 1>>;
+
+		template<typename>
+		struct member_list;
+
+		template<template<typename...> typename List, typename... Ts>
+		struct member_list<List<Ts...>> {
+			template<typename U>
+			using desc_t = typename describe_member<U>::type;
+
+			using type = json_member_list<desc_t<Ts>...>;
+		};
+	} // namespace describe_impl
+
+	template<typename T>
+	struct json_data_contract<
+	  T, std::enable_if_t<boost::describe::has_describe_members<T>::value and
+	                      use_boost_describe_v<T>>> {
+	private:
+		using pub_desc_t =
+		  boost::describe::describe_members<T, boost::describe::mod_public>;
+		using pri_desc_t =
+		  boost::describe::describe_members<T, boost::describe::mod_private>;
+		using pro_desc_t =
+		  boost::describe::describe_members<T, boost::describe::mod_protected>;
+		static_assert( boost::mp11::mp_empty<pri_desc_t>::value,
+		               "Classes with private member variables are not supported. "
+		               "Must use a manual mapping." );
+		static_assert( boost::mp11::mp_empty<pro_desc_t>::value,
+		               "Classes with protected member variables are not supported. "
+		               "Must use a manual mapping." );
+
+		template<typename U>
+		using desc_t = typename describe_impl::describe_member<U>::type;
+
+		template<template<typename...> typename List, typename... Ts>
+		static inline constexpr auto
+		to_json_data_impl( T const &value, List<Ts...> const & ) noexcept {
+			return std::forward_as_tuple( value.*Ts::pointer... );
+		}
+
+	public:
+		using type = typename describe_impl::member_list<pub_desc_t>::type;
+
+		static constexpr auto to_json_data( T const &value ) noexcept {
+			return to_json_data_impl( value, pub_desc_t{ } );
+		}
+	};
+} // namespace daw::json

--- a/include/daw/json/daw_json_link_types.h
+++ b/include/daw/json/daw_json_link_types.h
@@ -498,7 +498,7 @@ namespace daw::json {
 		 * @tparam Name name of json member
 		 * @tparam T type of number(e.g. double, int, unsigned...) to pass to
 		 * Constructor
-		 * @tparam LiteralAsString Could this number be embedded in a string
+		 * @tparam Options set options for this number parser
 		 * @tparam Constructor Callable used to construct result
 		 */
 		template<JSONNAMETYPE Name, typename T, json_options_t Options,

--- a/include/daw/json/daw_json_parse_options.h
+++ b/include/daw/json/daw_json_parse_options.h
@@ -140,7 +140,10 @@ namespace daw::json {
 				///
 				/// default: no
 				///
-				enum class TemporarilyMutateBuffer : unsigned { no, yes }; // 1bit
+
+				enum class [[deprecated(
+				  "This is not used" )]] TemporarilyMutateBuffer : unsigned{
+				  no, yes }; // 1bit
 
 				///
 				/// @brief Exclude characters under 0x20 that are not explicitly

--- a/include/daw/json/impl/daw_json_parse_options_impl.h
+++ b/include/daw/json/impl/daw_json_parse_options_impl.h
@@ -138,6 +138,7 @@ namespace daw::json {
 			  default_json_option_value<options::ExpectLongNames> =
 			    options::ExpectLongNames::no;
 
+			/*
 			template<>
 			inline constexpr unsigned
 			  json_option_bits_width<options::TemporarilyMutateBuffer> = 1;
@@ -146,6 +147,7 @@ namespace daw::json {
 			inline constexpr auto
 			  default_json_option_value<options::TemporarilyMutateBuffer> =
 			    options::TemporarilyMutateBuffer::no;
+			    */
 
 			template<>
 			inline constexpr unsigned
@@ -161,9 +163,8 @@ namespace daw::json {
 			  options::PolicyCommentTypes, options::CheckedParseMode,
 			  options::AllowEscapedNames, options::IEEE754Precise,
 			  options::ForceFullNameCheck, options::MinifiedDocument,
-			  options::UseExactMappingsByDefault, options::TemporarilyMutateBuffer,
-			  options::MustVerifyEndOfDataIsValid, options::ExcludeSpecialEscapes,
-			  options::ExpectLongNames>::type;
+			  options::UseExactMappingsByDefault, options::MustVerifyEndOfDataIsValid,
+			  options::ExcludeSpecialEscapes, options::ExpectLongNames>::type;
 
 			template<typename Policy, typename Policies>
 			inline constexpr unsigned basic_policy_bits_start =

--- a/include/daw/json/impl/daw_json_parse_policy.h
+++ b/include/daw/json/impl/daw_json_parse_policy.h
@@ -58,13 +58,15 @@ namespace daw::json {
 			 * Allow temporarily setting a sentinel in the buffer to reduce range
 			 * checking costs
 			 */
-			static DAW_CONSTEVAL bool allow_temporarily_mutating_buffer( ) {
-				return json_details::get_bits_for<options::TemporarilyMutateBuffer>(
-				         PolicyFlags ) == options::TemporarilyMutateBuffer::yes;
-			}
+			/*
+		 static DAW_CONSTEVAL bool allow_temporarily_mutating_buffer( ) {
+			 return json_details::get_bits_for<options::TemporarilyMutateBuffer>(
+			          PolicyFlags ) == options::TemporarilyMutateBuffer::yes;
+		 }
+			 */
 
-			using CharT = std::conditional_t<allow_temporarily_mutating_buffer( ),
-			                                 char, char const>;
+			using CharT = char const; /*std::conditional_t<allow_temporarily_mutating_buffer(
+			                             ), char, char const>;*/
 			using iterator = CharT *;
 
 			/***

--- a/include/daw/json/impl/daw_json_parse_value.h
+++ b/include/daw/json/impl/daw_json_parse_value.h
@@ -845,7 +845,7 @@ namespace daw::json {
 			}
 
 			template<typename JsonMember, typename ParseState>
-			static constexpr auto find_index( ParseState parse_state ) {
+			static constexpr auto find_index( ParseState const & parse_state ) {
 				using tag_member = typename JsonMember::tag_member;
 				using class_wrapper_t = typename JsonMember::tag_member_class_wrapper;
 

--- a/include/daw/json/impl/daw_json_traits.h
+++ b/include/daw/json/impl/daw_json_traits.h
@@ -277,6 +277,7 @@ namespace daw::json {
 			  not is_rvalue_string<String> and
 			  std::is_const_v<std::remove_reference_t<String>>;
 
+			/*
 			template<typename ParsePolicy, typename String, auto OptionMutable,
 			         auto OptionImmutable>
 			using apply_mutable_policy = std::conditional_t<
@@ -288,6 +289,7 @@ namespace daw::json {
 			    (is_rvalue_string<String> and is_mutable_string_v<String>),
 			    apply_policy_option_t<ParsePolicy, OptionMutable>,
 			    apply_policy_option_t<ParsePolicy, OptionImmutable>>>;
+			    */
 		} // namespace json_details
 
 		/***

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,8 +9,7 @@ else()
     set( CMAKE_CXX_EXTENSIONS OFF )
 endif()
 
-# 1.71 has MP issues, setting to 1.72 hoping that fixes them.  At the least it prevents compiling on Ubuntu 20.04
-find_package( Boost 1.72.0 COMPONENTS container system )
+find_package( Boost 1.78.0 COMPONENTS container system )
 find_package( Threads )
 
 if( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
@@ -239,6 +238,11 @@ if( Boost_FOUND )
     add_executable( twitter_test_pmr EXCLUDE_FROM_ALL src/twitter_test_pmr.cpp )
     target_link_libraries( twitter_test_pmr PRIVATE json_test Boost::headers Boost::container )
     add_dependencies( full twitter_test_pmr )
+
+    add_executable( daw_json_link_describe_bin src/daw_json_link_describe_test.cpp )
+    target_link_libraries( daw_json_link_describe_bin PRIVATE json_test Boost::headers )
+    target_compile_features( daw_json_link_describe_bin INTERFACE cxx_std_20 )
+    add_test( NAME daw_json_link_describe_test COMMAND daw_json_link_describe_bin )
 endif()
 
 if( DAW_JSON_FULL_TESTS )
@@ -557,12 +561,12 @@ add_dependencies( full cookbook_dates4_test )
 
 # Cannot be used due to perf issue with uncaught_exceptions/MSVC's dtors that prevent this facility
 if( NOT DEFINED MSVC )
-	add_executable( no_move_or_copy_cls_test src/no_move_or_copy_cls_test.cpp )
-	target_link_libraries( no_move_or_copy_cls_test PRIVATE json_test )
-	add_test( NAME no_move_or_copy_cls_test COMMAND no_move_or_copy_cls_test )
-	add_dependencies( ci_tests no_move_or_copy_cls_test )
-	add_dependencies( full no_move_or_copy_cls_test )
-endif( )
+    add_executable( no_move_or_copy_cls_test src/no_move_or_copy_cls_test.cpp )
+    target_link_libraries( no_move_or_copy_cls_test PRIVATE json_test )
+    add_test( NAME no_move_or_copy_cls_test COMMAND no_move_or_copy_cls_test )
+    add_dependencies( ci_tests no_move_or_copy_cls_test )
+    add_dependencies( full no_move_or_copy_cls_test )
+endif()
 
 add_executable( cookbook_class_from_array1_test src/cookbook_class_from_array1_test.cpp )
 target_link_libraries( cookbook_class_from_array1_test PRIVATE json_test )
@@ -932,6 +936,12 @@ add_test( NAME issue_370_exact_class_mapping_test_test COMMAND issue_370_exact_c
 add_dependencies( ci_tests issue_370_exact_class_mapping_test )
 add_dependencies( full issue_370_exact_class_mapping_test )
 
+#add_executable( issue_373_empty_string_nullable_test src/issue_373_empty_string_nullable_test.cpp )
+#target_link_libraries( issue_373_empty_string_nullable_test PRIVATE json_test )
+#add_test( NAME issue_373_empty_string_nullable_test COMMAND issue_373_empty_string_nullable_test ./issue_373_empty_string_nullable.json WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test_data/" )
+#add_dependencies( ci_tests issue_373_empty_string_nullable_test )
+#add_dependencies( full issue_373_empty_string_nullable_test )
+
 add_executable( carray_test src/carray_test.cpp )
 target_link_libraries( carray_test json_test )
 add_test( NAME carray_test_test COMMAND carray_test )
@@ -946,7 +956,6 @@ add_dependencies( full base_child_class_test )
 
 add_executable( json_bench_viewer src/json_bench_viewer.cpp )
 target_link_libraries( json_bench_viewer json_test )
-
 
 if( Threads_FOUND )
     add_executable( json_lines_bench_test src/json_lines_bench_test.cpp )

--- a/tests/cmake/test_compiler_options.cmake
+++ b/tests/cmake/test_compiler_options.cmake
@@ -55,6 +55,7 @@ if( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
             AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16 )
             add_compile_options(
                     -Wno-c++2b-extensions
+                    -Wno-unsafe-buffer-usage
             )
         endif()
         if( ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang" OR
@@ -179,6 +180,7 @@ elseif( MSVC )
     add_compile_options( "/wd4146" )
     add_compile_options( "/bigobj" )
     add_compile_options( "/w14868" )
+    add_compile_options( "/w14296" )
     # Ensure that string pooling is enabled. Otherwise it breaks constexpr string literals.
     # This affects debug modes by default, but optionally Release
     # https://developercommunity.visualstudio.com/t/codegen:-constexpr-pointer-to-trailing-z/900648

--- a/tests/src/daw_json_link_describe_test.cpp
+++ b/tests/src/daw_json_link_describe_test.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link_describe
+//
+
+#include <daw/json/daw_json_link_describe.h>
+
+#include <boost/describe.hpp>
+#include <cassert>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+
+struct X {
+	int m1;
+	int m2;
+};
+BOOST_DESCRIBE_STRUCT( X, ( ), ( m1, m2 ) );
+
+struct Y {
+	X m0;
+	std::string m1;
+};
+BOOST_DESCRIBE_STRUCT( Y, ( ), ( m0, m1 ) );
+
+struct Z {
+	std::map<std::string, int> kv;
+};
+BOOST_DESCRIBE_STRUCT( Z, ( ), ( kv ) );
+
+struct Foo {
+	std::optional<Y> m0;
+	std::vector<X> m1;
+	std::shared_ptr<int> m2;
+};
+BOOST_DESCRIBE_STRUCT( Foo, ( ), ( m0, m1, m2 ) );
+
+int main( ) {
+	constexpr daw::string_view json_doc0 = R"json(
+{
+	"m1": 55,
+	"m2": 123
+}
+)json";
+	constexpr auto val0 = daw::json::from_json<X>( json_doc0 );
+	assert( val0.m1 == 55 );
+	assert( val0.m2 == 123 );
+	std::cout << "json: " << daw::json::to_json( val0 ) << '\n';
+
+	constexpr daw::string_view json_doc1 = R"json(
+{
+	"m0": { "m1": 55, "m2": 123 },
+	"m1": "Hello World!"
+}
+)json";
+
+	auto const val1 = daw::json::from_json<Y>( json_doc1 );
+	assert( val1.m0.m1 == 55 );
+	assert( val1.m0.m2 == 123 );
+	assert( val1.m1 == "Hello World!" );
+	std::cout << "json: " << daw::json::to_json( val1 ) << '\n';
+
+	constexpr daw::string_view json_doc2 = R"json(
+{
+	"kv": { "key0": 0, "key1": 1, "key2": 2 },
+}
+)json";
+	auto val2 = daw::json::from_json<Z>( json_doc2 );
+	auto p = val2.kv.find( "key0" );
+	assert( p != val2.kv.end( ) );
+	assert( p->second == 0 );
+
+	p = val2.kv.find( "key1" );
+	assert( p != val2.kv.end( ) );
+	assert( p->second == 1 );
+
+	p = val2.kv.find( "key2" );
+	assert( p != val2.kv.end( ) );
+	assert( p->second == 2 );
+	std::cout << "json: " << daw::json::to_json( val2 ) << '\n';
+
+	constexpr daw::string_view json_doc3 = R"json(
+{
+	"m1": [ { "m1": 0, "m2": 1 }, { "m1": 2, "m2": 3 } ]
+}
+)json";
+	auto val3 = daw::json::from_json<Foo>( json_doc3 );
+	assert( not val3.m0 );
+	assert( val3.m1.size( ) == 2 );
+	assert( val3.m1[0].m1 == 0 );
+	assert( val3.m1[0].m2 == 1 );
+	assert( val3.m1[1].m1 == 2 );
+	assert( val3.m1[1].m2 == 3 );
+	std::cout << "json: " << daw::json::to_json( val3 ) << '\n';
+	using namespace daw::json::options;
+	auto json_doc3b = daw::json::to_json( val3, output_flags<SerializationFormat::Pretty> );
+	std::cout << "pretty json: " << json_doc3b << '\n';
+	auto val3b = daw::json::from_json<Foo>( json_doc3b );
+	assert( not val3b.m0 );
+	assert( val3b.m1.size( ) == 2 );
+	assert( val3b.m1[0].m1 == 0 );
+	assert( val3b.m1[0].m2 == 1 );
+	assert( val3b.m1[1].m1 == 2 );
+	assert( val3b.m1[1].m2 == 3 );
+}

--- a/tests/src/issue_373_empty_string_nullable_test.cpp
+++ b/tests/src/issue_373_empty_string_nullable_test.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+#include "defines.h"
+
+#include "daw/json/daw_json_link.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace impl {
+	template<typename T, daw::json::json_options_t Options, typename Constructor>
+	struct FromConverter {
+		constexpr T operator( )( std::string_view sv ) {
+
+			using namespace daw::json;
+			using parse_to_t =
+			  typename daw::json::json_number_null_no_name<T>::base_type;
+			using member_type =
+			  typename daw::json::json_number_null_no_name<T>::member_type;
+
+			constexpr auto opts =
+			  member_type::literal_as_string == options::LiteralAsStringOpt::Never
+			    ? json_details::number_opts_set<Options,
+			                                    options::LiteralAsStringOpt::Maybe>
+			    : Options;
+
+			using parse_type =
+			  daw::json::json_number_no_name<parse_to_t, opts, Constructor>;
+
+			auto jv = json_value( sv );
+			if( jv.is_string( ) and jv.template as<std::string_view>( ).empty( ) ) {
+				return { };
+			}
+			return from_json<parse_type>( jv );
+		}
+	};
+
+	template<typename T>
+	struct ToConverter {
+		inline T operator( )( T const &value ) {
+			return daw::json::to_json( value );
+		}
+	};
+} // namespace impl
+
+/**
+ * The member is a nullable number
+ * @tparam Name name of json member
+ * @tparam T type of number(e.g. double, int, unsigned...) to pass to
+ * Constructor
+ * @tparam LiteralAsString Could this number be embedded in a string
+ * @tparam Constructor Callable used to construct result
+ * @tparam RangeCheck Check if the value will fit in the result
+ */
+template<JSONNAMETYPE Name, typename T = std::optional<double>,
+         daw::json::json_options_t Options = daw::json::number_opts_def,
+         daw::json::JsonNullable NullableType =
+           daw::json::JsonNullable::Nullable,
+         typename Constructor = daw::use_default>
+using json_empty_nullable_number = daw::json::json_custom_lit_null<
+  Name, T, impl::FromConverter<T, Options, Constructor>, impl::ToConverter<T>,
+  daw::json::json_details::json_custom_opts_set<
+    Options, daw::json::json_custom_opts_def, NullableType>>;
+//************************************
+
+struct Thing {
+	std::optional<int> value;
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<Thing> {
+		static constexpr char const name[] = "value";
+		using type =
+		  json_member_list<json_empty_nullable_number<name, std::optional<int>>>;
+
+		static constexpr auto to_json_data( Thing const &value ) {
+			return std::forward_as_tuple( value.value );
+		}
+	};
+} // namespace daw::json
+
+int main( )
+#ifdef DAW_USE_EXCEPTIONS
+  try
+#endif
+{
+	constexpr std::string_view json_doc = R"json(
+[
+  { "value": "5" },
+  { "value": "" },
+  { "value": null },
+  { "value": "6" }
+]
+)json";
+	auto things = daw::json::from_json_array<Thing>( json_doc );
+	ensure( things.size( ) == 4 );
+	ensure( things[0].value );
+	ensure( not things[1].value );
+	ensure( not things[2].value );
+	ensure( things[3].value );
+}
+#ifdef DAW_USE_EXCEPTIONS
+catch( daw::json::json_exception const &jex ) {
+	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
+	exit( 1 );
+} catch( std::exception const &ex ) {
+	std::cerr << "Unknown exception thrown during testing: " << ex.what( )
+	          << '\n';
+	exit( 1 );
+} catch( ... ) {
+	std::cerr << "Unknown exception thrown during testing\n";
+	throw;
+}
+#endif


### PR DESCRIPTION
* The TemporarilyMutateBuffer option was not fruitful and wasn't used.
Setting the option caused errors. Fixes #372 
* Migrated the Boost.Describe bindings library via
  daw_json_link_describe.h to json link.  This allows one to use
  Boost.Desribe based reflection for JSON Link
* Fix for #374 