### PR TITLE
Fix for missing feature in issue #406

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-         VERSION "3.21.1"
+         VERSION "3.22.0"
          DESCRIPTION "Static JSON parsing in C++"
          HOMEPAGE_URL "https://github.com/beached/daw_json_link"
          LANGUAGES C CXX )

--- a/include/daw/json/impl/daw_json_link_types_fwd.h
+++ b/include/daw/json/impl/daw_json_link_types_fwd.h
@@ -687,7 +687,7 @@ namespace daw::json {
 		/// @tparam Constructor A callable used to construct Tuple. The default
 		/// supports normal and aggregate construction
 		/// @tparam Options
-		/// @tparam JsonTupleTypesList either deduced or a rjson_tuple_type_list
+		/// @tparam JsonTupleTypesList either deduced or a json_tuple_type_list
 		template<JSONNAMETYPE Name, typename Tuple,
 		         typename JsonTupleTypesList = use_default,
 		         typename Constructor = use_default>

--- a/include/daw/json/impl/daw_json_parse_common.h
+++ b/include/daw/json/impl/daw_json_parse_common.h
@@ -798,6 +798,11 @@ namespace daw::json {
 					  typename decltype( json_deduced_type_impl<value_type>( ) )::type;
 					using type = json_base::json_nullable<T, sub_type>;
 					return daw::traits::identity<type>{ };
+				} else if constexpr( std::is_empty_v<T> and
+				                     std::is_default_constructible_v<T> ) {
+					// Allow empty/default constructible types to work without mapping
+					using type = json_base::json_tuple<T, std::tuple<>>;
+					return daw::traits::identity<type>{ };
 				} else {
 					static_assert( daw::deduced_false_v<T>,
 					               "Could not deduced data contract type" );
@@ -826,9 +831,7 @@ namespace daw::json {
 
 			template<typename Constructor, typename... Members>
 			using json_class_parse_result_impl2 =
-			  std::invoke_result_t<Constructor,
-			                       typename Members::parse_to_t...>; /* decltype(
-Constructor{ }( std::declval<typename Members::parse_to_t &&>( )... ) );*/
+			  std::invoke_result_t<Constructor, typename Members::parse_to_t...>;
 
 			template<typename Constructor, typename... Members>
 			using json_class_parse_result_impl =

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -969,6 +969,12 @@ add_dependencies( full issue_361_test )
 #add_dependencies( ci_tests issue_373_empty_string_nullable_test )
 #add_dependencies( full issue_373_empty_string_nullable_test )
 
+add_executable( issue_406_test src/issue_406_test.cpp )
+target_link_libraries( issue_406_test PRIVATE json_test )
+add_test( NAME issue_406_test COMMAND issue_406_test WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test_data/" )
+add_dependencies( ci_tests issue_406_test )
+add_dependencies( full issue_406_test )
+
 add_executable( multi_tu_test src/multi_tu_p0_test.cpp src/multi_tu_p1_test.cpp )
 target_link_libraries( multi_tu_test json_test )
 add_test( NAME multi_tu_test_test COMMAND multi_tu_test )

--- a/tests/src/issue_406_test.cpp
+++ b/tests/src/issue_406_test.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+
+#include "defines.h"
+
+#include <daw/json/daw_json_link.h>
+
+#include <variant>
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<std::monostate> {
+		using type = json_member_list<>;
+
+		static constexpr std::tuple<> to_json_data( std::monostate ) noexcept {
+			return { };
+		}
+	};
+} // namespace daw::json
+
+struct SomeEmpty {};
+
+int main( ) {
+	using type = daw::json::json_variant_null_no_name<
+	  std::variant<std::monostate, double, std::string_view>>;
+	auto a = daw::json::from_json<type>( R"("hello")" );
+	ensure( a.index( ) == 2 );
+
+	using type2 = daw::json::json_variant_null_no_name<
+	  std::variant<SomeEmpty, double, std::string_view>>;
+	auto a2 = daw::json::from_json<type2>( R"("hello")" );
+	ensure( a2.index( ) == 2 );
+	auto b2 = daw::json::from_json<type2>( "null" );
+	ensure( b2.index( ) == 0 );
+}


### PR DESCRIPTION
Empty/default constructible types should default to not needing a mapping.  They can still be mapped explicitly.