### PR TITLE
Fixed output when invalid-utf8 encountered.  Option to escape works now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-         VERSION "3.18.0"
+         VERSION "3.19.0"
          DESCRIPTION "Static JSON parsing in C++"
          HOMEPAGE_URL "https://github.com/beached/daw_json_link"
          LANGUAGES C CXX )

--- a/docs/cookbook/output_options.md
+++ b/docs/cookbook/output_options.md
@@ -92,10 +92,11 @@ Allow for a JSON document that is ASCII only and each byte has a value <= 0x7F
 
 * `None` - Do not restrict to 7bit ASCII
 * `OnlyAllow7bitStrings` - Restrict all string member values and all member names to 7bits, escaping all values >= 0x7F.
+* `ErrorInvalidUTF8` - Throw an error when invalid UTF8 is encountered
 
 ### Default
 
-* `None`
+* `ErrorInvalidUTF8`
 
 ## `NewLineDelimiter`
 

--- a/include/daw/json/daw_json_exception.h
+++ b/include/daw/json/daw_json_exception.h
@@ -141,7 +141,7 @@ namespace daw::json {
 				return "Invalid or corrupt string"sv;
 			case ErrorReason::InvalidStringHighASCII:
 				return "String support limited to 0x20 < chr <= 0x7F when "
-				       "DisallowHighEightBit is true"sv;
+				       "DisallowHighEightBit or InvalidStringHighASCII is true"sv;
 			case ErrorReason::ExpectedKeyValueToStartWithBrace:
 				return "Expected key/value's JSON type to be of class type and "
 				       "beginning "

--- a/include/daw/json/daw_json_serialize_options.h
+++ b/include/daw/json/daw_json_serialize_options.h
@@ -62,6 +62,8 @@ namespace daw::json {
 					/* Do not impose any extra restrictions on string output during
 					   serialization */
 					None,
+					/// When invalid UTF8 is encountered, throw an error
+					ErrorInvalidUTF8,
 					/* Restrict all string member values and all member names to 7bits.
 					   This will result in escaping all values >= 0x7F.  This can affect
 					   round trips where the name contains high bits set*/

--- a/include/daw/json/impl/daw_json_serialize_options_impl.h
+++ b/include/daw/json/impl/daw_json_serialize_options_impl.h
@@ -50,12 +50,12 @@ namespace daw::json {
 
 			template<>
 			inline constexpr unsigned
-			  json_option_bits_width<options::RestrictedStringOutput> = 1;
+			  json_option_bits_width<options::RestrictedStringOutput> = 2;
 
 			template<>
 			inline constexpr auto
 			  default_json_option_value<options::RestrictedStringOutput> =
-			    options::RestrictedStringOutput::None;
+			    options::RestrictedStringOutput::ErrorInvalidUTF8;
 
 			template<>
 			inline constexpr bool is_output_option_v<options::NewLineDelimiter> =

--- a/include/daw/json/impl/daw_json_type_options.h
+++ b/include/daw/json/impl/daw_json_type_options.h
@@ -155,6 +155,7 @@ namespace daw::json {
 				/// encountered
 				/// during parse
 				DisallowHigh,
+
 				/// Allow the full 8bits in output without escaping
 				AllowFull
 			}; // 1bit

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -311,7 +311,18 @@ namespace daw::json {
 					auto first = it_t( std::begin( container ) );
 					auto const last = it_t( std::end( container ) );
 					while( first != last ) {
+						auto const last_it = first;
 						auto const cp = *first++;
+						if( last_it == first ) {
+							// Not a valid unicode cp
+							if constexpr( WritableType::restricted_string_output ==
+							              options::RestrictedStringOutput::
+							                ErrorInvalidUTF8 ) {
+								daw_json_error( ErrorReason::InvalidStringHighASCII );
+							} else {
+								first = it_t( std::next( first.base( ) ) );
+							}
+						}
 						switch( cp ) {
 						case '"':
 							it.write( "\\\"" );

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -945,6 +945,12 @@ add_dependencies( full issue_370_exact_class_mapping_test )
 #add_dependencies( ci_tests issue_373_empty_string_nullable_test )
 #add_dependencies( full issue_373_empty_string_nullable_test )
 
+add_executable( issue_389_test src/issue_389_test.cpp )
+target_link_libraries( issue_389_test PRIVATE json_test )
+add_test( NAME issue_389_test COMMAND issue_389_test ./issue_389.json WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test_data/" )
+add_dependencies( ci_tests issue_389_test )
+add_dependencies( full issue_389_test )
+
 add_executable( carray_test src/carray_test.cpp )
 target_link_libraries( carray_test json_test )
 add_test( NAME carray_test_test COMMAND carray_test )

--- a/tests/src/issue_389_test.cpp
+++ b/tests/src/issue_389_test.cpp
@@ -30,13 +30,19 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( ) {
-	std::cout << "Building New Request..." << std::endl;
-
 	constexpr std::string_view const test_string = "\x0D\x0ATEST\xFETEST\x0D\x0A";
 	constexpr auto document = test_document{ test_string };
 	std::string buff;
-	auto request_json_payload = daw::json::to_json( document, buff );
+	try {
+		auto request_json_payload = daw::json::to_json( document, buff );
+		std::cerr << "Expected error\n";
+		return 1;
+	} catch( daw::json::json_exception const & jex ) {
+		if( jex.reason_type()	!= daw::json::ErrorReason::InvalidStringHighASCII ) {
+			std::cerr << "Unexpected JSON error " << to_formatted_string( jex ) << '\n';
+			return 1;
+		}
+	}
 
-	std::cout << "Request JSON: " << request_json_payload << std::endl;
 	return 0;
 }

--- a/tests/src/issue_389_test.cpp
+++ b/tests/src/issue_389_test.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/
+//
+
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include <daw/daw_span.h>
+#include <daw/json/daw_json_link.h>
+
+struct test_document {
+	std::string_view in;
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<test_document> {
+		static inline constexpr char const _in[] = "in";
+		using type = json_member_list<json_string<_in, std::string_view>>;
+
+		static constexpr auto to_json_data( test_document const &doc ) {
+			return std::forward_as_tuple( doc.in );
+		}
+	};
+} // namespace daw::json
+
+int main( ) {
+	std::cout << "Building New Request..." << std::endl;
+
+	constexpr std::string_view const test_string = "\x0D\x0ATEST\xFETEST\x0D\x0A";
+	constexpr auto document = test_document{ test_string };
+	std::string buff;
+	auto request_json_payload = daw::json::to_json( document, buff );
+
+	std::cout << "Request JSON: " << request_json_payload << std::endl;
+	return 0;
+}


### PR DESCRIPTION
Fixed output when invalid-utf8 encountered.  Option to escape works now too.  Default is to Error