### PR TITLE
Allowing full nanosecond durations in json_date

### DIFF
--- a/include/daw/json/daw_json_link_types.h
+++ b/include/daw/json/daw_json_link_types.h
@@ -763,10 +763,12 @@ namespace daw::json {
 		namespace json_base {
 			template<typename T, typename Constructor>
 			struct json_date {
+				using clock_type = typename T::clock;
+				using duration_type = typename T::duration;
 				using i_am_a_json_type = void;
 				using constructor_t =
 				  std::conditional_t<std::is_same_v<use_default, Constructor>,
-				                     construct_from_iso8601_timestamp, Constructor>;
+				                     construct_from_iso8601_timestamp<T>, Constructor>;
 
 				using wrapped_type = T;
 				static constexpr bool must_be_class_member = false;

--- a/include/daw/json/impl/daw_json_link_types_iso8601.h
+++ b/include/daw/json/impl/daw_json_link_types_iso8601.h
@@ -18,14 +18,19 @@
 
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
-		struct construct_from_iso8601_timestamp {
-			using result_type = std::chrono::time_point<std::chrono::system_clock,
-			                                            std::chrono::milliseconds>;
+		template<typename TP>
+		struct construct_from_iso8601_timestamp;
+
+		template<typename Clock, typename Duration>
+		struct construct_from_iso8601_timestamp<
+		  std::chrono::time_point<Clock, Duration>> {
+			using result_type = std::chrono::time_point<Clock, Duration>;
 
 			[[nodiscard]] DAW_JSON_CPP23_STATIC_CALL_OP inline constexpr result_type
 			operator( )( char const *ptr,
 			             std::size_t sz ) DAW_JSON_CPP23_STATIC_CALL_OP_CONST {
-				return datetime::parse_iso8601_timestamp( daw::string_view( ptr, sz ) );
+				return datetime::parse_iso8601_timestamp<result_type>(
+				  daw::string_view( ptr, sz ) );
 			}
 		};
 	} // namespace DAW_JSON_VER

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -886,7 +886,7 @@ namespace daw::json {
 					return it;
 				}
 				it.put( '"' );
-				datetime::ymdhms const civil = datetime::time_point_to_civil( value );
+				datetime::ymdhms civil = datetime::time_point_to_civil( value );
 				it = utils::integer_to_string( it, civil.year );
 				it.put( '-' );
 				if( civil.month < 10 ) {
@@ -913,9 +913,12 @@ namespace daw::json {
 					it.put( '0' );
 				}
 				it = utils::integer_to_string( it, civil.second );
-				if( civil.millisecond > 0 ) {
+				if( civil.nanosecond > 0 ) {
+					while( civil.nanosecond != 0 and civil.nanosecond % 10 == 0 ) {
+						civil.nanosecond /= 10;
+					}
 					it.put( '.' );
-					it = utils::integer_to_string( it, civil.millisecond );
+					it = utils::integer_to_string( it, civil.nanosecond );
 				}
 				it.write( "Z\"" );
 				return it;
@@ -934,7 +937,10 @@ namespace daw::json {
 
 				static_assert(
 				  std::is_convertible_v<parse_to_t, typename JsonMember::parse_to_t> or
-				    std::is_same_v<parse_to_t, typename JsonMember::parse_to_t>, // This is for not-copy/movable types
+				    std::is_same_v<parse_to_t,
+				                   typename JsonMember::parse_to_t>, // This is for
+				                                                     // not-copy/movable
+				                                                     // types
 				  "value must be convertible to specified type in class contract" );
 
 				if constexpr( has_json_to_json_data_v<parse_to_t> ) {

--- a/tests/cmake/test_compiler_options.cmake
+++ b/tests/cmake/test_compiler_options.cmake
@@ -31,6 +31,7 @@ if( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQU
                 -pedantic
                 -Weverything
                 -ftemplate-backtrace-limit=0
+								-Wincompatible-pointer-types-discards-qualifiers
                 -Wno-c++98-compat
                 -Wno-c++98-compat-pedantic
                 -Wno-covered-switch-default

--- a/tests/src/daw_json_link_test.cpp
+++ b/tests/src/daw_json_link_test.cpp
@@ -1149,7 +1149,7 @@ int main( int, char ** ) {
 #if not defined( DAW_JSON_USE_FULL_DEBUG_ITERATORS )
 		static_assert( from_json<std::array<int, 4>>( "[1,2,3]"sv )[1] == 2 );
 #else
-		assert( (from_json<std::array<int, 4>>( "[1,2,3]"sv )[1] == 2) );
+	assert( ( from_json<std::array<int, 4>>( "[1,2,3]"sv )[1] == 2 ) );
 #endif
 
 		auto const test_bad_float = []( ) -> bool {
@@ -1270,6 +1270,32 @@ int main( int, char ** ) {
 
 		std::string negnumber_str = to_json<strsigned_t>( -1234567890LL );
 		ensure( negnumber_str == R"("-1234567890")" );
+
+		constexpr std::string_view ts = "\"2016-12-31T01:02:03.343Z\"";
+		using tp_t = std::chrono::time_point<std::chrono::system_clock,
+		                                     std::chrono::nanoseconds>;
+		constexpr auto parsed_dte =
+		  daw::json::from_json<daw::json::json_date_no_name<tp_t>>( ts );
+		(void)parsed_dte;
+#if defined( __cpp_lib_chrono ) and __cpp_lib_chrono >= 201907
+		std::cout << ts << " parsed as " << parsed_dte << '\n';
+#endif
+		constexpr std::string_view ts2 = "\"2016-12-31T01:02:03.123456789Z\"";
+		constexpr auto parsed_dte2 =
+		  daw::json::from_json<daw::json::json_date_no_name<tp_t>>( ts2 );
+		(void)parsed_dte;
+#if defined( __cpp_lib_chrono ) and __cpp_lib_chrono >= 201907
+		std::cout << ts2 << " parsed as " << parsed_dte2 << '\n';
+#endif
+		auto const parsed_dte_str =
+		  daw::json::to_json<daw::json::json_date_no_name<tp_t>>( parsed_dte );
+		std::cout << "round trip of " << ts << " became " << parsed_dte_str << '\n';
+		ensure( ts == parsed_dte_str );
+		auto const parsed_dte2_str =
+		  daw::json::to_json<daw::json::json_date_no_name<tp_t>>( parsed_dte2 );
+		std::cout << "round trip of " << ts2 << " became " << parsed_dte2_str
+		          << '\n';
+		ensure( ts2 == parsed_dte2_str );
 
 #if defined( __cpp_lib_char8_t )
 #if __cpp_lib_char8_t >= 201907L


### PR DESCRIPTION
Currently the duration of time_points was limited to millisecond accuracy.  Updated to allow up to nanosecond.