### PR TITLE
Removed usages of ParseTag except for json schema export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-         VERSION "3.26.0"
+         VERSION "3.27.0"
          DESCRIPTION "Static JSON parsing in C++"
          HOMEPAGE_URL "https://github.com/beached/daw_json_link"
          LANGUAGES C CXX )

--- a/include/daw/json/daw_from_json.h
+++ b/include/daw/json/daw_from_json.h
@@ -69,15 +69,17 @@ namespace daw::json {
 			auto parse_state = ParseState( first, last );
 
 			if constexpr( ParseState::must_verify_end_of_data_is_valid ) {
-				auto result = json_details::parse_value<json_member, KnownBounds>(
-				  parse_state, ParseTag<json_member::expected_type>{ } );
+				auto result =
+				  json_details::parse_value<json_member, KnownBounds,
+				                            json_member::expected_type>( parse_state );
 				parse_state.trim_left( );
 				daw_json_ensure( parse_state.empty( ), ErrorReason::InvalidEndOfValue,
 				                 parse_state );
 				return result;
 			} else {
-				return json_details::parse_value<json_member, KnownBounds>(
-				  parse_state, ParseTag<json_member::expected_type>{ } );
+				return json_details::parse_value<json_member, KnownBounds,
+				                                 json_member::expected_type>(
+				  parse_state );
 			}
 		}
 
@@ -140,15 +142,17 @@ namespace daw::json {
 
 			auto parse_state = ParseState::with_allocator( f, l, a );
 			if constexpr( ParseState::must_verify_end_of_data_is_valid ) {
-				auto result = json_details::parse_value<json_member, KnownBounds>(
-				  parse_state, ParseTag<json_member::expected_type>{ } );
+				auto result =
+				  json_details::parse_value<json_member, KnownBounds,
+				                            json_member::expected_type>( parse_state );
 				parse_state.trim_left( );
 				daw_json_ensure( parse_state.empty( ), ErrorReason::InvalidEndOfValue,
 				                 parse_state );
 				return result;
 			} else {
-				return json_details::parse_value<json_member, KnownBounds>(
-				  parse_state, ParseTag<json_member::expected_type>{ } );
+				return json_details::parse_value<json_member, KnownBounds,
+				                                 json_member::expected_type>(
+				  parse_state );
 			}
 		}
 
@@ -232,15 +236,17 @@ namespace daw::json {
 			}
 			auto parse_state = jv.get_raw_state( );
 			if constexpr( ParseState::must_verify_end_of_data_is_valid ) {
-				auto result = json_details::parse_value<json_member, KnownBounds>(
-				  parse_state, ParseTag<json_member::expected_type>{ } );
+				auto result =
+				  json_details::parse_value<json_member, KnownBounds,
+				                            json_member::expected_type>( parse_state );
 				parse_state.trim_left( );
 				daw_json_ensure( parse_state.empty( ), ErrorReason::InvalidEndOfValue,
 				                 parse_state );
 				return result;
 			} else {
-				return json_details::parse_value<json_member, KnownBounds>(
-				  parse_state, ParseTag<json_member::expected_type>{ } );
+				return json_details::parse_value<json_member, KnownBounds,
+				                                 json_member::expected_type>(
+				  parse_state );
 			}
 		}
 
@@ -325,15 +331,17 @@ namespace daw::json {
 			}
 			auto parse_state = jv.get_raw_state( );
 			if constexpr( ParseState::must_verify_end_of_data_is_valid ) {
-				auto result = json_details::parse_value<json_member, KnownBounds>(
-				  parse_state, ParseTag<json_member::expected_type>{ } );
+				auto result =
+				  json_details::parse_value<json_member, KnownBounds,
+				                            json_member::expected_type>( parse_state );
 				parse_state.trim_left( );
 				daw_json_ensure( parse_state.empty( ), ErrorReason::InvalidEndOfValue,
 				                 parse_state );
 				return result;
 			} else {
-				return json_details::parse_value<json_member, KnownBounds>(
-				  parse_state, ParseTag<json_member::expected_type>{ } );
+				return json_details::parse_value<json_member, KnownBounds,
+				                                 json_member::expected_type>(
+				  parse_state );
 			}
 		}
 
@@ -388,8 +396,9 @@ namespace daw::json {
 			              old_parse_state.class_first, old_parse_state.class_last,
 			              old_parse_state.get_allocator( ) );
 
-			return json_details::parse_value<json_member, KnownBounds>(
-			  parse_state, ParseTag<json_member::expected_type>{ } );
+			return json_details::parse_value<json_member, KnownBounds,
+			                                 json_member::expected_type>(
+			  parse_state );
 		}
 
 		/// @brief Parse a value from a json_value
@@ -451,8 +460,9 @@ namespace daw::json {
 				daw_json_ensure( jv, ErrorReason::JSONPathNotFound );
 			}
 			auto parse_state = jv.get_raw_state( );
-			return json_details::parse_value<json_member, KnownBounds>(
-			  parse_state, ParseTag<json_member::expected_type>{ } );
+			return json_details::parse_value<json_member, KnownBounds,
+			                                 json_member::expected_type>(
+			  parse_state );
 		}
 
 		/// @brief Parse a JSONMember from the json_data starting at member_path.

--- a/include/daw/json/daw_json_iterator.h
+++ b/include/daw/json/daw_json_iterator.h
@@ -12,6 +12,7 @@
 
 #include "impl/daw_json_link_types_fwd.h"
 #include "impl/daw_json_parse_class.h"
+#include "impl/daw_json_parse_value_fwd.h"
 
 #include <daw/daw_cxmath.h>
 #include <daw/daw_move.h>
@@ -128,8 +129,8 @@ namespace daw::json {
 				auto const run_after_parse =
 				  json_details::assign_on_dtor{ m_can_skip, tmp.first };
 				(void)run_after_parse;
-				return json_details::parse_value<element_type>(
-				  tmp, ParseTag<element_type::expected_type>{ } );
+				return json_details::parse_value<element_type, false,
+				                                 element_type::expected_type>( tmp );
 			}
 
 			/// @brief A dereferencable value proxy holding the result of operator*
@@ -281,8 +282,9 @@ namespace daw::json {
 				daw_json_assert_weak( m_state.has_more( ) and m_state.front( ) != ']',
 				                      ErrorReason::UnexpectedEndOfData, m_state );
 
-				return json_details::parse_value<element_type>(
-				  m_state, ParseTag<element_type::expected_type>{ } );
+				return json_details::parse_value<element_type, false,
+				                                 element_type::expected_type>(
+				  m_state );
 			}
 
 			/***

--- a/include/daw/json/daw_json_lines_iterator.h
+++ b/include/daw/json/daw_json_lines_iterator.h
@@ -62,8 +62,7 @@ namespace daw::json {
 		public:
 			explicit json_lines_iterator( ) = default;
 
-			explicit constexpr json_lines_iterator(
-			  daw::string_view json_lines_doc )
+			explicit constexpr json_lines_iterator( daw::string_view json_lines_doc )
 			  : m_state( ParseState( std::data( json_lines_doc ),
 			                         daw::data_end( json_lines_doc ) ) ) {
 
@@ -82,8 +81,8 @@ namespace daw::json {
 					m_can_skip = tmp.first;
 				} );
 				(void)run_after_parse;
-				return json_details::parse_value<element_type>(
-				  tmp, ParseTag<element_type::expected_type>{ } );
+				return json_details::parse_value<element_type, false,
+				                                 element_type::expected_type>( tmp );
 			}
 
 			/// @brief A dereferencable value proxy holding the result of operator* .

--- a/include/daw/json/daw_json_link_types.h
+++ b/include/daw/json/daw_json_link_types.h
@@ -192,8 +192,7 @@ namespace daw::json {
 				  JsonClass,
 				  daw::construct_a_t<json_details::json_result_t<JsonClass>>>(
 				  parse_state,
-				  json_details::parse_value<json_member, KnownBounds>(
-				    parse_state, ParseTag<json_member::expected_type>{ } ) );
+				  json_details::parse_value<json_member, KnownBounds, json_member::expected_type>( parse_state ) );
 			}
 		};
 

--- a/include/daw/json/impl/daw_json_parse_array_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_array_iterator.h
@@ -12,7 +12,6 @@
 
 #include "daw_json_arrow_proxy.h"
 #include "daw_json_assert.h"
-#include "daw_json_parse_value_fwd.h"
 
 #include <daw/daw_attributes.h>
 
@@ -120,8 +119,8 @@ namespace daw::json {
 					  base::parse_state and base::parse_state->has_more( ),
 					  ErrorReason::UnexpectedEndOfData, *base::parse_state );
 
-					return parse_value<element_t>(
-					  *base::parse_state, ParseTag<element_t::expected_type>{ } );
+					return parse_value<element_t, false, element_t::expected_type>(
+					  *base::parse_state );
 				}
 
 				DAW_ATTRIB_INLINE constexpr json_parse_array_iterator &operator++( ) {

--- a/include/daw/json/impl/daw_json_parse_array_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_array_iterator.h
@@ -12,6 +12,7 @@
 
 #include "daw_json_arrow_proxy.h"
 #include "daw_json_assert.h"
+#include "daw_json_parse_value.h"
 
 #include <daw/daw_attributes.h>
 

--- a/include/daw/json/impl/daw_json_parse_array_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_array_iterator.h
@@ -12,7 +12,7 @@
 
 #include "daw_json_arrow_proxy.h"
 #include "daw_json_assert.h"
-#include "daw_json_parse_value.h"
+#include "daw_json_parse_value_fwd.h"
 
 #include <daw/daw_attributes.h>
 

--- a/include/daw/json/impl/daw_json_parse_class.h
+++ b/include/daw/json/impl/daw_json_parse_class.h
@@ -69,15 +69,15 @@ namespace daw::json {
 					if constexpr( is_json_nullable_v<json_member_t> ) {
 
 						auto loc = ParseState{ };
-						return parse_value<json_member_t, true>(
-						  loc, ParseTag<json_member_t::expected_type>{ } );
+						return parse_value<json_member_t, true,
+						                   json_member_t::expected_type>( loc );
 					} else {
 						daw_json_error( missing_member( "ordered_class_member" ),
 						                parse_state );
 					}
 				}
-				return parse_value<json_member_t>(
-				  parse_state, ParseTag<json_member_t::expected_type>{ } );
+				return parse_value<json_member_t, false, json_member_t::expected_type>(
+				  parse_state );
 			}
 
 			///
@@ -118,18 +118,19 @@ namespace daw::json {
 								parse_state.class_first = cf;
 								parse_state.class_last = cl;
 							} );
-							return parse_value<without_name<JsonMember>>(
-							  parse_state, ParseTag<JsonMember::expected_type>{ } );
+							return parse_value<without_name<JsonMember>, false,
+							                   JsonMember::expected_type>( parse_state );
 						} else {
-							auto result = parse_value<without_name<JsonMember>>(
-							  parse_state, ParseTag<JsonMember::expected_type>{ } );
+							auto result =
+							  parse_value<without_name<JsonMember>, false,
+							              JsonMember::expected_type>( parse_state );
 							parse_state.class_first = cf;
 							parse_state.class_last = cl;
 							return result;
 						}
 					} else {
-						return parse_value<without_name<JsonMember>>(
-						  parse_state, ParseTag<JsonMember::expected_type>{ } );
+						return parse_value<without_name<JsonMember>, false,
+						                   JsonMember::expected_type>( parse_state );
 					}
 				}
 				// We cannot find the member, check if the member is nullable
@@ -145,8 +146,8 @@ namespace daw::json {
 				}
 
 				// Member was previously skipped
-				return parse_value<without_name<JsonMember>, true>(
-				  loc, ParseTag<JsonMember::expected_type>{ } );
+				return parse_value<without_name<JsonMember>, true,
+				                   JsonMember::expected_type>( loc );
 			}
 
 			template<bool IsExactClass, typename ParseState, typename OldClassPos>

--- a/include/daw/json/impl/daw_json_parse_element_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_element_iterator.h
@@ -99,8 +99,8 @@ namespace daw::json {
 					  base::parse_state and base::parse_state->has_more( ),
 					  ErrorReason::UnexpectedEndOfData, *base::parse_state );
 
-					return parse_value<element_t>(
-					  *base::parse_state, ParseTag<element_t::expected_type>{ } );
+					return parse_value<element_t, false, element_t::expected_type>(
+					  *base::parse_state );
 				}
 
 				DAW_ATTRIB_INLINE constexpr json_parse_array_iterator &operator++( ) {

--- a/include/daw/json/impl/daw_json_parse_kv_array_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_kv_array_iterator.h
@@ -107,8 +107,8 @@ namespace daw::json {
 					  base::parse_state and base::parse_state->has_more( ),
 					  ErrorReason::UnexpectedEndOfData, *base::parse_state );
 
-					return get_pair( parse_value<json_class_type>(
-					  *base::parse_state, ParseTag<JsonParseTypes::Class>{ } ) );
+					return get_pair(
+					  parse_value_class<json_class_type, false>( *base::parse_state ) );
 				}
 
 				DAW_ATTRIB_INLINE constexpr json_parse_kv_array_iterator &

--- a/include/daw/json/impl/daw_json_parse_kv_array_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_kv_array_iterator.h
@@ -108,7 +108,8 @@ namespace daw::json {
 					  ErrorReason::UnexpectedEndOfData, *base::parse_state );
 
 					return get_pair(
-					  parse_value_class<json_class_type, false>( *base::parse_state ) );
+					  parse_value<json_class_type, false, JsonParseTypes::Class>(
+					    *base::parse_state ) );
 				}
 
 				DAW_ATTRIB_INLINE constexpr json_parse_kv_array_iterator &

--- a/include/daw/json/impl/daw_json_parse_kv_class_iterator.h
+++ b/include/daw/json/impl/daw_json_parse_kv_class_iterator.h
@@ -114,15 +114,15 @@ namespace daw::json {
 					daw_json_assert_weak(
 					  base::parse_state and base::parse_state->has_more( ),
 					  ErrorReason::UnexpectedEndOfData, *base::parse_state );
-					auto key = parse_value<key_t>( *base::parse_state,
-					                               ParseTag<key_t::expected_type>{ } );
+					auto key = parse_value<key_t, false, key_t::expected_type>(
+					  *base::parse_state );
 					name::name_parser::trim_end_of_name( *base::parse_state );
 
 					return json_class_constructor<value_type,
 					                              default_constructor<value_type>>(
 					  std::move( key ),
-					  parse_value<value_t>( *base::parse_state,
-					                        ParseTag<value_t::expected_type>{ } ) );
+					  parse_value<value_t, false, value_t::expected_type>(
+					    *base::parse_state ) );
 				}
 
 				constexpr json_parse_kv_class_iterator &operator++( ) {

--- a/include/daw/json/impl/daw_json_parse_value.h
+++ b/include/daw/json/impl/daw_json_parse_value.h
@@ -71,8 +71,7 @@ namespace daw::json {
 				}
 			}
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
 			parse_value_real( ParseState &parse_state ) {
 				using constructor_t = json_constructor_t<JsonMember>;
@@ -175,8 +174,7 @@ namespace daw::json {
 				}
 			}
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
 			parse_value_signed( ParseState &parse_state ) {
 				using constructor_t = json_constructor_t<JsonMember>;
@@ -234,8 +232,7 @@ namespace daw::json {
 				}
 			}
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
 			parse_value_unsigned( ParseState &parse_state ) {
 				using constructor_t = json_constructor_t<JsonMember>;
@@ -293,8 +290,7 @@ namespace daw::json {
 				}
 			}
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
 			parse_value_null( ParseState &parse_state ) {
 
@@ -321,8 +317,8 @@ namespace daw::json {
 					}
 					return construct_value<base_member_type, constructor_t>(
 					  parse_state,
-					  parse_value<base_member_type, true>(
-					    parse_state, ParseTag<base_member_type::expected_type>{ } ) );
+					  parse_value<base_member_type, true,
+					              base_member_type::expected_type>( parse_state ) );
 				} else if constexpr( ParseState::is_unchecked_input ) {
 					if( not parse_state.has_more( ) or
 					    parse_state.is_at_token_after_value( ) ) {
@@ -336,8 +332,8 @@ namespace daw::json {
 					}
 					return construct_value<base_member_type, constructor_t>(
 					  parse_state,
-					  parse_value<base_member_type>(
-					    parse_state, ParseTag<base_member_type::expected_type>{ } ) );
+					  parse_value<base_member_type, false,
+					              base_member_type::expected_type>( parse_state ) );
 				} else {
 					if( not parse_state.has_more( ) or
 					    parse_state.is_at_token_after_value( ) ) {
@@ -361,19 +357,19 @@ namespace daw::json {
 						    concepts::construct_nullable_with_pointer_t, parse_to_t *> );
 						return construct_value<base_member_type, constructor_t>(
 						  parse_state, concepts::construct_nullable_with_pointer,
-						  new parse_to_t{ parse_value<base_member_type>(
-						    parse_state, ParseTag<base_member_type::expected_type>{ } ) } );
+						  new parse_to_t{
+						    parse_value<base_member_type, false,
+						                base_member_type::expected_type>( parse_state ) } );
 					} else {
 						return construct_value<base_member_type, constructor_t>(
 						  parse_state,
-						  parse_value<base_member_type>(
-						    parse_state, ParseTag<base_member_type::expected_type>{ } ) );
+						  parse_value<base_member_type, false,
+						              base_member_type::expected_type>( parse_state ) );
 					}
 				}
 			}
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
 			parse_value_bool( ParseState &parse_state ) {
 				using constructor_t = json_constructor_t<JsonMember>;
@@ -434,8 +430,7 @@ namespace daw::json {
 				}
 			}
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
 			parse_value_string_raw( ParseState &parse_state ) {
 
@@ -479,8 +474,7 @@ namespace daw::json {
 			DAW_JSON_MAKE_REQ_TYPE_ALIAS_TRAIT_NT( has_json_member_parse_to_v,
 			                                       json_result_t<T> );
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
 			parse_value_string_escaped( ParseState &parse_state ) {
 				static_assert( has_json_member_constructor_v<JsonMember> );
@@ -529,8 +523,7 @@ namespace daw::json {
 				}
 			}
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
 			parse_value_date( ParseState &parse_state ) {
 
@@ -625,8 +618,7 @@ namespace daw::json {
 			 * @param parse_state ParseState of input to parse
 			 * @return Constructed key_value container
 			 */
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] static constexpr json_result_t<JsonMember>
 			parse_value_keyvalue( ParseState &parse_state ) {
 
@@ -656,8 +648,7 @@ namespace daw::json {
 			 * @param parse_state ParseState of input to parse
 			 * @return Constructed key_value container
 			 */
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] static constexpr json_result_t<JsonMember>
 			parse_value_keyvalue_array( ParseState &parse_state ) {
 
@@ -678,8 +669,7 @@ namespace daw::json {
 				  parse_state, iter_t( parse_state ), iter_t( ) );
 			}
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] static constexpr json_result_t<JsonMember>
 			parse_value_array( ParseState &parse_state ) {
 				parse_state.trim_left( );
@@ -698,8 +688,7 @@ namespace daw::json {
 				  parse_state, iterator_t( parse_state ), iterator_t( ) );
 			}
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			[[nodiscard]] static constexpr json_result_t<JsonMember>
 			parse_value_sz_array( ParseState &parse_state ) {
 
@@ -711,8 +700,9 @@ namespace daw::json {
 
 				daw_json_ensure( is_found, ErrorReason::TagMemberNotFound,
 				                 parse_state );
-				auto const sz = parse_value<size_member>(
-				  parse_state2, ParseTag<size_member::expected_type>{ } );
+				auto const sz =
+				  parse_value<size_member, false, size_member::expected_type>(
+				    parse_state2 );
 
 				if constexpr( KnownBounds and ParseState::is_unchecked_input ) {
 					// We have the requested size and the actual size.  Let's see if they
@@ -749,8 +739,8 @@ namespace daw::json {
 				              pack_size_v<typename element_t::element_map_t> ) {
 					using JsonMember =
 					  pack_element_t<idx::value, typename element_t::element_map_t>;
-					return parse_value<JsonMember, KnownBounds>(
-					  parse_state, ParseTag<JsonMember::expected_type>{ } );
+					return parse_value<JsonMember, KnownBounds,
+					                   JsonMember::expected_type>( parse_state );
 				} else {
 					daw_json_error( ErrorReason::UnexpectedJSONVariantType );
 				}
@@ -811,11 +801,12 @@ namespace daw::json {
 				if( idx == pos ) {
 					using JsonMember = pack_element_t<pos, TypeList>;
 					if constexpr( std::is_same_v<json_result_t<JsonMember>, Result> ) {
-						return parse_value<JsonMember>(
-						  parse_state, ParseTag<JsonMember::expected_type>{ } );
+						return parse_value<JsonMember, false, JsonMember::expected_type>(
+						  parse_state );
 					} else {
-						return Result{ parse_value<JsonMember>(
-						  parse_state, ParseTag<JsonMember::expected_type>{ } ) };
+						return Result{
+						  parse_value<JsonMember, false, JsonMember::expected_type>(
+						    parse_state ) };
 					}
 				}
 				if constexpr( pos + 1 < pack_size_v<TypeList> ) {
@@ -843,15 +834,16 @@ namespace daw::json {
 					// This is an ordered class, class must start with '['
 					daw_json_assert_weak( parse_state2.is_opening_bracket_checked( ),
 					                      ErrorReason::InvalidArrayStart, parse_state );
-					return switcher_t{ }( std::get<0>( parse_value<class_wrapper_t>(
-					  parse_state2, ParseTag<class_wrapper_t::expected_type>{ } ) ) );
+					return switcher_t{ }( std::get<0>(
+					  parse_value<class_wrapper_t, false, class_wrapper_t::expected_type>(
+					    parse_state2 ) ) );
 				} else {
 					// This is a regular class, class must start with '{'
 					daw_json_assert_weak( parse_state2.is_opening_brace_checked( ),
 					                      ErrorReason::InvalidClassStart, parse_state );
 					return switcher_t{ }( std::get<0>(
-					  parse_value<class_wrapper_t>(
-					    parse_state2, ParseTag<class_wrapper_t::expected_type>{ } )
+					  parse_value<class_wrapper_t, false, class_wrapper_t::expected_type>(
+					    parse_state2 )
 					    .members ) );
 				}
 			}
@@ -875,12 +867,13 @@ namespace daw::json {
 					auto parse_state2 = parse_state;
 					using switcher_t = typename JsonMember::switcher;
 					if constexpr( is_an_ordered_member_v<tag_submember> ) {
-						return switcher_t{ }( std::get<0>( parse_value<class_wrapper_t>(
-						  parse_state2, ParseTag<class_wrapper_t::expected_type>{ } ) ) );
+						return switcher_t{ }( std::get<0>(
+						  parse_value<class_wrapper_t, false,
+						              class_wrapper_t::expected_type>( parse_state2 ) ) );
 					} else {
 						return switcher_t{ }( std::get<0>(
-						  parse_value<class_wrapper_t>(
-						    parse_state2, ParseTag<class_wrapper_t::expected_type>{ } )
+						  parse_value<class_wrapper_t, false,
+						              class_wrapper_t::expected_type>( parse_state2 )
 						    .members ) );
 					}
 				}( );
@@ -1061,18 +1054,19 @@ namespace daw::json {
 									parse_state.move_next_member_or_end( );
 								} );
 								(void)run_after_parse;
-								return parse_value<json_member_t>(
-								  parse_state, ParseTag<json_member_t::expected_type>{ } );
+								return parse_value<json_member_t, false,
+								                   json_member_t::expected_type>( parse_state );
 							} else {
-								auto result = parse_value<json_member_t>(
-								  parse_state, ParseTag<json_member_t::expected_type>{ } );
+								auto result =
+								  parse_value<json_member_t, false,
+								              json_member_t::expected_type>( parse_state );
 								parse_state.move_next_member_or_end( );
 								return result;
 							}
 						} else {
 							// Known Bounds
-							return parse_value<json_member_t, true>(
-							  parse_state2, ParseTag<json_member_t::expected_type>{ } );
+							return parse_value<json_member_t, true,
+							                   json_member_t::expected_type>( parse_state2 );
 						}
 					} else {
 #endif
@@ -1091,11 +1085,12 @@ namespace daw::json {
 								parse_state.move_next_member_or_end( );
 							} );
 							(void)run_after_parse;
-							return parse_value<json_member_t>(
-							  parse_state, ParseTag<json_member_t::expected_type>{ } );
+							return parse_value<json_member_t, false,
+							                   json_member_t::expected_type>( parse_state );
 						} else {
-							auto result = parse_value<json_member_t>(
-							  parse_state, ParseTag<json_member_t::expected_type>{ } );
+							auto result =
+							  parse_value<json_member_t, false, json_member_t::expected_type>(
+							    parse_state );
 							parse_state.move_next_member_or_end( );
 							return result;
 						}
@@ -1152,8 +1147,7 @@ namespace daw::json {
 				}
 			}
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			static constexpr json_result_t<JsonMember>
 			parse_value_tuple( ParseState &parse_state ) {
 				using element_pack =
@@ -1164,8 +1158,7 @@ namespace daw::json {
 				  std::make_index_sequence<std::tuple_size_v<element_pack>>{ } );
 			}
 
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState>
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
 			DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
 			parse_value_unknown( ParseState &parse_state ) {
 				using constructor_t = json_constructor_t<JsonMember>;
@@ -1180,10 +1173,10 @@ namespace daw::json {
 				}
 			}
 
-			template<typename JsonMember, bool KnownBounds, typename ParseState,
-			         JsonParseTypes PTag>
+			template<typename JsonMember, bool KnownBounds, JsonParseTypes PTag,
+			         typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
-			parse_value( ParseState &parse_state, ParseTag<PTag> ) {
+			parse_value( ParseState &parse_state ) {
 				if constexpr( PTag == JsonParseTypes::Real ) {
 					return parse_value_real<JsonMember, KnownBounds>( parse_state );
 				} else if constexpr( PTag == JsonParseTypes::Signed ) {
@@ -1244,64 +1237,64 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 0, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 1: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 1, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 2: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 2, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 3: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 3, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 4: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 4, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 5: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 5, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 6: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 6, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 7: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 7, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					default:
 						if constexpr( sizeof...( JsonClasses ) >= N + 8 ) {
@@ -1318,48 +1311,48 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 0, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 1: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 1, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 2: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 2, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 3: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 3, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 4: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 4, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 5: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 5, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					default: {
 						DAW_ASSUME( idx == N + 6 );
@@ -1367,8 +1360,8 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 6, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					}
 				} else if constexpr( sizeof...( JsonClasses ) == N + 6 ) {
@@ -1378,40 +1371,40 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 0, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 1: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 1, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 2: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 2, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 3: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 3, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 4: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 4, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					default: {
 						DAW_ASSUME( idx == N + 5 );
@@ -1419,8 +1412,8 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 5, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					}
 				} else if constexpr( sizeof...( JsonClasses ) == N + 5 ) {
@@ -1430,32 +1423,32 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 0, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 1: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 1, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 2: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 2, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 3: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 3, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					default: {
 						DAW_ASSUME( idx == N + 4 );
@@ -1463,8 +1456,8 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 4, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					}
 				} else if constexpr( sizeof...( JsonClasses ) == N + 4 ) {
@@ -1474,24 +1467,24 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 0, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 1: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 1, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 2: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 2, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					default: {
 						DAW_ASSUME( idx == N + 3 );
@@ -1499,8 +1492,8 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 3, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					}
 				} else if constexpr( sizeof...( JsonClasses ) == N + 3 ) {
@@ -1510,16 +1503,16 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 0, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					case N + 1: {
 						using cur_json_class_t =
 						  daw::traits::nth_element<N + 1, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					default: {
 						DAW_ASSUME( idx == N + 2 );
@@ -1527,8 +1520,8 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 2, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					}
 				} else if constexpr( sizeof...( JsonClasses ) == N + 2 ) {
@@ -1537,22 +1530,22 @@ namespace daw::json {
 						  daw::traits::nth_element<N + 0, JsonClasses...>;
 						return construct_value<T, Constructor>(
 						  parse_state,
-						  parse_value<cur_json_class_t>(
-						    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+						  parse_value<cur_json_class_t, false,
+						              cur_json_class_t::expected_type>( parse_state ) );
 					}
 					using cur_json_class_t =
 					  daw::traits::nth_element<N + 1, JsonClasses...>;
 					return construct_value<T, Constructor>(
 					  parse_state,
-					  parse_value<cur_json_class_t>(
-					    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+					  parse_value<cur_json_class_t, false,
+					              cur_json_class_t::expected_type>( parse_state ) );
 				} else {
 					using cur_json_class_t =
 					  daw::traits::nth_element<N + 0, JsonClasses...>;
 					return construct_value<T, Constructor>(
 					  parse_state,
-					  parse_value<cur_json_class_t>(
-					    parse_state, ParseTag<cur_json_class_t::expected_type>{ } ) );
+					  parse_value<cur_json_class_t, false,
+					              cur_json_class_t::expected_type>( parse_state ) );
 				}
 			}
 		} // namespace json_details

--- a/include/daw/json/impl/daw_json_parse_value_fwd.h
+++ b/include/daw/json/impl/daw_json_parse_value_fwd.h
@@ -15,10 +15,10 @@
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
 		namespace json_details {
-			template<typename JsonMember, bool KnownBounds = false,
-			         typename ParseState, JsonParseTypes PTag>
+			template<typename JsonMember, bool KnownBounds, JsonParseTypes PTag,
+			         typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
-			parse_value( ParseState &parse_state, ParseTag<PTag> );
+			parse_value( ParseState &parse_state );
 		} // namespace json_details
-	}   // namespace DAW_JSON_VER
+	} // namespace DAW_JSON_VER
 } // namespace daw::json

--- a/include/daw/json/impl/daw_json_value.h
+++ b/include/daw/json/impl/daw_json_value.h
@@ -504,8 +504,8 @@ namespace daw::json {
 			[[nodiscard]] constexpr auto as( ) const {
 				using result_t = json_details::json_deduced_type<Result>;
 				auto state = m_parse_state;
-				return json_details::parse_value<result_t>(
-				  state, ParseTag<result_t::expected_type>{ } );
+				return json_details::parse_value<result_t, false,
+				                                 result_t::expected_type>( state );
 			}
 
 			template<typename Result>
@@ -709,8 +709,8 @@ namespace daw::json {
 
 		basic_json_value( char const *first, std::size_t sz ) -> basic_json_value<>;
 
-		basic_json_value( char const *first, char const *last )
-		  -> basic_json_value<>;
+		basic_json_value( char const *first,
+		                  char const *last ) -> basic_json_value<>;
 
 		template<typename Result, json_options_t PolicyFlags, typename Allocator>
 		[[nodiscard]] constexpr Result

--- a/tests/include/bench_result.h
+++ b/tests/include/bench_result.h
@@ -45,9 +45,9 @@ struct JSONToNano {
 	constexpr std::chrono::nanoseconds operator( )( std::string_view sv ) const {
 		auto rng =
 		  daw::json::BasicParsePolicy( std::data( sv ), daw::data_end( sv ) );
-		return std::chrono::nanoseconds( daw::json::json_details::parse_value<
-		                                 daw::json::json_number_no_name<long long>>(
-		  rng, daw::json::ParseTag<daw::json::JsonParseTypes::Signed>{ } ) );
+		return std::chrono::nanoseconds(
+		  daw::json::json_details::parse_value_signed<
+		    daw::json::json_number_no_name<long long>, false>( rng ) );
 	}
 
 	std::string operator( )( std::chrono::nanoseconds t ) const {

--- a/tests/src/daw_json_link_test.cpp
+++ b/tests/src/daw_json_link_test.cpp
@@ -473,8 +473,7 @@ unsigned long long test_dblparse( std::string_view num,
 			rng = json_details::skip_number( rng );
 		}
 		using json_member = json_details::json_deduced_type<double>;
-		return json_details::parse_value<json_member, KnownBounds>(
-		  rng, ParseTag<json_member::expected_type>{ } );
+		return json_details::parse_value_real<json_member, KnownBounds>( rng );
 	};
 	auto lib_parse_dbl = dbl_lib_parser( num );
 	auto const ui0 = daw::bit_cast<std::uint64_t>( lib_parse_dbl );
@@ -522,8 +521,8 @@ unsigned long long test_dblparse2( std::string_view num, double orig,
 			  daw::json::BasicParsePolicy( num.data( ), num.data( ) + num.size( ) );
 			rng = daw::json::json_details::skip_number( rng );
 			using json_member = daw::json::json_details::json_deduced_type<double>;
-			return daw::json::json_details::parse_value<json_member, KnownBounds>(
-			  rng, daw::json::ParseTag<json_member::expected_type>{ } );
+			return daw::json::json_details::parse_value_real<json_member,
+			                                                 KnownBounds>( rng );
 		} else {
 			return daw::json::from_json<double, KnownBounds>( num );
 		}
@@ -561,8 +560,8 @@ unsigned long long test_dblparse2( std::string_view num, double orig,
 				  daw::json::BasicParsePolicy( num.data( ), num.data( ) + num.size( ) );
 				rng = daw::json::json_details::skip_number( rng );
 				using json_member = daw::json::json_details::json_deduced_type<double>;
-				return daw::json::json_details::parse_value<json_member, KnownBounds>(
-				  rng, daw::json::ParseTag<json_member::expected_type>{ } );
+				return daw::json::json_details::parse_value_real<json_member,
+				                                                 KnownBounds>( rng );
 			} else {
 				return daw::json::from_json<double, KnownBounds>( num );
 			}
@@ -1428,10 +1427,9 @@ int main( int, char ** ) {
 			ensure( x == 5 );
 		}
 		{
-			constexpr auto const x =
-			  daw::json::json_apply( R"json([])json", []( ) {
-				  return std::size_t{ 5 };
-			  } );
+			constexpr auto const x = daw::json::json_apply( R"json([])json", []( ) {
+				return std::size_t{ 5 };
+			} );
 			ensure( x == 5 );
 		}
 		{

--- a/tests/src/issue_433_test.cpp
+++ b/tests/src/issue_433_test.cpp
@@ -44,7 +44,7 @@ namespace daw::json {
 				return magic_enum::enum_name( e );
 			}
 
-			constexpr Enum operator( )( std::string_view sv ) const {
+			inline Enum operator( )( std::string_view sv ) const {
 				auto test = magic_enum::enum_cast<Enum>( sv );
 				if( !test ) {
 					std::string msg = "Bad enum value ";

--- a/tests/src/test_details_parse_real.cpp
+++ b/tests/src/test_details_parse_real.cpp
@@ -77,8 +77,8 @@ void test_lots_of_doubles( ) {
 		  for( std::size_t n = 0; n < NUM_VALS; ++n ) {
 			  auto rng = nums[n];
 			  using json_member = daw::json::json_details::json_deduced_type<float>;
-			  auto const r = daw::json::json_details::parse_value<json_member, false>(
-			    rng, daw::json::ParseTag<json_member::expected_type>{ } );
+			  auto const r =
+			    daw::json::json_details::parse_value_real<json_member, false>( rng );
 			  daw::do_not_optimize( r );
 		  }
 	  },
@@ -90,8 +90,8 @@ void test_lots_of_doubles( ) {
 		  for( std::size_t n = 0; n < NUM_VALS; ++n ) {
 			  auto rng = nums[n];
 			  using json_member = daw::json::json_details::json_deduced_type<double>;
-			  auto const r = daw::json::json_details::parse_value<json_member, false>(
-			    rng, daw::json::ParseTag<json_member::expected_type>{ } );
+			  auto const r =
+			    daw::json::json_details::parse_value_real<json_member, false>( rng );
 			  daw::do_not_optimize( r );
 		  }
 	  },
@@ -104,8 +104,8 @@ void test_lots_of_doubles( ) {
 			  auto rng = nums[n];
 			  using json_member =
 			    daw::json::json_details::json_deduced_type<long double>;
-			  auto const r = daw::json::json_details::parse_value<json_member, false>(
-			    rng, daw::json::ParseTag<json_member::expected_type>{ } );
+			  auto const r =
+			    daw::json::json_details::parse_value_real<json_member, false>( rng );
 			  daw::do_not_optimize( r );
 		  }
 	  },
@@ -117,8 +117,8 @@ void test_lots_of_doubles( ) {
 		  for( std::size_t n = 0; n < NUM_VALS; ++n ) {
 			  auto rng = nums[n];
 			  using json_member = daw::json::json_details::json_deduced_type<float>;
-			  auto const r = daw::json::json_details::parse_value<json_member, true>(
-			    rng, daw::json::ParseTag<json_member::expected_type>{ } );
+			  auto const r =
+			    daw::json::json_details::parse_value_real<json_member, true>( rng );
 			  daw::do_not_optimize( r );
 		  }
 	  },
@@ -130,8 +130,8 @@ void test_lots_of_doubles( ) {
 		  for( std::size_t n = 0; n < NUM_VALS; ++n ) {
 			  auto rng = nums[n];
 			  using json_member = daw::json::json_details::json_deduced_type<double>;
-			  auto const r = daw::json::json_details::parse_value<json_member, true>(
-			    rng, daw::json::ParseTag<json_member::expected_type>{ } );
+			  auto const r =
+			    daw::json::json_details::parse_value_real<json_member, true>( rng );
 			  daw::do_not_optimize( r );
 		  }
 	  },
@@ -144,8 +144,8 @@ void test_lots_of_doubles( ) {
 			  auto rng = nums[n];
 			  using json_member =
 			    daw::json::json_details::json_deduced_type<long double>;
-			  auto const r = daw::json::json_details::parse_value<json_member, true>(
-			    rng, daw::json::ParseTag<json_member::expected_type>{ } );
+			  auto const r =
+			    daw::json::json_details::parse_value_real<json_member, true>( rng );
 			  daw::do_not_optimize( r );
 		  }
 	  },

--- a/tests/src/test_details_parse_value_array.cpp
+++ b/tests/src/test_details_parse_value_array.cpp
@@ -10,6 +10,7 @@
 
 #include <daw/json/daw_json_link.h>
 #include <daw/json/impl/daw_json_parse_common.h>
+#include <daw/json/impl/daw_json_parse_value.h>
 
 #include <daw/daw_benchmark.h>
 
@@ -23,7 +24,7 @@ bool empty_array_empty_json_array( ) {
 
 	DAW_CONSTEXPR std::string_view sv = "[]";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value_array<json_array_no_name<int>>( rng );
+	auto v = parse_value_array<json_array_no_name<int>, false>( rng );
 	return v.empty( );
 }
 
@@ -34,7 +35,7 @@ bool int_array_json_string_array_fail( ) {
 	std::string_view sv = R"([ "this is strange" ])";
 	daw::do_not_optimize( sv );
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value_array<json_array_no_name<int>>( rng );
+	auto v = parse_value_array<json_array_no_name<int>, false>( rng );
 	daw::do_not_optimize( v );
 	return true;
 }
@@ -72,7 +73,7 @@ bool array_with_closing_class_fail( ) {
 	std::string_view sv = R"([ {}}, ])";
 	daw::do_not_optimize( sv );
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value_array<json_array_no_name<InlineClass<>>>( rng );
+	auto v = parse_value_array<json_array_no_name<InlineClass<>>, false>( rng );
 	daw::do_not_optimize( v );
 	return true;
 }
@@ -87,13 +88,13 @@ bool array_with_closing_class_fail( ) {
 	do {                                                                   \
 	} while( false )
 
-#define do_fail_test( ... )                                   \
-	do {                                                        \
-		try {                                                     \
-			daw::expecting_message( __VA_ARGS__, "" #__VA_ARGS__ ); \
-		} catch( daw::json::json_exception const & ) { break; }   \
-		std::cerr << "Expected exception, but none thrown in '"   \
-		          << "" #__VA_ARGS__ << "'\n";                    \
+#define do_fail_test( ... )                                                    \
+	do {                                                                         \
+		try {                                                                      \
+			daw::expecting_message( __VA_ARGS__, "" #__VA_ARGS__ );                  \
+		} catch( daw::json::json_exception const & ) { break; }                    \
+		std::cerr << "Expected exception, but none thrown in '" << "" #__VA_ARGS__ \
+		          << "'\n";                                                        \
 	} while( false )
 
 int main( int, char ** )

--- a/tests/src/test_details_parse_value_class.cpp
+++ b/tests/src/test_details_parse_value_class.cpp
@@ -27,13 +27,13 @@
 	do {                                                                   \
 	} while( false )
 
-#define do_fail_test( ... )                                   \
-	do {                                                        \
-		try {                                                     \
-			daw::expecting_message( __VA_ARGS__, "" #__VA_ARGS__ ); \
-		} catch( daw::json::json_exception const & ) { break; }   \
-		std::cerr << "Expected exception, but none thrown in '"   \
-		          << "" #__VA_ARGS__ << "'\n";                    \
+#define do_fail_test( ... )                                                    \
+	do {                                                                         \
+		try {                                                                      \
+			daw::expecting_message( __VA_ARGS__, "" #__VA_ARGS__ );                  \
+		} catch( daw::json::json_exception const & ) { break; }                    \
+		std::cerr << "Expected exception, but none thrown in '" << "" #__VA_ARGS__ \
+		          << "'\n";                                                        \
 	} while( false )
 
 namespace daw::json {
@@ -54,8 +54,7 @@ bool empty_class_empty_json_class( ) {
 	std::string_view sv = "{}";
 	daw::do_not_optimize( sv );
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<json_class_no_name<daw::Empty>>(
-	  rng, ParseTag<JsonParseTypes::Class>{ } );
+	auto v = parse_value_class<json_class_no_name<daw::Empty>, false>( rng );
 	daw::do_not_optimize( v );
 	return true;
 }
@@ -64,8 +63,7 @@ bool empty_class_nonempty_json_class( ) {
 	std::string_view sv = R"({ "a": 12345, "b": {} })";
 	daw::do_not_optimize( sv );
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<json_class_no_name<daw::Empty>>(
-	  rng, ParseTag<JsonParseTypes::Class>{ } );
+	auto v = parse_value_class<json_class_no_name<daw::Empty>, false>( rng );
 	daw::do_not_optimize( v );
 	return true;
 }
@@ -81,8 +79,9 @@ bool missing_members_fail( ) {
 	daw::do_not_optimize( sv );
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
 
-	auto v = parse_value<json_class_no_name<missing_members_fail_t::class_t>>(
-	  rng, ParseTag<JsonParseTypes::Class>{ } );
+	auto v =
+	  parse_value_class<json_class_no_name<missing_members_fail_t::class_t>,
+	                    false>( rng );
 	daw::do_not_optimize( v );
 	return true;
 }
@@ -97,8 +96,9 @@ bool wrong_member_type_fail( ) {
 	daw::do_not_optimize( sv );
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
 
-	auto v = parse_value<json_class_no_name<wrong_member_type_fail_t::class_t>>(
-	  rng, ParseTag<JsonParseTypes::Class>{ } );
+	auto v =
+	  parse_value_class<json_class_no_name<wrong_member_type_fail_t::class_t>,
+	                    false>( rng );
 	daw::do_not_optimize( v );
 	return true;
 }
@@ -113,9 +113,8 @@ bool wrong_member_number_type_fail( ) {
 	daw::do_not_optimize( sv );
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
 
-	auto v =
-	  parse_value<json_class_no_name<wrong_member_number_type_fail_t::class_t>>(
-	    rng, ParseTag<JsonParseTypes::Class>{ } );
+	auto v = parse_value_class<
+	  json_class_no_name<wrong_member_number_type_fail_t::class_t>, false>( rng );
 	daw::do_not_optimize( v );
 	return true;
 }
@@ -129,8 +128,8 @@ bool unexpected_eof_in_class1_fail( ) {
 	daw::do_not_optimize( sv );
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
 
-	auto v = parse_value<json_class_no_name<unexpected_eof_in_class1_fail_t::class_t>>(
-	  rng, ParseTag<JsonParseTypes::Class>{ } );
+	auto v = parse_value_class<
+	  json_class_no_name<unexpected_eof_in_class1_fail_t::class_t>, false>( rng );
 	daw::do_not_optimize( v );
 	return true;
 }
@@ -147,9 +146,8 @@ bool wrong_member_stored_pos_fail( ) {
 	daw::do_not_optimize( sv );
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
 
-	auto v =
-	  parse_value<json_class_no_name<wrong_member_stored_pos_fail_t::class_t>>(
-	    rng, ParseTag<JsonParseTypes::Class>{ } );
+	auto v = parse_value_class<
+	  json_class_no_name<wrong_member_stored_pos_fail_t::class_t>, false>( rng );
 	daw::do_not_optimize( v );
 	return true;
 }

--- a/tests/src/test_details_parse_value_custom.cpp
+++ b/tests/src/test_details_parse_value_custom.cpp
@@ -30,8 +30,9 @@ bool empty_array_empty_json_array( ) {
 	DAW_CONSTEXPR std::string_view sv = R"({ "a": "20200130" })";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
 	rng.remove_prefix( 7 );
-	auto v = parse_value<json_custom_no_name<std::string_view, NoOp>>(
-	  rng, ParseTag<JsonParseTypes::Custom>{ } );
+	auto v =
+	  parse_value_custom<json_custom_no_name<std::string_view, NoOp>, false>(
+	    rng );
 	return v.size( ) == 8;
 }
 

--- a/tests/src/test_details_parse_value_null.cpp
+++ b/tests/src/test_details_parse_value_null.cpp
@@ -24,7 +24,7 @@ bool test_null_literal_untrusted( ) {
 	using my_number = json_number_null_no_name<std::optional<int>>;
 	DAW_CONSTEXPR std::string_view sv = "null,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Null>{ } );
+	auto v = parse_value_null<my_number, false>( rng );
 	return not v;
 }
 
@@ -34,8 +34,7 @@ bool test_null_literal_known( ) {
 
 	using my_number = json_number_null_no_name<std::optional<int>>;
 	auto rng = BasicParsePolicy( );
-	auto v =
-	  parse_value<my_number, true>( rng, ParseTag<JsonParseTypes::Null>{ } );
+	auto v = parse_value_null<my_number, true>( rng );
 	return not v;
 }
 
@@ -46,7 +45,7 @@ bool test_null_number_untrusted( ) {
 	using my_number = json_number_null_no_name<std::optional<int>>;
 	DAW_CONSTEXPR std::string_view sv = "5,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Null>{ } );
+	auto v = parse_value_null<my_number, false>( rng );
 	return v and *v == 5;
 }
 
@@ -57,7 +56,7 @@ bool test_null_number_trusted( ) {
 	using my_number = json_number_null_no_name<std::optional<int>>;
 	DAW_CONSTEXPR std::string_view sv = "5,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Null>{ } );
+	auto v = parse_value_null<my_number, false>( rng );
 	return v and *v == 5;
 }
 
@@ -68,8 +67,7 @@ bool test_null_number_untrusted_known( ) {
 	using my_number = json_number_null_no_name<std::optional<int>>;
 	DAW_CONSTEXPR std::string_view sv = "5,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) - 1 );
-	auto v =
-	  parse_value<my_number, true>( rng, ParseTag<JsonParseTypes::Null>{ } );
+	auto v = parse_value_null<my_number, true>( rng );
 	return v and *v == 5;
 }
 

--- a/tests/src/test_details_parse_value_real.cpp
+++ b/tests/src/test_details_parse_value_real.cpp
@@ -19,7 +19,7 @@
 #include <string_view>
 
 #if defined( DAW_HAS_MSVC )
-#pragma warning (disable : 4702)
+#pragma warning( disable : 4702 )
 #endif
 
 bool test_zero_untrusted( ) {
@@ -29,7 +29,7 @@ bool test_zero_untrusted( ) {
 	using my_number = json_number_no_name<>;
 	DAW_CONSTEXPR std::string_view sv = "0,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Real>{ } );
+	auto v = parse_value_real<my_number, false>( rng );
 	return v == 0;
 }
 
@@ -40,7 +40,7 @@ bool test_positive_zero_untrusted( ) {
 	using my_number = json_number_no_name<>;
 	DAW_CONSTEXPR std::string_view sv = "+0,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Real>{ } );
+	auto v = parse_value_real<my_number, false>( rng );
 	return v == 0;
 }
 
@@ -51,7 +51,7 @@ bool test_negative_zero_untrusted( ) {
 	using my_number = json_number_no_name<>;
 	DAW_CONSTEXPR std::string_view sv = "-0,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Real>{ } );
+	auto v = parse_value_real<my_number, false>( rng );
 	return v == 0;
 }
 
@@ -62,7 +62,7 @@ bool test_missing_untrusted( ) {
 	using my_number = json_number_no_name<>;
 	DAW_CONSTEXPR std::string_view sv = " ,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Real>{ } );
+	auto v = parse_value_real<my_number, false>( rng );
 	daw::do_not_optimize( v );
 	return false;
 }
@@ -74,7 +74,7 @@ bool test_real_untrusted( ) {
 	using my_number = json_number_no_name<>;
 	DAW_CONSTEXPR std::string_view sv = "1.23,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Real>{ } );
+	auto v = parse_value_real<my_number, false>( rng );
 	return v >= ( 1.23 - daw::numeric_limits<double>::epsilon( ) ) and
 	       v <= ( 1.23 + daw::numeric_limits<double>::epsilon( ) );
 }
@@ -86,7 +86,7 @@ bool test_bad_real_untrusted( ) {
 	using my_number = json_number_no_name<>;
 	DAW_CONSTEXPR std::string_view sv = "1.0fsdf3,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Real>{ } );
+	auto v = parse_value_real<my_number, false>( rng );
 	Unused( v );
 	return false;
 }
@@ -100,7 +100,7 @@ bool test_bad_real_untrusted2( ) {
 	                                options::LiteralAsStringOpt::Always )>;
 	DAW_CONSTEXPR std::string_view sv = R"("1.0fsdf3",)";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Real>{ } );
+	auto v = parse_value_real<my_number, false>( rng );
 	Unused( v );
 	return false;
 }
@@ -115,13 +115,13 @@ bool test_bad_real_untrusted2( ) {
 	do {                                                                   \
 	} while( false )
 
-#define do_fail_test( ... )                                   \
-	do {                                                        \
-		try {                                                     \
-			daw::expecting_message( (__VA_ARGS__), "" #__VA_ARGS__ ); \
-		} catch( daw::json::json_exception const & ) { break; }   \
-		std::cerr << "Expected exception, but none thrown in '"   \
-		          << "" #__VA_ARGS__ << "'\n";                    \
+#define do_fail_test( ... )                                                    \
+	do {                                                                         \
+		try {                                                                      \
+			daw::expecting_message( ( __VA_ARGS__ ), "" #__VA_ARGS__ );              \
+		} catch( daw::json::json_exception const & ) { break; }                    \
+		std::cerr << "Expected exception, but none thrown in '" << "" #__VA_ARGS__ \
+		          << "'\n";                                                        \
 	} while( false )
 
 int main( int, char ** )

--- a/tests/src/test_details_parse_value_signed.cpp
+++ b/tests/src/test_details_parse_value_signed.cpp
@@ -24,7 +24,7 @@ bool test_zero_untrusted( ) {
 	using my_number = json_number_no_name<signed>;
 	DAW_CONSTEXPR std::string_view sv = "0,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Signed>{ } );
+	auto v = parse_value_signed<my_number, false>( rng );
 	return not v;
 }
 
@@ -35,7 +35,7 @@ bool test_positive_zero_untrusted( ) {
 	using my_number = json_number_no_name<signed>;
 	DAW_CONSTEXPR std::string_view sv = "+0,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Signed>{ } );
+	auto v = parse_value_signed<my_number, false>( rng );
 	return not v;
 }
 
@@ -46,7 +46,7 @@ bool test_negative_zero_untrusted( ) {
 	using my_number = json_number_no_name<signed>;
 	DAW_CONSTEXPR std::string_view sv = "-0,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Signed>{ } );
+	auto v = parse_value_signed<my_number, false>( rng );
 	return not v;
 }
 
@@ -57,7 +57,7 @@ bool test_missing_untrusted( ) {
 	using my_number = json_number_no_name<signed>;
 	DAW_CONSTEXPR std::string_view sv = " ,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Signed>{ } );
+	auto v = parse_value_signed<my_number, false>( rng );
 	daw::do_not_optimize( v );
 	return false;
 }
@@ -69,7 +69,7 @@ bool test_real_untrusted( ) {
 	using my_number = json_number_no_name<signed>;
 	DAW_CONSTEXPR std::string_view sv = "1.23,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Signed>{ } );
+	auto v = parse_value_signed<my_number, false>( rng );
 	daw::do_not_optimize( v );
 	return false;
 }
@@ -86,13 +86,13 @@ bool test_real_untrusted( ) {
 	do {                                                                   \
 	} while( false )
 
-#define do_fail_test( ... )                                   \
-	do {                                                        \
-		try {                                                     \
-			daw::expecting_message( __VA_ARGS__, "" #__VA_ARGS__ ); \
-		} catch( daw::json::json_exception const & ) { break; }   \
-		std::cerr << "Expected exception, but none thrown in '"   \
-		          << "" #__VA_ARGS__ << "'\n";                    \
+#define do_fail_test( ... )                                                    \
+	do {                                                                         \
+		try {                                                                      \
+			daw::expecting_message( __VA_ARGS__, "" #__VA_ARGS__ );                  \
+		} catch( daw::json::json_exception const & ) { break; }                    \
+		std::cerr << "Expected exception, but none thrown in '" << "" #__VA_ARGS__ \
+		          << "'\n";                                                        \
 	} while( false )
 
 int main( int, char ** )

--- a/tests/src/test_details_parse_value_unsigned.cpp
+++ b/tests/src/test_details_parse_value_unsigned.cpp
@@ -29,7 +29,7 @@ bool test_zero_untrusted( ) {
 	using my_number = json_number_no_name<unsigned>;
 	DAW_CONSTEXPR std::string_view sv = "0,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Unsigned>{ } );
+	auto v = parse_value_unsigned<my_number, false>( rng );
 	return not v;
 }
 
@@ -40,7 +40,7 @@ bool test_missing_untrusted( ) {
 	using my_number = json_number_no_name<unsigned>;
 	DAW_CONSTEXPR std::string_view sv = " ,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Unsigned>{ } );
+	auto v = parse_value_unsigned<my_number, false>( rng );
 	daw::do_not_optimize( v );
 	return false;
 }
@@ -52,7 +52,7 @@ bool test_negative_untrusted( ) {
 	using my_number = json_number_no_name<unsigned>;
 	DAW_CONSTEXPR std::string_view sv = "-1,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Unsigned>{ } );
+	auto v = parse_value_unsigned<my_number, false>( rng );
 	daw::do_not_optimize( v );
 	return false;
 }
@@ -64,7 +64,7 @@ bool test_real_untrusted( ) {
 	using my_number = json_number_no_name<unsigned>;
 	DAW_CONSTEXPR std::string_view sv = "1.23,";
 	auto rng = BasicParsePolicy( sv.data( ), sv.data( ) + sv.size( ) );
-	auto v = parse_value<my_number>( rng, ParseTag<JsonParseTypes::Unsigned>{ } );
+	auto v = parse_value_unsigned<my_number, false>( rng );
 	daw::do_not_optimize( v );
 	return false;
 }
@@ -79,13 +79,13 @@ bool test_real_untrusted( ) {
 	do {                                                                   \
 	} while( false )
 
-#define do_fail_test( ... )                                   \
-	do {                                                        \
-		try {                                                     \
-			daw::expecting_message( __VA_ARGS__, "" #__VA_ARGS__ ); \
-		} catch( daw::json::json_exception const & ) { break; }   \
-		std::cerr << "Expected exception, but none thrown in '"   \
-		          << "" #__VA_ARGS__ << "'\n";                    \
+#define do_fail_test( ... )                                                    \
+	do {                                                                         \
+		try {                                                                      \
+			daw::expecting_message( __VA_ARGS__, "" #__VA_ARGS__ );                  \
+		} catch( daw::json::json_exception const & ) { break; }                    \
+		std::cerr << "Expected exception, but none thrown in '" << "" #__VA_ARGS__ \
+		          << "'\n";                                                        \
 	} while( false )
 
 int main( int, char ** )


### PR DESCRIPTION
Removed usages of ParseTag except for json schema export as it isn't actually dispatching