### PR TITLE
Refactor preprocessor conditionals for consistency

### DIFF
--- a/include/daw/third_party/dragonbox/dragonbox.h
+++ b/include/daw/third_party/dragonbox/dragonbox.h
@@ -207,7 +207,7 @@ namespace daw::jkj::dragonbox {
 
 				auto output2 = static_cast<std::uint32_t>( output );
 				while( output2 >= 10000 ) {
-#ifdef __clang__ // https://bugs.llvm.org/show_bug.cgi?id=38217
+#if defined( __clang__ ) // https://bugs.llvm.org/show_bug.cgi?id=38217
 					const std::uint32_t c = output2 - 10000 * ( output2 / 10000 );
 #else
 					const std::uint32_t c = output2 % 10000;
@@ -297,5 +297,5 @@ namespace daw::jkj::dragonbox {
 				return to_chars_impl( v, buffer, digit_count );
 			}
 		} // namespace to_chars_detail
-	}   // namespace DAW_JSON_VER
+	} // namespace DAW_JSON_VER
 } // namespace daw::jkj::dragonbox

--- a/include/daw/third_party/dragonbox/dragonbox_to_decimal.h
+++ b/include/daw/third_party/dragonbox/dragonbox_to_decimal.h
@@ -318,7 +318,7 @@ namespace daw::jkj::dragonbox {
 
 #if( defined( __GNUC__ ) or defined( __clang__ ) ) and \
   defined( __SIZEOF_INT128__ ) and defined( __x86_64__ )
-#ifdef __GNUC__
+#if defined( __GNUC__ )
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
@@ -331,7 +331,7 @@ namespace daw::jkj::dragonbox {
 
 					constexpr uint128( unsigned __int128 u ) noexcept
 					  : internal_{ u } {}
-#ifdef __GNUC__
+#if defined( __GNUC__ )
 #pragma GCC diagnostic pop
 #endif
 					[[nodiscard]] constexpr std::uint64_t high( ) const noexcept {
@@ -385,13 +385,13 @@ namespace daw::jkj::dragonbox {
 				umul128( std::uint64_t x, std::uint64_t y ) noexcept {
 #if( defined( __GNUC__ ) or defined( __clang__ ) ) and \
   defined( __SIZEOF_INT128__ ) and defined( __x86_64__ )
-#ifdef __GNUC__
+#if defined( __GNUC__ )
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 					return static_cast<unsigned __int128>( x ) *
 					       static_cast<unsigned __int128>( y );
-#ifdef __GNUC__
+#if defined( __GNUC__ )
 #pragma GCC diagnostic pop
 #endif
 #elif defined( _MSC_VER ) and defined( _M_X64 ) and \
@@ -443,14 +443,14 @@ namespace daw::jkj::dragonbox {
 				umul128_upper64( std::uint64_t x, std::uint64_t y ) noexcept {
 #if( defined( __GNUC__ ) or defined( __clang__ ) ) and \
   defined( __SIZEOF_INT128__ ) and defined( __x86_64__ )
-#ifdef __GNUC__
+#if defined( __GNUC__ )
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
 					auto p = static_cast<unsigned __int128>( x ) *
 					         static_cast<unsigned __int128>( y );
 					return std::uint64_t( p >> 64 );
-#ifdef __GNUC__
+#if defined( __GNUC__ )
 #pragma GCC diagnostic pop
 #endif
 #elif defined( DAW_IS_CONSTANT_EVALUATED ) and defined( _MSC_VER ) and \

--- a/tests/include/citm_test_json.h
+++ b/tests/include/citm_test_json.h
@@ -115,7 +115,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::citm::venueNames_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string_raw<"PLEYEL_PLEYEL", std::string_view>>;
 #else
@@ -132,7 +132,7 @@ namespace daw::json {
 	template<>
 	struct json_data_contract<daw::citm::citm_object_t> {
 		using ignore_unknown_members = void;
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_key_value<"areaNames",
 		                 std::unordered_map<std::int64_t, std::string_view>,

--- a/tests/include/citm_test_json_alloc.h
+++ b/tests/include/citm_test_json_alloc.h
@@ -17,7 +17,7 @@
 #include <string_view>
 #include <tuple>
 
-#ifdef __GNUC__
+#if defined( __GNUC__ )
 #define DAW_HIDDEN __attribute__( ( visibility( "hidden" ) ) )
 #else
 #define DAW_HIDDEN

--- a/tests/include/fixed_alloc.h
+++ b/tests/include/fixed_alloc.h
@@ -153,7 +153,7 @@ namespace daw {
 		[[nodiscard]] T *allocate( std::size_t n ) noexcept {
 			assert( m_data->buffer_start and m_data->ptr );
 			// Ensure aligned.  Underlying ptr could be shared so must be done
-#ifndef NDEBUG
+#if not defined( NDEBUG )
 			daw_json_ensure( ( ( used( ) + n ) < m_data->capacity ),
 			                 daw::json::ErrorReason::Unknown );
 #endif

--- a/tests/include/geojson_alloc.h
+++ b/tests/include/geojson_alloc.h
@@ -67,7 +67,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::geojson::Property> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_string_raw<"name", std::string_view>>;
 #else
 		static constexpr char const name[] = "name";
@@ -82,7 +82,7 @@ namespace daw::json {
 	template<>
 	struct json_data_contract<daw::geojson::Polygon> {
 
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_string_raw<"type", std::string_view>,
 		  json_array<
@@ -106,7 +106,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::geojson::Feature> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string_raw<"type", std::string_view>,
 		                   json_class<"properties", daw::geojson::Property>,
@@ -129,7 +129,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::geojson::FeatureCollection> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string_raw<"type", std::string_view>,
 		                   json_array<"features", daw::geojson::Feature,

--- a/tests/include/geojson_json.h
+++ b/tests/include/geojson_json.h
@@ -36,7 +36,7 @@ namespace daw::json {
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::geojson::Property> {
 		using ignore_unknown_members = void;
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_string_raw<"name", std::string_view>>;
 #else
 		static constexpr char const type_sym[] = "type";
@@ -51,7 +51,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::geojson::Polygon> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_string_raw<"type", std::string_view>,
 		  json_array<"coordinates", std::vector<daw::geojson::Point>>>;
@@ -72,7 +72,7 @@ namespace daw::json {
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::geojson::Feature> {
 		using ignore_unknown_members = void;
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string_raw<"type", std::string_view>,
 		                   json_class<"properties", daw::geojson::Property>,
@@ -96,7 +96,7 @@ namespace daw::json {
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::geojson::FeatureCollection> {
 		using ignore_unknown_members = void;
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string_raw<"type", std::string_view>,
 		                   json_array<"features", daw::geojson::Feature>>;

--- a/tests/include/twitter_test2_json.h
+++ b/tests/include/twitter_test2_json.h
@@ -21,7 +21,7 @@
 namespace daw::json {
 	template<>
 	struct json_data_contract<daw::twitter2::metadata_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string_raw<"result_type", std::string_view>,
 		                   json_string_raw<"iso_language_code", std::string_view>>;
@@ -42,7 +42,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::twitter2::urls_element_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_string_raw<"url", std::string_view>,
 		  json_string_raw<"expanded_url", std::string_view>,
@@ -68,7 +68,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::twitter2::url_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_array<"urls", daw::twitter2::urls_element_t>>;
 #else
@@ -84,7 +84,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::twitter2::description_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_array<"urls", daw::twitter2::urls_element_t>>;
 #else
@@ -411,7 +411,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::twitter2::thumb_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_custom<"w", std::string_view>,
 		                              json_custom<"h", std::string_view>,
 		                              json_string_raw<"resize", std::string_view>>;
@@ -431,7 +431,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::twitter2::large_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_custom<"w", std::string_view>,
 		                              json_custom<"h", std::string_view>,
 		                              json_string_raw<"resize", std::string_view>>;
@@ -451,7 +451,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::twitter2::sizes_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_class<"medium", daw::twitter2::medium_t>,
 		                              json_class<"small", daw::twitter2::small_t>,
 		                              json_class<"thumb", daw::twitter2::thumb_t>,

--- a/tests/include/twitter_test_alloc_json.h
+++ b/tests/include/twitter_test_alloc_json.h
@@ -21,7 +21,7 @@
 #include <tuple>
 #include <vector>
 
-#ifdef __GNUC__
+#if defined( __GNUC__ )
 #define DAW_HIDDEN __attribute__( ( visibility( "hidden" ) ) )
 #else
 #define DAW_HIDDEN
@@ -118,7 +118,7 @@ namespace daw::twitter {
 namespace daw::json {
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::metadata_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string<"result_type", daw::twitter::String>,
 		                   json_string<"iso_language_code", daw::twitter::String>>;
@@ -139,7 +139,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::urls_element_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_string<"url", daw::twitter::String>,
 		  json_string<"expanded_url", daw::twitter::String>,
@@ -165,7 +165,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::url_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_array<"urls", daw::twitter::urls_element_t,
 		             daw::twitter::Vector<daw::twitter::urls_element_t>>>;
@@ -183,7 +183,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::description_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_array<"urls", daw::twitter::urls_element_t,
 		             daw::twitter::Vector<daw::twitter::urls_element_t>>>;
@@ -201,7 +201,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::entities_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_class_null<"url", std::optional<daw::twitter::url_t>>,
 		  json_class_null<"description",
@@ -221,7 +221,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::user_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_number<"id", int64_t>, json_string<"id_str", daw::twitter::String>,
 		  json_string<"name", daw::twitter::String>,
@@ -366,7 +366,7 @@ namespace daw::json {
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::hashtags_element_t> {
 		using constructor = daw::construct_a_t<daw::twitter::hashtags_element_t>;
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_string<"text", daw::twitter::String>,
 		  json_array<"indices", int32_t, daw::twitter::Vector<int32_t>>>;
@@ -385,7 +385,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::tweet_object_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_class<"metadata", daw::twitter::metadata_t>,
 		  json_custom<"created_at", daw::twitter::twitter_tp,
@@ -467,7 +467,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::user_mentions_element_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_string<"screen_name", daw::twitter::String>,
 		  json_string<"name", daw::twitter::String>, json_number<"id", int64_t>,
@@ -494,7 +494,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::medium_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"w", int64_t>, json_number<"h", int64_t>,
 		                   json_string<"resize", daw::twitter::String>>;
@@ -514,7 +514,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::small_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"w", int64_t>, json_number<"h", int64_t>,
 		                   json_string<"resize", daw::twitter::String>>;
@@ -534,7 +534,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::thumb_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"w", int64_t>, json_number<"h", int64_t>,
 		                   json_string<"resize", daw::twitter::String>>;
@@ -554,7 +554,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::large_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"w", int64_t>, json_number<"h", int64_t>,
 		                   json_string<"resize", daw::twitter::String>>;
@@ -574,7 +574,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::sizes_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_class<"medium", daw::twitter::medium_t>,
 		                              json_class<"small", daw::twitter::small_t>,
 		                              json_class<"thumb", daw::twitter::thumb_t>,
@@ -598,7 +598,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::media_element_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_number<"id", int64_t>, json_string<"id_str", daw::twitter::String>,
 		  json_array<"indices", int64_t, daw::twitter::Vector<int64_t>>,
@@ -642,7 +642,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::retweeted_status_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_class<"metadata", daw::twitter::metadata_t>,
 		  json_custom<"created_at", daw::twitter::twitter_tp,
@@ -724,7 +724,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::search_metadata_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_number<"completed_in">, json_number<"max_id", int64_t>,
 		  json_string<"max_id_str", daw::twitter::String>,
@@ -764,7 +764,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_HIDDEN json_data_contract<daw::twitter::twitter_object_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_array<"statuses", daw::twitter::tweet_object_t,
 		             daw::twitter::Vector<daw::twitter::tweet_object_t>>,

--- a/tests/include/twitter_test_json.h
+++ b/tests/include/twitter_test_json.h
@@ -117,7 +117,7 @@ namespace daw::twitter {
 namespace daw::json {
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::metadata_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_string<"result_type">,
 		                              json_string<"iso_language_code">>;
 #else
@@ -136,7 +136,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::urls_element_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string<"url">, json_string<"expanded_url">,
 		                   json_string<"display_url">,
@@ -159,7 +159,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::url_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_array<"urls", daw::twitter::urls_element_t>>;
 #else
@@ -176,7 +176,7 @@ namespace daw::json {
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::entities_t> {
 		using ignore_unknown_members = void;
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_class_null<"url", std::optional<daw::twitter::url_t>>,
 		  json_class_null<"description", std::optional<daw::twitter::url_t>>>;
@@ -300,7 +300,7 @@ namespace daw::json {
 	template<>
 	struct DAW_ATTRIB_HIDDEN
 	  json_data_contract<daw::twitter::hashtags_element_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string<"text">, json_array<"indices", int32_t>>;
 #else
@@ -318,7 +318,7 @@ namespace daw::json {
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::tweet_object_t> {
 		using ignore_unknown_members = void;
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_class<"metadata", daw::twitter::metadata_t>,
 		  json_custom<"created_at", daw::twitter::twitter_tp,
@@ -399,7 +399,7 @@ namespace daw::json {
 	template<>
 	struct DAW_ATTRIB_HIDDEN
 	  json_data_contract<daw::twitter::user_mentions_element_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string<"screen_name">, json_string<"name">,
 		                   json_number<"id", int64_t>, json_string<"id_str">,
@@ -423,7 +423,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::size_item_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"w", int64_t>, json_number<"h", int64_t>,
 		                   json_string<"resize">>;
@@ -442,7 +442,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::sizes_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_class<"medium", daw::twitter::size_item_t>,
 		                   json_class<"small", daw::twitter::size_item_t>,
@@ -467,7 +467,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::media_element_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"id", int64_t>, json_string<"id_str">,
 		                   json_array<"indices", int64_t>, json_string<"media_url">,
@@ -506,7 +506,7 @@ namespace daw::json {
 	template<>
 	struct DAW_ATTRIB_HIDDEN
 	  json_data_contract<daw::twitter::retweeted_status_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_class<"metadata", daw::twitter::metadata_t>,
 		  json_custom<"created_at", daw::twitter::twitter_tp,
@@ -586,7 +586,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::search_metadata_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_number<"completed_in">, json_number<"max_id", int64_t>,
 		  json_string<"max_id_str">, json_string<"next_results">,
@@ -620,7 +620,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::twitter_object_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_array<"statuses", daw::twitter::tweet_object_t>,
 		  json_class<"search_metadata", daw::twitter::search_metadata_t>>;

--- a/tests/include/twitter_test_pmr_json.h
+++ b/tests/include/twitter_test_pmr_json.h
@@ -116,7 +116,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::metadata_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string<"result_type", daw::twitter::String>,
 		                   json_string<"iso_language_code", daw::twitter::String>>;
@@ -137,7 +137,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::urls_element_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_string<"url", daw::twitter::String>,
 		  json_string<"expanded_url", daw::twitter::String>,
@@ -163,7 +163,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::url_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_array<"urls", daw::twitter::urls_element_t,
 		             daw::twitter::Vector<daw::twitter::urls_element_t>>>;
@@ -181,7 +181,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::description_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_array<"urls", daw::twitter::urls_element_t,
 		             daw::twitter::Vector<daw::twitter::urls_element_t>>>;
@@ -199,7 +199,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::entities_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_class_null<"url", std::optional<daw::twitter::url_t>>,
 		  json_class_null<"description",
@@ -219,7 +219,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::user_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_number<"id", int64_t>, json_string<"id_str", daw::twitter::String>,
 		  json_string<"name", daw::twitter::String>,
@@ -365,7 +365,7 @@ namespace daw::json {
 	struct DAW_ATTRIB_HIDDEN
 	  json_data_contract<daw::twitter::hashtags_element_t> {
 		using constructor = daw::construct_a_t<daw::twitter::hashtags_element_t>;
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_string<"text", daw::twitter::String>,
 		  json_array<"indices", int32_t, daw::twitter::Vector<int32_t>>>;
@@ -384,7 +384,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::tweet_object_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_class<"metadata", daw::twitter::metadata_t>,
 		  json_custom<"created_at", daw::twitter::twitter_tp,
@@ -467,7 +467,7 @@ namespace daw::json {
 	template<>
 	struct DAW_ATTRIB_HIDDEN
 	  json_data_contract<daw::twitter::user_mentions_element_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_string<"screen_name", daw::twitter::String>,
 		  json_string<"name", daw::twitter::String>, json_number<"id", int64_t>,
@@ -494,7 +494,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::medium_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"w", int64_t>, json_number<"h", int64_t>,
 		                   json_string<"resize", daw::twitter::String>>;
@@ -514,7 +514,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::small_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"w", int64_t>, json_number<"h", int64_t>,
 		                   json_string<"resize", daw::twitter::String>>;
@@ -534,7 +534,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::thumb_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"w", int64_t>, json_number<"h", int64_t>,
 		                   json_string<"resize", daw::twitter::String>>;
@@ -554,7 +554,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::large_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"w", int64_t>, json_number<"h", int64_t>,
 		                   json_string<"resize", daw::twitter::String>>;
@@ -574,7 +574,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::sizes_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_class<"medium", daw::twitter::medium_t>,
 		                              json_class<"small", daw::twitter::small_t>,
 		                              json_class<"thumb", daw::twitter::thumb_t>,
@@ -598,7 +598,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::media_element_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_number<"id", int64_t>, json_string<"id_str", daw::twitter::String>,
 		  json_array<"indices", int64_t, daw::twitter::Vector<int64_t>>,
@@ -643,7 +643,7 @@ namespace daw::json {
 	template<>
 	struct DAW_ATTRIB_HIDDEN
 	  json_data_contract<daw::twitter::retweeted_status_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_class<"metadata", daw::twitter::metadata_t>,
 		  json_custom<"created_at", daw::twitter::twitter_tp,
@@ -725,7 +725,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::search_metadata_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_number<"completed_in">, json_number<"max_id", int64_t>,
 		  json_string<"max_id_str", daw::twitter::String>,
@@ -765,7 +765,7 @@ namespace daw::json {
 
 	template<>
 	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter::twitter_object_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_array<"statuses", daw::twitter::tweet_object_t,
 		             daw::twitter::Vector<daw::twitter::tweet_object_t>>,

--- a/tests/src/amazon_cellphones_test.cpp
+++ b/tests/src/amazon_cellphones_test.cpp
@@ -116,7 +116,7 @@ void test( daw::string_view json ) {
 
 int main( int argc, char **argv ) {
 	auto json_doc = std::optional<std::string>{ };
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try
 #endif
 	{
@@ -133,7 +133,7 @@ int main( int argc, char **argv ) {
 		test<options::ExecModeTypes::compile_time>( json_sv );
 		test<options::ExecModeTypes::runtime>( json_sv );
 	}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	catch( daw::json::json_exception const &jex ) {
 		std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 		std::cerr << to_formatted_string( jex, json_doc->data( ) ) << '\n';

--- a/tests/src/apache_builds_cpp_comments_test.cpp
+++ b/tests/src/apache_builds_cpp_comments_test.cpp
@@ -98,7 +98,7 @@ void test( std::string_view json_sv1 ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -127,7 +127,7 @@ int main( int argc, char **argv )
 		  json_data1 );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/apache_builds_hash_comments_test.cpp
+++ b/tests/src/apache_builds_hash_comments_test.cpp
@@ -96,7 +96,7 @@ void test( std::string_view json_sv1 ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -127,7 +127,7 @@ int main( int argc, char **argv )
 		  json_sv1 );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/apache_builds_test.cpp
+++ b/tests/src/apache_builds_test.cpp
@@ -97,7 +97,7 @@ void test( std::string_view json_sv1 ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -123,7 +123,7 @@ int main( int argc, char **argv )
 		test<options::ExecModeTypes::simd>( json_data1 );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/canada_output_test.cpp
+++ b/tests/src/canada_output_test.cpp
@@ -57,7 +57,7 @@ inline auto get_canada_check( std::string_view f1 ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -114,7 +114,7 @@ int main( int argc, char **argv )
 	                 "Expected round trip to produce same result" );
 	                 */
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/canada_test.cpp
+++ b/tests/src/canada_test.cpp
@@ -108,7 +108,7 @@ void test( std::string_view json_sv1, bool do_asserts ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -181,7 +181,7 @@ int main( int argc, char **argv )
 	                 "Expected round trip to produce same result" );
 	                 */
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/canada_test_alloc.cpp
+++ b/tests/src/canada_test_alloc.cpp
@@ -88,7 +88,7 @@ void test( std::string_view json_sv1, AllocType &alloc ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -151,7 +151,7 @@ int main( int argc, char **argv )
 		  canada_result );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/canada_test_basic.cpp
+++ b/tests/src/canada_test_basic.cpp
@@ -22,7 +22,7 @@
 #include <cstdio>
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -32,7 +32,7 @@ int main( int argc, char **argv )
 	}
 	using namespace daw::json;
 	auto json_data = std::string( *daw::read_file( argv[1] ) );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		for( int n = 0; n < 100; ++n ) {
@@ -48,14 +48,14 @@ int main( int argc, char **argv )
 			// );
 			daw::do_not_optimize( canada_result );
 		}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( daw::json::json_exception const &jex ) {
 		display_exception( jex, json_data.data( ) );
 		exit( 1 );
 	}
 #endif
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( std::exception const &ex ) {
 	std::cerr << "Unknown exception thrown during testing: " << ex.what( )
 	          << '\n';

--- a/tests/src/citm_test.cpp
+++ b/tests/src/citm_test.cpp
@@ -77,7 +77,7 @@ void test( std::string_view json_sv1, bool do_asserts ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -127,7 +127,7 @@ int main( int argc, char **argv )
 	test_assert( not str.empty( ), "Expected a string value" );
 	daw::do_not_optimize( str );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/citm_test_alloc.cpp
+++ b/tests/src/citm_test_alloc.cpp
@@ -79,7 +79,7 @@ void test( std::string_view json_sv1, AllocType &alloc ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -126,7 +126,7 @@ int main( int argc, char **argv )
 	test_assert( not str.empty( ), "Expected a string value" );
 	daw::do_not_optimize( str );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/citm_test_basic.cpp
+++ b/tests/src/citm_test_basic.cpp
@@ -25,7 +25,7 @@
 #include <streambuf>
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -48,7 +48,7 @@ int main( int argc, char **argv )
 	test_assert( citm_result.areaNames[205706005] == "1er balcon jardin",
 	             "Incorrect value" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/city_test.cpp
+++ b/tests/src/city_test.cpp
@@ -22,6 +22,7 @@
 #include <daw/iterator/daw_back_inserter.h>
 
 #include <iostream>
+#include <numeric>
 #include <streambuf>
 #include <string_view>
 #include <vector>
@@ -45,7 +46,7 @@ struct City {
 namespace daw::json {
 	template<>
 	struct json_data_contract<City> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_string<"country">, json_string<"name">,
 		  json_number<"lat", float,
@@ -72,7 +73,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -221,12 +222,11 @@ int main( int argc, char **argv )
 	  "Calculate Middle Latitude", json_data.size( ),
 	  []( auto const &jstr ) -> float {
 		  uint32_t tot = 0;
-		  auto result =
-		    daw::algorithm::accumulate( iterator_t( jstr ), iterator_t( ), 0.0f,
-		                                [&tot]( float cur, City const &city ) {
-			                                ++tot;
-			                                return cur + city.lat;
-		                                } );
+		  auto result = std::accumulate( iterator_t( jstr ), iterator_t( ), 0.0f,
+		                                 [&tot]( float cur, City const &city ) {
+			                                 ++tot;
+			                                 return cur + city.lat;
+		                                 } );
 		  return result / static_cast<float>( tot );
 	  },
 	  json_data );
@@ -250,7 +250,7 @@ int main( int argc, char **argv )
 	  json_data );
 	std::cout << "mid_lat2 of all is: " << mid_lat2 << '\n';
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_aliases1_test.cpp
+++ b/tests/src/cookbook_aliases1_test.cpp
@@ -33,7 +33,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -49,7 +49,7 @@ int main( int argc, char **argv )
 	std::cout << json0 << '\n';
 	(void)c0;
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_array1_test.cpp
+++ b/tests/src/cookbook_array1_test.cpp
@@ -22,7 +22,7 @@
 #include <vector>
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -43,7 +43,7 @@ int main( int argc, char **argv )
 		test_assert( count++ == val, "Unexpected value" );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_array2_test.cpp
+++ b/tests/src/cookbook_array2_test.cpp
@@ -57,7 +57,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -78,7 +78,7 @@ int main( int argc, char **argv )
 
 	test_assert( ve == ve2, "Roundtrip failed" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_array3_test.cpp
+++ b/tests/src/cookbook_array3_test.cpp
@@ -37,7 +37,7 @@ namespace daw::cookbook_array3 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<daw::cookbook_array3::MyArrayClass1> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"member0", int>, json_array<"member1", int>,
 		                   json_array<"member2", std::string>>;
@@ -58,7 +58,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -82,7 +82,7 @@ int main( int argc, char **argv )
 
 	test_assert( my_array_class == my_array_class2, "Round trip failed" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_class1_test.cpp
+++ b/tests/src/cookbook_class1_test.cpp
@@ -57,7 +57,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -81,7 +81,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_class2_test.cpp
+++ b/tests/src/cookbook_class2_test.cpp
@@ -46,7 +46,7 @@ namespace daw::cookbook_class2 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<daw::cookbook_class2::MyClass1> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string<"member0">, json_number<"member1", int>,
 		                   json_bool<"member2">>;
@@ -67,7 +67,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::cookbook_class2::MyClass2> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_class<"a", daw::cookbook_class2::MyClass1>,
 		                   json_number<"b", unsigned>>;
@@ -85,7 +85,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -108,7 +108,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_class3_test.cpp
+++ b/tests/src/cookbook_class3_test.cpp
@@ -83,7 +83,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -107,7 +107,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_class_from_array1_test.cpp
+++ b/tests/src/cookbook_class_from_array1_test.cpp
@@ -45,7 +45,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -72,7 +72,7 @@ int main( int argc, char **argv )
 		puts( "not exact same\n" );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_class_from_array2_test.cpp
+++ b/tests/src/cookbook_class_from_array2_test.cpp
@@ -46,7 +46,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -72,7 +72,7 @@ int main( int argc, char **argv )
 		puts( "not exact same\n" );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_dates1_test.cpp
+++ b/tests/src/cookbook_dates1_test.cpp
@@ -53,7 +53,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -75,7 +75,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_dates2_test.cpp
+++ b/tests/src/cookbook_dates2_test.cpp
@@ -152,7 +152,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -175,7 +175,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_dates3_test.cpp
+++ b/tests/src/cookbook_dates3_test.cpp
@@ -86,7 +86,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -108,7 +108,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_dates4_test.cpp
+++ b/tests/src/cookbook_dates4_test.cpp
@@ -99,7 +99,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -121,7 +121,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls4, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_enums1_test.cpp
+++ b/tests/src/cookbook_enums1_test.cpp
@@ -67,7 +67,7 @@ namespace daw::cookbook_enums1 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<daw::cookbook_enums1::MyClass1> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_array<
 		  "member0", json_custom_no_name<daw::cookbook_enums1::Colours>>>;
 #else
@@ -83,7 +83,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -112,7 +112,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_enums2_test.cpp
+++ b/tests/src/cookbook_enums2_test.cpp
@@ -36,7 +36,7 @@ namespace daw::cookbook_enums2 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<daw::cookbook_enums2::MyClass1> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_array<"member0", daw::cookbook_enums2::Colours>>;
 #else
@@ -52,7 +52,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -81,7 +81,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_escaped_strings1_test.cpp
+++ b/tests/src/cookbook_escaped_strings1_test.cpp
@@ -46,7 +46,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -74,7 +74,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_graphs1_test.cpp
+++ b/tests/src/cookbook_graphs1_test.cpp
@@ -43,7 +43,7 @@ namespace daw::cookbook_graphs1 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<daw::cookbook_graphs1::Metadata> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_number<"member0", int>,
 		                              json_string<"member1">, json_bool<"member2">>;
 #else
@@ -57,7 +57,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::cookbook_graphs1::GraphNode> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_number<"id", size_t,
 		              options::number_opt( options::LiteralAsStringOpt::Always )>,
@@ -74,7 +74,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::cookbook_graphs1::GraphEdge> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_number<"source", size_t,
 		              options::number_opt( options::LiteralAsStringOpt::Always )>,
@@ -100,7 +100,7 @@ struct Node {
 };
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -173,7 +173,7 @@ int main( int argc, char **argv )
 
 	return 0;
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_inserting_extracting_raw_json1_test.cpp
+++ b/tests/src/cookbook_inserting_extracting_raw_json1_test.cpp
@@ -33,7 +33,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -54,7 +54,7 @@ int main( int argc, char **argv )
 
 	puts( data2.c_str( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_kv1_test.cpp
+++ b/tests/src/cookbook_kv1_test.cpp
@@ -32,7 +32,7 @@ namespace daw::cookbook_kv1 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<daw::cookbook_kv1::MyKeyValue1> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_key_value<"kv", std::unordered_map<std::string, int>, int>>;
 #else
@@ -48,7 +48,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -71,7 +71,7 @@ int main( int argc, char **argv )
 
 	test_assert( kv == kv2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_kv2_test.cpp
+++ b/tests/src/cookbook_kv2_test.cpp
@@ -32,7 +32,7 @@ namespace daw::cookbook_kv2 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<daw::cookbook_kv2::MyKeyValue2> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_key_value_array<"kv", std::unordered_map<intmax_t, std::string>>>;
 #else
@@ -48,7 +48,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -71,7 +71,7 @@ int main( int argc, char **argv )
 	  std::string_view( str.data( ), str.size( ) ) );
 	test_assert( kv == kv2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_kv3_test.cpp
+++ b/tests/src/cookbook_kv3_test.cpp
@@ -32,7 +32,7 @@ namespace daw::cookbook_kv3 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<cookbook_kv3::MyKeyValue3> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_key_value<
 		  "kv", std::multimap<std::string, std::string>, std::string>>;
 #else
@@ -47,7 +47,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -72,7 +72,7 @@ int main( int argc, char **argv )
 	  std::string_view( str.data( ), str.size( ) ) );
 	test_assert( kv == kv3, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_kv4_test.cpp
+++ b/tests/src/cookbook_kv4_test.cpp
@@ -21,7 +21,7 @@
 #include <string>
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -42,7 +42,7 @@ int main( int argc, char **argv )
 	test_assert( kv.begin( )->second != std::prev( kv.end( ) )->second,
 	             "Unexpected value" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_numbers1_test.cpp
+++ b/tests/src/cookbook_numbers1_test.cpp
@@ -37,7 +37,7 @@ namespace daw::cookbook_numbers1 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<daw::cookbook_numbers1::MyClass1> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"member0">, json_number<"member1">,
 		                   json_number<"member2">, json_number<"member3">,
@@ -61,7 +61,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -87,7 +87,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_numbers2_test.cpp
+++ b/tests/src/cookbook_numbers2_test.cpp
@@ -35,7 +35,7 @@ namespace daw::cookbook_numbers2 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<daw::cookbook_numbers2::MyClass2> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_number<"member_unsigned0", unsigned>,
 		                              json_number<"member_unsigned1", unsigned>,
 		                              json_number<"member_signed", signed>>;
@@ -56,7 +56,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -79,7 +79,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls == cls2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_numbers3_test.cpp
+++ b/tests/src/cookbook_numbers3_test.cpp
@@ -36,7 +36,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -65,7 +65,7 @@ int main( int argc, char **argv )
 	test_assert( numbers.size( ) == numbers2.size( ),
 	             "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_optional_values1_test.cpp
+++ b/tests/src/cookbook_optional_values1_test.cpp
@@ -69,7 +69,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -100,7 +100,7 @@ int main( int argc, char **argv )
 	test_assert( stuff == stuff2, "Unexpected round trip error" );
 	return 0;
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_parsing_individual_members1_test.cpp
+++ b/tests/src/cookbook_parsing_individual_members1_test.cpp
@@ -20,7 +20,7 @@
 #include <unordered_map>
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -41,7 +41,7 @@ int main( int argc, char **argv )
 
 	test_assert( not opt_value, "Did not expect a value" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_parsing_individual_members2_test.cpp
+++ b/tests/src/cookbook_parsing_individual_members2_test.cpp
@@ -20,7 +20,7 @@
 #include <unordered_map>
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -41,7 +41,7 @@ int main( int argc, char **argv )
 	test_assert( value.size( ) == 4, "Unexpected value" );
 	test_assert( value[1] == "is", "Unexpected value" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_parsing_individual_members3_test.cpp
+++ b/tests/src/cookbook_parsing_individual_members3_test.cpp
@@ -20,7 +20,7 @@
 #include <unordered_map>
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -45,7 +45,7 @@ int main( int argc, char **argv )
 
 	test_assert( opt_value.empty( ), "Unexpected result" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_tuple1_test.cpp
+++ b/tests/src/cookbook_tuple1_test.cpp
@@ -39,7 +39,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -92,7 +92,7 @@ int main( int argc, char **argv )
 	(void)foo2;
 	assert( foo1 == foo2 );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_unknown_types_and_raw_parsing1_test.cpp
+++ b/tests/src/cookbook_unknown_types_and_raw_parsing1_test.cpp
@@ -19,7 +19,7 @@
 #include <string>
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -43,7 +43,7 @@ int main( int argc, char **argv )
 		          << member.value.get_string_view( ) << '\n';
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_unknown_types_and_raw_parsing2_test.cpp
+++ b/tests/src/cookbook_unknown_types_and_raw_parsing2_test.cpp
@@ -82,7 +82,7 @@ bool operator==( MyClass2 const &lhs, MyClass2 const &rhs ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -107,7 +107,7 @@ int main( int argc, char **argv )
 	auto const val2 = daw::json::from_json<MyClass2>( json_str2 );
 	test_assert( val == val2, "Broken round trip" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_unknown_types_and_raw_parsing3_test.cpp
+++ b/tests/src/cookbook_unknown_types_and_raw_parsing3_test.cpp
@@ -44,7 +44,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -57,7 +57,7 @@ int main( )
 	test_assert( my_thing.raw_json == val2.raw_json,
 	             "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_variant1_test.cpp
+++ b/tests/src/cookbook_variant1_test.cpp
@@ -53,7 +53,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<daw::cookbook_variant1::MyVariantStuff1> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_variant<
 		    "member0",
@@ -85,7 +85,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -115,7 +115,7 @@ int main( int argc, char **argv )
 	test_assert( stuff == stuff2, "Unexpected round trip error" );
 	return 0;
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_variant2_test.cpp
+++ b/tests/src/cookbook_variant2_test.cpp
@@ -44,7 +44,7 @@ namespace daw::cookbook_variant2 {
 
 template<>
 struct daw::json::json_data_contract<daw::cookbook_variant2::MyClass> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<
 	  json_string<"name">,
 	  json_tagged_variant<"value", std::variant<std::string, int, bool>,
@@ -67,7 +67,7 @@ struct daw::json::json_data_contract<daw::cookbook_variant2::MyClass> {
 };
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -88,7 +88,7 @@ int main( int argc, char **argv )
 
 	test_assert( values1 == values2, "Error in round tripping" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_variant3_test.cpp
+++ b/tests/src/cookbook_variant3_test.cpp
@@ -44,7 +44,7 @@ namespace daw::cookbook_variant3 {
 
 template<>
 struct daw::json::json_data_contract<daw::cookbook_variant3::MyClass> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<
 	  json_string<"name">,
 	  json_tagged_variant<
@@ -71,7 +71,7 @@ struct daw::json::json_data_contract<daw::cookbook_variant3::MyClass> {
 };
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -92,7 +92,7 @@ int main( int argc, char **argv )
 
 	test_assert( values1 == values2, "Error in round tripping" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_variant4_test.cpp
+++ b/tests/src/cookbook_variant4_test.cpp
@@ -104,7 +104,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -121,7 +121,7 @@ int main( int argc, char **argv )
 	std::string const json_str = daw::json::to_json_array( configs );
 	std::cout << json_str << '\n';
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/cookbook_variant5_test.cpp
+++ b/tests/src/cookbook_variant5_test.cpp
@@ -130,7 +130,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -147,7 +147,7 @@ int main( int argc, char **argv )
 	std::string const json_str = daw::json::to_json_array( configs );
 	std::cout << json_str << '\n';
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/coords_test.cpp
+++ b/tests/src/coords_test.cpp
@@ -34,7 +34,7 @@ struct coordinates_t {
 namespace daw::json {
 	template<>
 	struct json_data_contract<coordinate_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"x">, json_number<"y">, json_number<"z">>;
 #else
@@ -48,7 +48,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<coordinates_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_array<"coordinates", coordinate_t>>;
 #else
 		static constexpr char const coordinates[] = "coordinates";
@@ -58,7 +58,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -96,7 +96,7 @@ int main( int argc, char **argv )
 	std::cout << y / dsz << '\n';
 	std::cout << z / dsz << '\n';
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/coords_test2.cpp
+++ b/tests/src/coords_test2.cpp
@@ -43,7 +43,7 @@ struct coordinates_t {
 namespace daw::json {
 	template<>
 	struct json_data_contract<coordinate_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"x">, json_number<"y">, json_number<"z">>;
 #else
@@ -57,7 +57,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<coordinates_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_array<"coordinates", coordinate_t>>;
 #else
 		static constexpr char const coordinates[] = "coordinates";
@@ -67,7 +67,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -109,7 +109,7 @@ int main( int argc, char **argv )
 	std::cout << y / dsz << '\n';
 	std::cout << z / dsz << '\n';
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/daw_json_fuzzing.cpp
+++ b/tests/src/daw_json_fuzzing.cpp
@@ -89,7 +89,7 @@ public:
 			auto rng = p.value.get_raw_state( );
 			auto s = static_cast<std::string>(
 			  daw::string_view( rng.first, rng.size( ) ).pop_front( 10 ) );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 			throw std::runtime_error( s );
 #else
 			std::terminate( );
@@ -153,7 +153,7 @@ extern "C" int LLVMFuzzerTestOneInput( std::uint8_t const *data,
 	auto ofile = std::ofstream( "/dev/null", std::ios::trunc | std::ios::binary );
 	auto json_doc =
 	  std::string_view( reinterpret_cast<char const *>( data ), size );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		auto jv = daw::json::basic_json_value<daw::json::parse_options(
@@ -177,13 +177,13 @@ extern "C" int LLVMFuzzerTestOneInput( std::uint8_t const *data,
 		case daw::json::JsonBaseParseTypes::Null:
 			break;
 		case daw::json::JsonBaseParseTypes::None:
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 			throw std::exception( );
 #else
 		std::terminate( );
 #endif
 		}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( ... ) {}
 #endif
 	return 0;

--- a/tests/src/daw_json_fuzzing_gsoc.cpp
+++ b/tests/src/daw_json_fuzzing_gsoc.cpp
@@ -24,13 +24,13 @@ extern "C" int LLVMFuzzerTestOneInput( std::uint8_t const *data,
 	}
 	auto json_doc =
 	  std::string_view( reinterpret_cast<char const *>( data ), size );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		auto t = daw::json::from_json<daw::gsoc::gsoc_object_t>(
 		  json_doc, daw::json::options::parse_flags<DAW_JSON_CONFORMANCE_FLAGS> );
 		(void)t;
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( ... ) {}
 #endif
 	return 0;

--- a/tests/src/daw_json_fuzzing_replay.cpp
+++ b/tests/src/daw_json_fuzzing_replay.cpp
@@ -88,7 +88,7 @@ public:
 			auto rng = p.value.get_raw_state( );
 			auto s = static_cast<std::string>(
 			  daw::string_view( rng.first, rng.size( ) ).pop_front( 10 ) );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 			throw std::runtime_error( s );
 #else
 			std::terminate( );
@@ -147,7 +147,7 @@ extern "C" int LLVMFuzzerTestOneInput( std::uint8_t const *data,
 	auto json_doc =
 	  std::string_view( reinterpret_cast<char const *>( data ), size );
 
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		auto jv = daw::json::basic_json_value<daw::json::ConformancePolicy.value>(
@@ -171,13 +171,13 @@ extern "C" int LLVMFuzzerTestOneInput( std::uint8_t const *data,
 		case daw::json::JsonBaseParseTypes::Null:
 			break;
 		case daw::json::JsonBaseParseTypes::None:
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 			throw std::exception( );
 #else
 		std::terminate( );
 #endif
 		}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( ... ) {}
 #endif
 	return 0;

--- a/tests/src/daw_json_fuzzing_twitter.cpp
+++ b/tests/src/daw_json_fuzzing_twitter.cpp
@@ -24,13 +24,13 @@ extern "C" int LLVMFuzzerTestOneInput( std::uint8_t const *data,
 	}
 	auto json_doc =
 	  std::string_view( reinterpret_cast<char const *>( data ), size );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		auto t = daw::json::from_json<daw::twitter::twitter_object_t>(
 		  json_doc, daw::json::options::parse_flags<DAW_JSON_CONFORMANCE_FLAGS> );
 		(void)t;
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( ... ) {}
 #endif
 	return 0;

--- a/tests/src/daw_json_fuzzing_twitter_replay.cpp
+++ b/tests/src/daw_json_fuzzing_twitter_replay.cpp
@@ -22,13 +22,13 @@ int main( int argc, char **argv ) {
 	ensure( argc >= 2 );
 	auto json_doc = daw::filesystem::memory_mapped_file_t<char>( argv[1] );
 	ensure( not json_doc.empty( ) );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		auto t = daw::json::from_json<daw::twitter::twitter_object_t>(
 		  json_doc, daw::json::options::parse_flags<DAW_JSON_CONFORMANCE_FLAGS> );
 		(void)t;
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( ... ) {}
 #endif
 	return 0;

--- a/tests/src/daw_json_link_test.cpp
+++ b/tests/src/daw_json_link_test.cpp
@@ -56,7 +56,7 @@ struct NumberX {
 namespace daw::json {
 	template<>
 	struct json_data_contract<NumberX> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_number<"x", int>>;
 #else
 		static constexpr char const x[] = "x";
@@ -191,7 +191,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<test_002_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_class<"a", test_001_t>>;
 #else
 		static constexpr char const a[] = "a";
@@ -204,7 +204,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<test_003_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_class_null<"a", std::optional<test_001_t>>>;
 #else
@@ -379,7 +379,7 @@ struct Empty2 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<Empty2> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_class<"b", EmptyClassTest>, json_number<"c", int>>;
 #else
@@ -424,7 +424,7 @@ static_assert( static_cast<bool>(
   ( not defined( _MSC_VER ) ) and                                          \
   ( not defined( __clang__ ) and not defined( _LIBCPP_VERSION ) or         \
     __clang_major__ > 9 )
-#ifdef __GNUC__
+#if defined( __GNUC__ )
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
@@ -450,7 +450,7 @@ void test128( ) {
 	          << static_cast<std::uint64_t>( val & 0xFFFF'FFFF'FFFF'FFFFULL )
 	          << '\n';
 }
-#ifdef __GNUC__
+#if defined( __GNUC__ )
 #pragma GCC diagnostic pop
 #endif
 #endif
@@ -485,7 +485,7 @@ unsigned long long test_dblparse( std::string_view num,
 		std::cout << "->ulp diff: " << std::dec << diff << '\n';
 		std::cout.precision( old_precision );
 	}
-#ifndef NDEBUG
+#if not defined( NDEBUG )
 	if( diff > ( Precise ? 0 : 2 ) ) {
 		auto const old_precision = std::cout.precision( );
 		// Do again to do it from debugger
@@ -540,7 +540,7 @@ unsigned long long test_dblparse2( std::string_view num, double orig,
 		std::cout << "->ulp diff: " << std::dec << diff << '\n';
 		std::cout.precision( old_precision );
 	}
-#ifndef NDEBUG
+#if not defined( NDEBUG )
 	if( diff > 2 ) {
 		double o = orig;
 		(void)o;
@@ -785,7 +785,7 @@ struct Unmapped9 {
 };
 
 int main( int, char ** ) {
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		constexpr daw::string_view foo2_json =
@@ -1175,11 +1175,11 @@ int main( int, char ** ) {
 #endif
 
 		auto const test_bad_float = []( ) -> bool {
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 			try {
 #endif
 				(void)from_json<double>( "0e "sv );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 			} catch( daw::json::json_exception const &ex ) {
 				(void)ex;
 				return true;
@@ -1190,7 +1190,7 @@ int main( int, char ** ) {
 		daw_json_ensure( test_bad_float( ), ErrorReason::Unknown );
 
 		auto const test_empty_map = []( ) -> bool {
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 			try {
 #endif
 				auto m = from_json<std::map<std::string, std::string>>( "{}"sv );
@@ -1200,7 +1200,7 @@ int main( int, char ** ) {
 				auto const s = to_json( m );
 
 				return s == "{}";
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 			} catch( daw::json::json_exception const &jex ) {
 				std::cerr << "Exception thrown by parser: " << jex.reason( )
 				          << std::endl;
@@ -1212,12 +1212,12 @@ int main( int, char ** ) {
 
 		auto const test_leading_zero = []( auto i ) {
 			using test_t = daw::remove_cvref_t<decltype( i )>;
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 			try {
 #endif
 				auto l0 = from_json<test_t>( "01.0"sv );
 				(void)l0;
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 			} catch( daw::json::json_exception const & ) { return true; }
 #endif
 			return false;
@@ -1479,7 +1479,7 @@ int main( int, char ** ) {
 			ensure( x == 5 );
 		}
 	}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	catch( daw::json::json_exception const &jex ) {
 		std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 		exit( 1 );

--- a/tests/src/daw_json_minify.cpp
+++ b/tests/src/daw_json_minify.cpp
@@ -152,7 +152,7 @@ int main( int argc, char **argv ) {
 	auto data =
 	  daw::read_file( args[0].value, daw::terminate_on_read_file_error );
 
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try
 #endif
 	{
@@ -170,7 +170,7 @@ int main( int argc, char **argv ) {
 			minify( args, data, std::ostreambuf_iterator<char>( std::cout ) );
 		}
 	}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	catch( daw::json::json_exception const &jex ) {
 		std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 		exit( 1 );

--- a/tests/src/daw_json_minify_full.cpp
+++ b/tests/src/daw_json_minify_full.cpp
@@ -176,7 +176,7 @@ int main( int argc, char **argv ) {
 	auto data =
 	  daw::read_file( args[0].value, daw::terminate_on_read_file_error );
 
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try
 #endif
 	{
@@ -191,7 +191,7 @@ int main( int argc, char **argv ) {
 			minify( args, data, std::ostreambuf_iterator<char>( std::cout ) );
 		}
 	}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	catch( daw::json::json_exception const &jex ) {
 		std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 		exit( 1 );

--- a/tests/src/daw_json_roundtrip.cpp
+++ b/tests/src/daw_json_roundtrip.cpp
@@ -159,7 +159,7 @@ void roundtrip( daw::Arguments const &args, std::string_view data,
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -177,7 +177,7 @@ int main( int argc, char **argv )
 	auto data =
 	  daw::read_file( args[0].value, daw::terminate_on_read_file_error );
 
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		if( args.size( ) > 1 and args[1].name.empty( ) ) {
@@ -193,7 +193,7 @@ int main( int argc, char **argv )
 		} else {
 			roundtrip( args, data, std::ostreambuf_iterator<char>( std::cout ) );
 		}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( daw::json::json_exception const &jex ) {
 		std::cerr << "Exception thrown by parser\n"
 		          << to_formatted_string( jex, data.data( ) ) << '\n';
@@ -201,7 +201,7 @@ int main( int argc, char **argv )
 	}
 #endif
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( std::exception const &ex ) {
 	std::cerr << "Unknown exception thrown during testing: " << ex.what( )
 	          << '\n';

--- a/tests/src/find_tweet_test.cpp
+++ b/tests/src/find_tweet_test.cpp
@@ -129,7 +129,7 @@ void test( std::string_view json_sv1, std::uint64_t id ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -149,7 +149,7 @@ int main( int argc, char **argv )
 	test<options::ExecModeTypes::compile_time>( json_sv1, id );
 	test<options::ExecModeTypes::runtime>( json_sv1, id );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/float_array_basic_test.cpp
+++ b/tests/src/float_array_basic_test.cpp
@@ -63,7 +63,7 @@ void test_func( ankerl::nanobench::Bench &b ) {
 }
 
 int main( int argc, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -79,7 +79,7 @@ int main( int argc, char ** )
 		test_func<1'000ULL>( b1 );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/float_array_test.cpp
+++ b/tests/src/float_array_test.cpp
@@ -41,7 +41,7 @@ struct Number2 {
 namespace daw::json {
 	template<>
 	struct json_data_contract<Number> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_number<"a", float>>;
 #else
 		static constexpr char const a[] = "a";
@@ -51,7 +51,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<Number2> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_number<"a", float>>;
 #else
 		static constexpr char const a[] = "a";
@@ -283,7 +283,7 @@ void test_func( ) {
 			std::cout << "double parse count: " << count3 << '\n';
 		}
 	}
-#ifdef DAW_ALLOW_SSE42
+#if defined( DAW_ALLOW_SSE42 )
 	// ***********************************************
 	// SSE42
 	std::cout << "**********************\nSSE42 Processing\n";
@@ -481,7 +481,7 @@ void test_func( ) {
 }
 
 int main( int argc, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -491,7 +491,7 @@ int main( int argc, char ** )
 		test_func<1'000ULL>( );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/full_unicode_roundtrip_test.cpp
+++ b/tests/src/full_unicode_roundtrip_test.cpp
@@ -37,7 +37,7 @@ bool operator==( unicode_data const &lhs, unicode_data const &rhs ) {
 namespace daw::json {
 	template<>
 	struct json_data_contract<unicode_data> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_string<"escaped">, json_string<"unicode">>;
 #else
@@ -130,7 +130,7 @@ void test( MMF const &json_str, MMF const &json_str_escaped ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -156,7 +156,7 @@ int main( int argc, char **argv )
 		test<options::ExecModeTypes::simd>( json_str, json_str_escaped );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/gsoc_test.cpp
+++ b/tests/src/gsoc_test.cpp
@@ -25,7 +25,7 @@ static inline constexpr std::size_t DAW_NUM_RUNS = 2;
 static_assert( DAW_NUM_RUNS > 0 );
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -108,7 +108,7 @@ int main( int argc, char **argv )
 		                 ErrorReason::NumberOutOfRange );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/int_array_basic_test.cpp
+++ b/tests/src/int_array_basic_test.cpp
@@ -64,7 +64,7 @@ static void test_json_array_iterator( std::string_view json_sv ) {
 
 template<size_t NUMVALUES>
 void test_func( ) {
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		using int_type = uintmax_t;
@@ -72,7 +72,7 @@ void test_func( ) {
 		auto const json_sv = std::string_view( json_str.data( ), json_str.size( ) );
 		test_from_json_array<NUMVALUES, int_type>( json_sv );
 		test_json_array_iterator<int_type>( json_sv );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( daw::json::json_exception const &je ) {
 		std::cout << "Exception while processing: " << je.reason( ) << '\n';
 		exit( 1 );
@@ -81,7 +81,7 @@ void test_func( ) {
 }
 
 int main( int argc, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -91,7 +91,7 @@ int main( int argc, char ** )
 		test_func<1'000ULL>( );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/int_array_test.cpp
+++ b/tests/src/int_array_test.cpp
@@ -38,7 +38,7 @@ struct Number {
 namespace daw::json {
 	template<>
 	struct json_data_contract<Number> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_number<"a", intmax_t>>;
 #else
 		static constexpr char const a[] = "a";
@@ -470,7 +470,7 @@ void test_func( ) {
 }
 
 int main( int argc, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -480,7 +480,7 @@ int main( int argc, char ** )
 		test_func<1'000ULL>( );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/int_sanity_test.cpp
+++ b/tests/src/int_sanity_test.cpp
@@ -63,7 +63,7 @@ void test( ) {
 }
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -74,7 +74,7 @@ int main( int, char ** )
 		test<ExecModeTypes::simd, 1000>( );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/issue_361_test.cpp
+++ b/tests/src/issue_361_test.cpp
@@ -47,7 +47,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -68,7 +68,7 @@ int main( int argc, char **argv )
 
 	test_assert( kv == kv2, "Unexpected round trip error" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/issue_373_empty_string_nullable_test.cpp
+++ b/tests/src/issue_373_empty_string_nullable_test.cpp
@@ -88,7 +88,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -107,7 +107,7 @@ int main( )
 	ensure( not things[2].value );
 	ensure( things[3].value );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/json_benchmark.cpp
+++ b/tests/src/json_benchmark.cpp
@@ -26,25 +26,25 @@
 #include <string_view>
 
 // These come from build system and must be defined
-#ifndef SOURCE_CONTROL_REVISION
+#if not defined( SOURCE_CONTROL_REVISION )
 #error "SOURCE_CONTROL_REVSION must be defined"
 #endif
-#ifndef PROCESSOR_DESCRIPTION
+#if not defined( PROCESSOR_DESCRIPTION )
 #error "PROCESSOR_DESCRIPTION must be defined"
 #endif
-#ifndef OS_NAME
+#if not defined( OS_NAME )
 #error "OS_NAME must be defined"
 #endif
-#ifndef OS_RELEASE
+#if not defined( OS_RELEASE )
 #error "OS_RELEASE must be defined"
 #endif
-#ifndef OS_VERSION
+#if not defined( OS_VERSION )
 #error "OS_VERSION must be defined"
 #endif
-#ifndef OS_PLATFORM
+#if not defined( OS_PLATFORM )
 #error "OS_PLATFORM must be defined"
 #endif
-#ifndef BUILD_TYPE
+#if not defined( BUILD_TYPE )
 #error "BUILD_TYPE must be defined"
 #endif
 
@@ -91,7 +91,7 @@ inline namespace {
 
 	std::ostream &operator<<( std::ostream &os, std::chrono::nanoseconds t ) {
 		auto const ae = daw::on_scope_exit(
-		  [&os, old_flags = std::ios_base::fmtflags( os.flags( ) )] {
+		  [&os, old_flags = std::ios_base::fmtflags{ os.flags( ) }] {
 			  os.flags( old_flags );
 		  } );
 
@@ -504,7 +504,7 @@ inline namespace {
 } // namespace
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -571,7 +571,7 @@ int main( int argc, char **argv )
 	out_file.write( out_data.data( ),
 	                static_cast<std::streamsize>( out_data.size( ) ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/kostya_bench.cpp
+++ b/tests/src/kostya_bench.cpp
@@ -40,7 +40,7 @@ struct coordinates_t {
 namespace daw::json {
 	template<>
 	struct json_data_contract<coordinate_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"x">, json_number<"y">, json_number<"z">>;
 #else
@@ -54,7 +54,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -92,7 +92,7 @@ int main( int, char ** )
 	std::cout << y / dsz << '\n';
 	std::cout << z / dsz << '\n';
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/kv_map_test.cpp
+++ b/tests/src/kv_map_test.cpp
@@ -31,7 +31,7 @@ struct kv2_t {
 namespace daw::json {
 	template<>
 	struct json_data_contract<kv_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_key_value<"kv", std::unordered_map<std::string, int>, int>>;
 #else
@@ -43,7 +43,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<kv2_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_key_value<
 		  "kv", daw::bounded_hash_map<daw::string_view, int, 5, daw::fnv1a_hash_t>,
 		  int, daw::string_view>>;
@@ -57,7 +57,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -77,7 +77,7 @@ int main( int, char ** )
 	test_assert( kv2_test.kv["key1"] == 1, "Unexpected value" );
 	test_assert( kv2_test.kv["key2"] == 2, "Unexpected value" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/nativejson_bench.cpp
+++ b/tests/src/nativejson_bench.cpp
@@ -75,7 +75,7 @@ void test( char **argv, bool do_asserts ) {
 	std::optional<daw::citm::citm_object_t> citm_result{ };
 	std::optional<daw::geojson::Polygon> canada_result{ };
 
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try
 #endif
 	{
@@ -88,7 +88,7 @@ void test( char **argv, bool do_asserts ) {
 		  json_sv1 );
 		twitter_result = ret.get( );
 	}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	catch( json_exception const &jex ) {
 		std::cerr << "Error while testing twitter.json\n";
 		std::cerr << to_formatted_string( jex ) << '\n';
@@ -282,7 +282,7 @@ void test( char **argv, bool do_asserts ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -310,7 +310,7 @@ int main( int argc, char **argv )
 	}
 	test<options::ExecModeTypes::simd>( argv, do_asserts );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/nativejson_bench2.cpp
+++ b/tests/src/nativejson_bench2.cpp
@@ -30,11 +30,11 @@ static inline constexpr std::size_t DAW_NUM_RUNS = 2;
 static_assert( DAW_NUM_RUNS > 0 );
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		using namespace daw::json;
@@ -225,14 +225,14 @@ int main( int argc, char **argv )
 		test_assert( citm_result->areaNames[205706005] == "1er balcon jardin",
 		             "Incorrect value" );
 		test_assert( canada_result, "Missing value" );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( daw::json::json_exception const &je ) {
 		std::cerr << "Unexpected error while testing: " << je.reason( ) << '\n';
 		exit( EXIT_FAILURE );
 	}
 #endif
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( std::exception const &ex ) {
 	std::cerr << "Unknown exception thrown during testing: " << ex.what( )
 	          << '\n';

--- a/tests/src/nativejson_bench_alloc.cpp
+++ b/tests/src/nativejson_bench_alloc.cpp
@@ -60,7 +60,7 @@ void test( char **argv, AllocType &alloc ) {
 	std::optional<daw::twitter::twitter_object_t> twitter_result{ };
 	std::optional<daw::citm::citm_object_t> citm_result{ };
 	std::optional<daw::geojson::Polygon> canada_result{ };
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		(void)daw::bench_n_test_mbs<DAW_NUM_RUNS>(
@@ -75,7 +75,7 @@ void test( char **argv, AllocType &alloc ) {
 		  json_sv1 );
 		std::cout << "Total Allocations: " << alloc.used( ) << " bytes\n";
 		daw::do_not_optimize( twitter_result );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( daw::json::json_exception const &jex ) {
 		std::cerr << "Error while testing twitter.json\n";
 		std::cerr << to_formatted_string( jex ) << '\n';
@@ -263,12 +263,12 @@ void test( char **argv, AllocType &alloc ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
 	auto alloc = AllocType( 5'000'000ULL );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		using namespace daw::json;
@@ -288,14 +288,14 @@ int main( int argc, char **argv )
 			test<ExecModeTypes::runtime>( argv, alloc );
 		}
 		test<ExecModeTypes::simd>( argv, alloc );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( daw::json::json_exception const &je ) {
 		std::cerr << "Unexpected error while testing: " << je.reason( ) << '\n';
 		exit( EXIT_FAILURE );
 	}
 #endif
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/nativejson_bench_basic.cpp
+++ b/tests/src/nativejson_bench_basic.cpp
@@ -31,7 +31,7 @@ static inline constexpr std::size_t DAW_NUM_RUNS = 2;
 static_assert( DAW_NUM_RUNS > 0 );
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -85,7 +85,7 @@ int main( int argc, char **argv )
 	}
 #endif
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/nativejson_bench_basic2.cpp
+++ b/tests/src/nativejson_bench_basic2.cpp
@@ -30,7 +30,7 @@ static inline constexpr std::size_t DAW_NUM_RUNS = 2;
 static_assert( DAW_NUM_RUNS > 0 );
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -53,7 +53,7 @@ int main( int argc, char **argv )
 	std::optional<daw::twitter2::twitter_object_t> j1{ };
 	std::optional<daw::citm::citm_object_t> j2{ };
 	std::optional<daw::geojson::Polygon> j3{ };
-#ifdef NDEBUG
+#if defined( NDEBUG )
 	std::cout << "non-debug run\n";
 	auto const sz = sv_twitter.size( ) + sv_citm.size( ) + sv_canada.size( );
 	(void)daw::bench_n_test_mbs<DAW_NUM_RUNS>(
@@ -101,7 +101,7 @@ int main( int argc, char **argv )
 	test_assert( j2, "Missing value" );
 	test_assert( j3, "Missing value" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/nativejson_roundtrip.cpp
+++ b/tests/src/nativejson_roundtrip.cpp
@@ -31,7 +31,7 @@ std::string read_file( std::string const &filename ) {
 }
 
 int main( int argc, char *argv[] )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -102,7 +102,7 @@ int main( int argc, char *argv[] )
 
 	return EXIT_SUCCESS;
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/no_move_or_copy_cls_test.cpp
+++ b/tests/src/no_move_or_copy_cls_test.cpp
@@ -48,7 +48,7 @@ namespace daw::json {
 	template<>
 	struct json_data_contract<B> {
 		using force_aggregate_construction = void;
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_class<"a", A>>;
 
 #else
@@ -62,7 +62,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -80,7 +80,7 @@ int main( int, char ** )
 	daw::expecting( daw::json::from_json<B>( json_data2, policy_v ).a.member ==
 	                1234 );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/numbers_test.cpp
+++ b/tests/src/numbers_test.cpp
@@ -62,7 +62,7 @@ void test( std::string_view data ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -77,7 +77,7 @@ int main( int argc, char **argv )
 	auto const sv_numbers =
 	  std::string_view( mm_numbers.data( ), mm_numbers.size( ) );
 
-#ifndef NDEBUG
+#if not defined( NDEBUG )
 	std::cout << "non-debug run\n";
 #endif
 	test<daw::json::options::ExecModeTypes::compile_time>( sv_numbers );
@@ -86,7 +86,7 @@ int main( int argc, char **argv )
 	test<daw::json::options::ExecModeTypes::simd>( sv_numbers );
 #endif
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/optional_tagged_variant_test.cpp
+++ b/tests/src/optional_tagged_variant_test.cpp
@@ -48,7 +48,7 @@ struct test_t {
 
 template<>
 struct daw::json::json_data_contract<MyClass> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<
 	  json_string<"name">,
 	  json_tagged_variant_null<
@@ -71,7 +71,7 @@ struct daw::json::json_data_contract<MyClass> {
 };
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -92,7 +92,7 @@ int main( int argc, char **argv )
 
 	test_assert( values1 == values2, "Error in round tripping" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/optional_variant_test.cpp
+++ b/tests/src/optional_variant_test.cpp
@@ -52,7 +52,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -83,7 +83,7 @@ int main( int argc, char **argv )
 	test_assert( stuff == stuff2, "Unexpected round trip error" );
 	return 0;
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/should_fail_001.cpp
+++ b/tests/src/should_fail_001.cpp
@@ -9,13 +9,13 @@
 #include "defines.h"
 
 // Ensure that we are always checking
-#ifdef DAW_JSON_CHECK_DEBUG_ONLY
+#if defined( DAW_JSON_CHECK_DEBUG_ONLY )
 #undef DAW_JSON_CHECK_DEBUG_ONLY
 #endif
 
 #include <daw/json/daw_json_link.h>
 
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 #include <exception>
 #endif
 #include <iostream>
@@ -36,7 +36,7 @@ namespace tests {
 
 template<>
 struct daw::json::json_data_contract<tests::Coordinate> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<json_number<"lat">, json_number<"lng">,
 	                              json_string<"name">>;
 #else
@@ -50,7 +50,7 @@ struct daw::json::json_data_contract<tests::Coordinate> {
 
 template<>
 struct daw::json::json_data_contract<tests::UriList> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<json_array<"uris", std::string>>;
 #else
 	static constexpr char const uris[] = "uris";
@@ -257,7 +257,7 @@ namespace tests {
 	}
 } // namespace tests
 
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 #define expect_fail( Bool, Reason )                                          \
 	do {                                                                       \
 		std::cout << "testing: "                                                 \
@@ -286,11 +286,11 @@ namespace tests {
 #endif
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	std::exception_ptr last_uncaught_except = nullptr;
 #endif
 	expect_fail( tests::quotes_in_numbers( ),
@@ -335,14 +335,14 @@ int main( int, char ** )
 	             "Incomplete false in array not caught" );
 
 	expect_fail( tests::bad_true( ), "bad true value not caught" );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	if( last_uncaught_except ) {
 		std::rethrow_exception( last_uncaught_except );
 	}
 #endif
 	return 0;
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( std::exception const &ex ) {
 	std::cerr << "Unknown exception thrown during testing: " << ex.what( )
 	          << '\n';

--- a/tests/src/simple_test.cpp
+++ b/tests/src/simple_test.cpp
@@ -27,7 +27,7 @@ struct City {
 namespace daw::json {
 	template<>
 	struct json_data_contract<City> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
 		  json_string_raw<"country", std::string_view>,
 		  json_string_raw<"name", std::string_view>,
@@ -55,7 +55,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -85,7 +85,7 @@ int main( int argc, char **argv )
 
 	std::cout << "Chitungwiza was found.\n" << to_json( *pos ) << '\n';
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/small_test.cpp
+++ b/tests/src/small_test.cpp
@@ -27,7 +27,7 @@ namespace daw {
 namespace daw::json {
 	template<>
 	struct json_data_contract<daw::Data> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_number<"a", int>>;
 #else
 		static constexpr char const a[] = "a";
@@ -40,7 +40,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -55,7 +55,7 @@ int main( int argc, char **argv )
 
 	test_assert( cls.a == 12345, "Unexpected value" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/stream_output_test.cpp
+++ b/tests/src/stream_output_test.cpp
@@ -52,7 +52,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -78,7 +78,7 @@ int main( int, char ** )
 	std::string const str = ss.str( );
 	puts( str.c_str( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/strings_escaped_test.cpp
+++ b/tests/src/strings_escaped_test.cpp
@@ -98,7 +98,7 @@ auto test( std::string_view json_data ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -122,7 +122,7 @@ int main( int argc, char **argv )
 		test_assert( h0 == h2, "constexpr/fast exec model hashes do not match" );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/strings_test.cpp
+++ b/tests/src/strings_test.cpp
@@ -126,7 +126,7 @@ std::size_t test( std::string_view json_data ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -150,7 +150,7 @@ int main( int argc, char **argv )
 		test_equal( h0, h2, "constexpr/fast exec model hashes do not match" );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_array_of_ordered.cpp
+++ b/tests/src/test_array_of_ordered.cpp
@@ -67,7 +67,7 @@ namespace daw::json {
 } // namespace daw::json
 
 int main( ) {
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try
 #endif
 	{
@@ -80,7 +80,7 @@ int main( ) {
 		auto parsed = daw::json::from_json<DepthUpdateJson>( testJson1 );
 		std::cout << "";
 	}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	catch( daw::json::json_exception const &e ) {
 		std::cout << "formatted: " << to_formatted_string( e ) << "\n\n";
 		std::cout << "daw error: " << e.reason( ) << " near: '"

--- a/tests/src/test_dawjsonlink.cpp
+++ b/tests/src/test_dawjsonlink.cpp
@@ -33,7 +33,7 @@ struct coordinates_t {
 namespace daw::json {
 	template<>
 	struct json_data_contract<coordinate_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type =
 		  json_member_list<json_number<"x">, json_number<"y">, json_number<"z">>;
 #else
@@ -47,7 +47,7 @@ namespace daw::json {
 
 	template<>
 	struct json_data_contract<coordinates_t> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<json_array<"coordinates", coordinate_t>>;
 #else
 		constexpr inline static char const coordinates[] = "coordinates";
@@ -66,7 +66,7 @@ std::string read_file( std::string const &filename ) {
 }
 
 int main( int argc, char *argv[] )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -98,7 +98,7 @@ int main( int argc, char *argv[] )
 
 	return EXIT_SUCCESS;
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_parse_real.cpp
+++ b/tests/src/test_details_parse_real.cpp
@@ -165,13 +165,13 @@ void test_lots_of_doubles( ) {
 }
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
 	test_lots_of_doubles( );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_parse_value_array.cpp
+++ b/tests/src/test_details_parse_value_array.cpp
@@ -98,14 +98,14 @@ bool array_with_closing_class_fail( ) {
 	} while( false )
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
 	do_test( empty_array_empty_json_array( ) );
 	do_fail_test( int_array_json_string_array_fail( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_parse_value_class.cpp
+++ b/tests/src/test_details_parse_value_class.cpp
@@ -153,7 +153,7 @@ bool wrong_member_stored_pos_fail( ) {
 }
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -168,7 +168,7 @@ int main( int, char ** )
 	do_fail_test( unexpected_eof_in_class1_fail( ) );
 	do_fail_test( wrong_member_stored_pos_fail( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_parse_value_custom.cpp
+++ b/tests/src/test_details_parse_value_custom.cpp
@@ -36,7 +36,7 @@ bool empty_array_empty_json_array( ) {
 	return v.size( ) == 8;
 }
 
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 #define do_test( ... )                                                   \
 	try {                                                                  \
 		daw::expecting_message( __VA_ARGS__, "" #__VA_ARGS__ );              \
@@ -64,13 +64,13 @@ bool empty_array_empty_json_array( ) {
 */
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
 	do_test( empty_array_empty_json_array( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_parse_value_iso8601.cpp
+++ b/tests/src/test_details_parse_value_iso8601.cpp
@@ -19,7 +19,7 @@
 #include <string_view>
 
 int main( )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -29,7 +29,7 @@ int main( )
 	auto result = daw::twitter::TimestampConverter{ }( sv );
 	(void)result;
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_parse_value_null.cpp
+++ b/tests/src/test_details_parse_value_null.cpp
@@ -71,7 +71,7 @@ bool test_null_number_untrusted_known( ) {
 	return v and *v == 5;
 }
 
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 #define do_test( ... )                                                   \
 	try {                                                                  \
 		daw::expecting_message( __VA_ARGS__, "" #__VA_ARGS__ );              \
@@ -99,7 +99,7 @@ bool test_null_number_untrusted_known( ) {
 */
 
 int main( )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -109,7 +109,7 @@ int main( )
 	do_test( test_null_number_trusted( ) );
 	do_test( test_null_number_untrusted_known( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_parse_value_real.cpp
+++ b/tests/src/test_details_parse_value_real.cpp
@@ -125,7 +125,7 @@ bool test_bad_real_untrusted2( ) {
 	} while( false )
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -137,7 +137,7 @@ int main( int, char ** )
 	do_fail_test( test_bad_real_untrusted( ) );
 	do_fail_test( test_bad_real_untrusted2( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_parse_value_signed.cpp
+++ b/tests/src/test_details_parse_value_signed.cpp
@@ -96,7 +96,7 @@ bool test_real_untrusted( ) {
 	} while( false )
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -106,7 +106,7 @@ int main( int, char ** )
 	do_fail_test( test_missing_untrusted( ) );
 	do_fail_test( test_real_untrusted( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_parse_value_unsigned.cpp
+++ b/tests/src/test_details_parse_value_unsigned.cpp
@@ -89,7 +89,7 @@ bool test_real_untrusted( ) {
 	} while( false )
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -98,7 +98,7 @@ int main( int, char ** )
 	do_fail_test( test_negative_untrusted( ) );
 	do_fail_test( test_real_untrusted( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_skip_array.cpp
+++ b/tests/src/test_details_skip_array.cpp
@@ -121,7 +121,7 @@ bool test_embedded_arrays_broken_001( ) {
 	} while( false )
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -137,7 +137,7 @@ int main( int, char ** )
 	do_test( test_embedded_arrays( ) );
 	do_fail_test( test_embedded_arrays_broken_001( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_skip_class.cpp
+++ b/tests/src/test_details_skip_class.cpp
@@ -159,7 +159,7 @@ bool test_class_close_mid_array_without_open( ) {
 	} while( false )
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -177,7 +177,7 @@ int main( int, char ** )
 	do_fail_test( test_embedded_class_broken_001( ) );
 	do_fail_test( test_class_close_mid_array_without_open( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_skip_number.cpp
+++ b/tests/src/test_details_skip_number.cpp
@@ -40,7 +40,7 @@ bool test_number_space( ) {
 	auto v = skip_number( rng );
 	return std::string_view( v.first, v.size( ) ) == "12345";
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 #define do_test( ... )                                                   \
 	try {                                                                  \
 		daw::expecting_message( __VA_ARGS__, "" #__VA_ARGS__ );              \
@@ -68,7 +68,7 @@ bool test_number_space( ) {
 */
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -76,7 +76,7 @@ int main( int, char ** )
 	do_test( test_number( ) );
 	do_test( test_number_space( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_details_skip_string.cpp
+++ b/tests/src/test_details_skip_string.cpp
@@ -165,7 +165,7 @@ bool test_escaped_quote_004( ) {
 	} while( false )
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -199,7 +199,7 @@ int main( int, char ** )
 	do_fail_test( test_missing_quotes_002( ) );
 	do_fail_test( test_missing_quotes_003( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/test_stateful_json_value.cpp
+++ b/tests/src/test_stateful_json_value.cpp
@@ -52,7 +52,7 @@ coordinate_t calc( std::string_view text ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -66,7 +66,7 @@ int main( int argc, char **argv )
 	std::cout << "x: " << coords.x << " y: " << coords.y << " z: " << coords.z
 	          << '\n';
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/trailing_commas.cpp
+++ b/tests/src/trailing_commas.cpp
@@ -25,7 +25,7 @@ struct string_trail {
 
 template<>
 struct daw::json::json_data_contract<string_trail> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<json_string<"a">>;
 #else
 	static constexpr char const a[] = "a";
@@ -34,14 +34,14 @@ struct daw::json::json_data_contract<string_trail> {
 };
 
 bool test_string_trail( ) {
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		static DAW_CONSTEXPR std::string_view json_data =
 		  R"({"b": 5, "c": true, "a": "hello", } )";
 		auto const result = daw::json::from_json<string_trail>( json_data );
 		test_assert( result.a == "hello", "Unexpected result" );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( daw::json::json_exception const &je ) {
 		std::cerr << "string trail parsing failed: " << je.reason( ) << '\n';
 		return false;
@@ -56,7 +56,7 @@ struct string_raw_trail {
 
 template<>
 struct daw::json::json_data_contract<string_raw_trail> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<json_string_raw<"a", std::string_view>>;
 #else
 	static constexpr char const a[] = "a";
@@ -81,7 +81,7 @@ struct int_trail {
 
 template<>
 struct daw::json::json_data_contract<int_trail> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<json_number<"a", int>>;
 #else
 	static constexpr char const a[] = "a";
@@ -106,7 +106,7 @@ struct unsigned_trail {
 
 template<>
 struct daw::json::json_data_contract<unsigned_trail> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<json_number<"a", unsigned>>;
 #else
 	static constexpr char const a[] = "a";
@@ -130,7 +130,7 @@ struct bool_trail {
 
 template<>
 struct daw::json::json_data_contract<bool_trail> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<json_bool<"a">>;
 #else
 	static constexpr char const a[] = "a";
@@ -155,7 +155,7 @@ struct object_trail {
 
 template<>
 struct daw::json::json_data_contract<object_trail> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<json_class<"a", int_trail>>;
 #else
 	static constexpr char const a[] = "a";
@@ -180,7 +180,7 @@ struct array_member_trail {
 
 template<>
 struct daw::json::json_data_contract<array_member_trail> {
-#ifdef DAW_JSON_CNTTP_JSON_NAME
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
 	using type = json_member_list<json_array<"a", int>>;
 #else
 	static constexpr char const a[] = "a";
@@ -193,13 +193,13 @@ bool test_array_member_trail( ) {
 
 	static DAW_CONSTEXPR std::string_view json_data =
 	  R"({"b": 5, "c": true, "a": [1,2,3,4], } )";
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		auto const result = daw::json::from_json<array_member_trail>( json_data );
 		test_assert( result.a.size( ) == 4, "Unexpected result" );
 		test_assert( result.a[0] == 1, "Unexpected result" );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( daw::json::json_exception const &je ) {
 		std::cerr << "array_member trail parsing failed: " << je.reason( ) << '\n';
 		return false;
@@ -210,7 +210,7 @@ bool test_array_member_trail( ) {
 
 bool test_array_trail( ) {
 	static DAW_CONSTEXPR std::string_view json_data = "[1,2,3,4,5,]";
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
 		std::vector<int> const result =
@@ -218,7 +218,7 @@ bool test_array_trail( ) {
 		test_assert( result.size( ) == 5, "Unexpected result" );
 		test_assert( result[0] == 1, "Unexpected result" );
 		test_assert( result[4] == 5, "Unexpected result" );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	} catch( daw::json::json_exception const &je ) {
 		std::cerr << "array trail parsing failed: " << je.reason( ) << '\n';
 		return false;
@@ -228,7 +228,7 @@ bool test_array_trail( ) {
 }
 
 int main( int, char ** )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -246,7 +246,7 @@ int main( int, char ** )
 	daw::expecting( test_array_member_trail( ) );
 	daw::expecting( test_array_trail( ) );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/twitter_output_test.cpp
+++ b/tests/src/twitter_output_test.cpp
@@ -31,7 +31,7 @@ static_assert( DAW_NUM_RUNS > 0 );
 using namespace daw::json::options;
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -70,7 +70,7 @@ int main( int argc, char **argv )
 	  daw::json::from_json<daw::twitter::twitter_object_t>( str );
 	daw::do_not_optimize( twitter_result2 );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/twitter_test.cpp
+++ b/tests/src/twitter_test.cpp
@@ -33,7 +33,7 @@ using namespace daw::json::options;
 inline namespace {
 	template<ExecModeTypes ExecMode>
 	void test( std::string_view json_data, bool do_asserts )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	  try
 #endif
 	{
@@ -181,7 +181,7 @@ inline namespace {
 			             "Missing value" );
 		}
 	}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	catch( daw::json::json_exception const &jex ) {
 		std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 		exit( 1 );
@@ -197,7 +197,7 @@ inline namespace {
 } // namespace
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -249,7 +249,7 @@ int main( int argc, char **argv )
 	  daw::json::from_json<daw::twitter::twitter_object_t>( str );
 	daw::do_not_optimize( twitter_result2 );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/twitter_test2.cpp
+++ b/tests/src/twitter_test2.cpp
@@ -45,7 +45,7 @@ DAW_CONSTEXPR bool operator==( T const &lhs, T const &rhs ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -115,7 +115,7 @@ int main( int argc, char **argv )
 	/*test_assert( twitter_result == twitter_result2,
 	                 "Expected round trip to produce same result" );*/
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/twitter_test_alloc.cpp
+++ b/tests/src/twitter_test_alloc.cpp
@@ -49,7 +49,7 @@ using namespace daw::json::options;
 
 template<ExecModeTypes ExecMode>
 void test( std::string_view json_data, AllocType &alloc )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -215,7 +215,7 @@ void test( std::string_view json_data, AllocType &alloc )
 	test_assert( twitter_result->statuses.front( ).user.id == 1186275104,
 	             "Missing value" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );
@@ -230,7 +230,7 @@ catch( daw::json::json_exception const &jex ) {
 #endif
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -281,7 +281,7 @@ int main( int argc, char **argv )
 	  daw::json::from_json_alloc<daw::twitter::twitter_object_t>( str, alloc );
 	daw::do_not_optimize( twitter_result2 );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/twitter_test_basic.cpp
+++ b/tests/src/twitter_test_basic.cpp
@@ -18,7 +18,7 @@
 #include <streambuf>
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -52,7 +52,7 @@ int main( int argc, char **argv )
 		             "Missing value" );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/twitter_test_basic2.cpp
+++ b/tests/src/twitter_test_basic2.cpp
@@ -26,7 +26,7 @@ int main( int argc, char **argv ) {
 	auto const json_data1 = *daw::read_file( argv[1] );
 	auto const json_sv1 =
 	  std::string_view( json_data1.data( ), json_data1.size( ) );
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	try
 #endif
 	{
@@ -37,7 +37,7 @@ int main( int argc, char **argv ) {
 		test_assert( twitter_result.statuses.front( ).user.id == "1186275104",
 		             "Missing value" );
 	}
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 	catch( daw::json::json_exception const &jex ) {
 		std::cerr << "Exception thrown by parser: "
 		          << to_formatted_string( jex, json_data1.data( ) ) << '\n';

--- a/tests/src/twitter_test_pmr.cpp
+++ b/tests/src/twitter_test_pmr.cpp
@@ -53,7 +53,7 @@ using namespace daw::json::options;
 template<ExecModeTypes ExecMode>
 void test( std::string_view json_data,
            boost::container::pmr::monotonic_buffer_resource *alloc )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -240,7 +240,7 @@ void test( std::string_view json_data,
 	test_assert( twitter_result->statuses.front( ).user.id == 1186275104,
 	             "Missing value" );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );
@@ -255,7 +255,7 @@ catch( daw::json::json_exception const &jex ) {
 #endif
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -313,7 +313,7 @@ int main( int argc, char **argv )
 	           daw::twitter::twitter_object_t>( alloc ) );
 	daw::do_not_optimize( twitter_result2 );
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );

--- a/tests/src/twitter_timeline_test.cpp
+++ b/tests/src/twitter_timeline_test.cpp
@@ -95,7 +95,7 @@ void test( std::string_view json_sv1 ) {
 }
 
 int main( int argc, char **argv )
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
   try
 #endif
 {
@@ -122,7 +122,7 @@ int main( int argc, char **argv )
 		test<options::ExecModeTypes::simd>( json_sv1 );
 	}
 }
-#ifdef DAW_USE_EXCEPTIONS
+#if defined( DAW_USE_EXCEPTIONS )
 catch( daw::json::json_exception const &jex ) {
 	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
 	exit( 1 );


### PR DESCRIPTION
Updated preprocessor conditionals to use `#if defined(...)` instead of `#ifdef` for clarity and consistency across multiple test files. This improves the readability and unity of the codebase.