### PR TITLE
handle large negative floating point numbers correctly

### DIFF
--- a/docs/cookbook/numbers.md
+++ b/docs/cookbook/numbers.md
@@ -9,11 +9,12 @@ There is direct support for numbers in JSON of the form `integer`[.`fraction`][e
   "member0": 1.23,
   "member1": 1,
   "member2": 1.2e3,
-  "member3": 3e3
+  "member3": 3e3,
+  "member4": -3e10
 }
 ```
 
-The above JSON object has 4 members, each of which are numbers.
+The above JSON object has five members, each of which are numbers.
 
 Below is the C++ data structure and trait to map the structure to the JSON object.
 To see a working example using this code, refer to [cookbook_numbers1_test.cpp](../../tests/src/cookbook_numbers1_test.cpp)
@@ -24,6 +25,7 @@ struct MyClass1 {
   double member1;
   double member2;
   double member3;
+  double member4;
 };
 namespace daw::json {
   template<>
@@ -32,7 +34,8 @@ namespace daw::json {
     json_number<"member0">, 
     json_number<"member1">, 
     json_number<"member2">,
-    json_number<"member3">
+    json_number<"member3">,
+    json_number<"member4">
   >;
 
   static inline auto to_json_data( MyClass1 const &value ) {
@@ -40,7 +43,8 @@ namespace daw::json {
     value.member0, 
     value.member1,
     value.member2,
-    value.member3 );
+    value.member3,
+    value.member4 );
   }
   };
 }

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -1497,9 +1497,6 @@ namespace daw::json {
 					}
 				}( );
 				if( dec.significand == 0 ) {
-					if( br.is_negative( ) ) {
-						out_it.put( '-' );
-					}
 					out_it.put( '0' );
 					return out_it;
 				}

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -1503,6 +1503,9 @@ namespace daw::json {
 					out_it.put( '0' );
 					return out_it;
 				}
+				if( br.is_negative( ) ) {
+					out_it.put( '-' );
+				}
 				if( fp_output_fmt == options::FPOutputFormat::Scientific ) {
 					char buff[50]{ };
 					char *ptr = buff;
@@ -1519,9 +1522,6 @@ namespace daw::json {
 						out_it.copy_buffer( buff, ptr );
 						return out_it;
 					}
-				}
-				if( br.is_negative( ) ) {
-					out_it.put( '-' );
 				}
 				if( dec.significand == 0 ) {
 					out_it.put( '0' );

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -1520,10 +1520,6 @@ namespace daw::json {
 						return out_it;
 					}
 				}
-				if( dec.significand == 0 ) {
-					out_it.put( '0' );
-					return out_it;
-				}
 				if( dec.exponent < 0 ) {
 					if( whole_dig < 0 ) {
 						out_it.write( "0." );

--- a/test_data/cookbook_numbers1.json
+++ b/test_data/cookbook_numbers1.json
@@ -2,5 +2,6 @@
   "member0": 1.23,
   "member1": 1,
   "member2": 1.2e3,
-  "member3": 3e3
+  "member3": 3e3,
+  "member4": -3e10,
 }

--- a/tests/src/cookbook_numbers1_test.cpp
+++ b/tests/src/cookbook_numbers1_test.cpp
@@ -24,10 +24,12 @@ namespace daw::cookbook_numbers1 {
 		double member1;
 		double member2;
 		double member3;
+		double member4;
 
 		DAW_CONSTEXPR bool operator==( MyClass1 const &rhs ) const {
 			return member0 == rhs.member0 and member1 == rhs.member1 and
-			       member2 == rhs.member2 and member3 == rhs.member3;
+			       member2 == rhs.member2 and member3 == rhs.member3 and
+			       member4 == rhs.member4;
 		}
 	};
 } // namespace daw::cookbook_numbers1
@@ -38,19 +40,22 @@ namespace daw::json {
 #ifdef DAW_JSON_CNTTP_JSON_NAME
 		using type =
 		  json_member_list<json_number<"member0">, json_number<"member1">,
-		                   json_number<"member2">, json_number<"member3">>;
+		                   json_number<"member2">, json_number<"member3">,
+		                   json_number<"member4">>;
 #else
 		static constexpr char const member0[] = "member0";
 		static constexpr char const member1[] = "member1";
 		static constexpr char const member2[] = "member2";
 		static constexpr char const member3[] = "member3";
+		static constexpr char const member4[] = "member4";
 		using type = json_member_list<json_number<member0>, json_number<member1>,
-		                              json_number<member2>, json_number<member3>>;
+		                              json_number<member2>, json_number<member3>,
+		                              json_number<member4>>;
 #endif
 		static inline auto
 		to_json_data( cookbook_numbers1::MyClass1 const &value ) {
 			return std::forward_as_tuple( value.member0, value.member1, value.member2,
-			                              value.member3 );
+			                              value.member3, value.member4 );
 		}
 	};
 } // namespace daw::json
@@ -73,6 +78,7 @@ int main( int argc, char **argv )
 	test_assert( cls.member1 == 1, "Unexpected value" );
 	test_assert( cls.member2 == 1200, "Unexpected value" );
 	test_assert( cls.member3 == 3000, "Unexpected value" );
+	test_assert( cls.member4 == -3e10, "Unexpected value" );
 	std::string const str = daw::json::to_json( cls );
 	puts( str.c_str( ) );
 


### PR DESCRIPTION
When writing large negative values as double to json, the minus sign is omitted.
The limit seems to be when the number is so large that it is written with an exponent.

This adds such a number to the cookbook code and the associated test.

I also tried to fix it, hopefully the fix is correct. The tests pass.