### PR TITLE
Updated deduced empty fix to serialize and fast path the parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-         VERSION "3.22.0"
+         VERSION "3.22.1"
          DESCRIPTION "Static JSON parsing in C++"
          HOMEPAGE_URL "https://github.com/beached/daw_json_link"
          LANGUAGES C CXX )

--- a/include/daw/json/impl/daw_json_parse_common.h
+++ b/include/daw/json/impl/daw_json_parse_common.h
@@ -267,7 +267,29 @@ namespace daw::json {
 			inline constexpr bool is_json_nullable_v<
 			  json_base::json_nullable<T, JsonMember, NullableType, Constructor>> =
 			  true;
-		} // namespace json_details
+
+			template<typename T>
+			struct json_empty_class {
+				static_assert( std::is_empty_v<T>, "T is expected to empty" );
+				using i_am_a_json_type = void;
+				using i_am_a_deduced_empty_class = void;
+				using wrapped_type = T;
+				static constexpr bool must_be_class_member = false;
+
+				using constructor_t = default_constructor<T>;
+				using parse_to_t = T;
+				using base_type = T;
+
+				static constexpr JsonParseTypes expected_type = JsonParseTypes::Class;
+
+				static constexpr JsonBaseParseTypes underlying_json_type =
+				  JsonBaseParseTypes::Class;
+			};
+
+			template<typename T>
+			inline constexpr bool is_deduced_empty_class_v<
+			  T, std::void_t<typename T::i_am_a_deduced_empty_class>> = true;
+		}; // namespace json_details
 
 		namespace json_base {
 
@@ -801,7 +823,7 @@ namespace daw::json {
 				} else if constexpr( std::is_empty_v<T> and
 				                     std::is_default_constructible_v<T> ) {
 					// Allow empty/default constructible types to work without mapping
-					using type = json_base::json_tuple<T, std::tuple<>>;
+					using type = json_details::json_empty_class<T>;
 					return daw::traits::identity<type>{ };
 				} else {
 					static_assert( daw::deduced_false_v<T>,

--- a/include/daw/json/impl/daw_json_parse_value.h
+++ b/include/daw/json/impl/daw_json_parse_value.h
@@ -619,6 +619,9 @@ namespace daw::json {
 					(void)run_after_parse;
 					return json_data_contract_trait_t<element_t>::parse_to_class(
 					  parse_state, template_arg<JsonMember> );
+				} else if constexpr( is_deduced_empty_class_v<JsonMember> ) {
+					parse_state.trim_left_checked( );
+					return json_result<JsonMember>{ };
 				} else {
 					auto result = json_data_contract_trait_t<element_t>::parse_to_class(
 					  parse_state, template_arg<JsonMember> );

--- a/include/daw/json/impl/daw_json_traits.h
+++ b/include/daw/json/impl/daw_json_traits.h
@@ -430,6 +430,9 @@ namespace daw::json {
 
 			template<typename JsonMember>
 			using literal_json_type_as_string = typename JsonMember::as_string;
+
+			template<typename, typename = void>
+			inline constexpr bool is_deduced_empty_class_v = false;
 		} // namespace json_details
 	}   // namespace DAW_JSON_VER
 } // namespace daw::json

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -964,6 +964,11 @@ namespace daw::json {
 				} else if constexpr( is_json_map_alias_v<parse_to_t> ) {
 					return json_data_contract_trait_t<parse_to_t>::serialize( it, value,
 					                                                          value );
+				} else if constexpr( std::is_empty_v<parse_to_t> and
+				                     std::is_default_constructible_v<parse_to_t> and
+				                     not has_json_data_contract_trait_v<parse_to_t> ) {
+					it.write( "{}" );
+					return it;
 				} else {
 					static_assert( is_submember_tagged_variant_v<parse_to_t>,
 					               "Could not find appropriate mapping or to_json_data "

--- a/tests/src/issue_406_test.cpp
+++ b/tests/src/issue_406_test.cpp
@@ -30,11 +30,16 @@ int main( ) {
 	  std::variant<std::monostate, double, std::string_view>>;
 	auto a = daw::json::from_json<type>( R"("hello")" );
 	ensure( a.index( ) == 2 );
-
+	auto a_str = daw::json::to_json<type>( a );
+	ensure( a_str == R"("hello")" );
 	using type2 = daw::json::json_variant_null_no_name<
 	  std::variant<SomeEmpty, double, std::string_view>>;
 	auto a2 = daw::json::from_json<type2>( R"("hello")" );
 	ensure( a2.index( ) == 2 );
+	auto a2_str = daw::json::to_json<type2>( a2 );
+	ensure( a2_str == R"("hello")" );
 	auto b2 = daw::json::from_json<type2>( "null" );
 	ensure( b2.index( ) == 0 );
+	auto b2_str = daw::json::to_json<type2>( b2 );
+	(void)b2_str;
 }


### PR DESCRIPTION
This should be a better fix for #406.  It will serialize the deduced empty types to `{}` and reduced the complexity of the parsing to return the default constructed value.