### PR TITLE
Refactor `json_writer_t`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-				 VERSION "3.32.2"
+				 VERSION "3.33.0"
 				 DESCRIPTION "Static JSON parsing in C++"
 				 HOMEPAGE_URL "https://github.com/beached/daw_json_link"
 				 LANGUAGES C CXX )

--- a/docs/cookbook/json_writer.md
+++ b/docs/cookbook/json_writer.md
@@ -5,7 +5,8 @@ when the document structure is known while writing, but constructing an
 intermediate C++ object or container would be inconvenient.
 
 Include the incremental writer header and create a writer over any supported
-writable output:
+writable output. This includes string-like containers, C++ output streams, and
+C `FILE *` outputs:
 
 ```cpp
 #include <daw/json/daw_json_writer.h>
@@ -14,6 +15,13 @@ writable output:
 
 auto result = std::string{ };
 auto writer = daw::json::json_writer( result );
+```
+
+For example, a writer can write directly to standard output:
+
+```cpp
+auto stream_writer = daw::json::json_writer( std::cout );
+auto file_writer = daw::json::json_writer( stdout );
 ```
 
 Values passed to `write_value` and `write_key_value` use the same serialization
@@ -92,8 +100,8 @@ The result is:
 [1,"two",true]
 ```
 
-`write_values` can append an initializer list, a container-like range, or a
-heterogeneous argument list:
+`write_array_values` appends an initializer list, a container-like range, or a
+heterogeneous argument list to an open array:
 
 ```cpp
 #include <vector>
@@ -103,9 +111,9 @@ auto result = std::string{ };
 {
   auto writer = daw::json::json_writer( result );
   writer.open_array( );
-  writer.write_values( values );
-  writer.write_values( { 4, 5 } );
-  writer.write_values( 6, "seven", false );
+  writer.write_array_values( values );
+  writer.write_array_values( { 4, 5 } );
+  writer.write_array_values( 6, "seven", false );
   writer.close_array( );
 }
 ```
@@ -114,6 +122,34 @@ The result is:
 
 ```json
 [1,2,3,4,5,6,"seven",false]
+```
+
+`write_value` also accepts an initializer list or multiple values and writes
+them as a complete JSON array. This is useful at the root or after `add_key`:
+
+```cpp
+auto result = std::string{ };
+{
+  auto writer = daw::json::json_writer( result );
+  writer.open_object( );
+  writer.add_key( "values" );
+  writer.write_value( 1, "two", false );
+  writer.close_object( );
+}
+```
+
+The result is:
+
+```json
+{"values":[1,"two",false]}
+```
+
+Likewise, passing an initializer list or multiple values to
+`write_key_value` writes the member value as an array:
+
+```cpp
+writer.write_key_value( "numbers", { 1, 2, 3 } );
+writer.write_key_value( "mixed", 42, "Hello", 44 );
 ```
 
 ## Nesting Objects and Arrays
@@ -232,7 +268,7 @@ auto result = std::string{ };
   writer.write_key_value( "answer", 42 );
   writer.add_key( "values" );
   writer.open_array( );
-  writer.write_values( { 1, 2, 3 } );
+  writer.write_array_values( { 1, 2, 3 } );
   writer.close_array( );
   writer.close_object( );
 }
@@ -327,7 +363,9 @@ surrounding output format before writing the next root value.
 * `add_key` and `write_key_value` are valid only inside an object.
 * An object value written separately must follow `add_key`.
 * The scalar write functions write an array element when inside an array.
-* `write_values` is valid only inside an array.
+* `write_array_values` is valid only inside an array.
+* Passing multiple values or an initializer list to `write_value` or
+  `write_key_value` writes those values as an array.
 * `close_object` and `close_array` must match the currently open container.
 * A writer produces one root JSON value between construction or `reset()` and
   the next `reset()`.

--- a/include/daw/json/daw_json_writer.h
+++ b/include/daw/json/daw_json_writer.h
@@ -26,22 +26,22 @@ namespace daw::json {
 			  json_details::ident_trait<json_details::json_deduced_type, Value>,
 			  json_details::ident_trait<json_details::json_deduced_type,
 			                            JsonClass>>::type;
-		} // namespace json_writer_details
 
-		enum class json_writer_states : std::uint8_t {
-			/**
-			 * Not writing a member or value
-			 */
-			json_writer_nothing,
-			/**
-			 * Indicates we are inside a class
-			 */
-			json_writer_object,
-			/**
-			 * Indicates we are inside an array
-			 */
-			json_writer_array
-		};
+			enum class json_writer_states : std::uint8_t {
+				/**
+				 * Not writing a member or value
+				 */
+				json_writer_nothing,
+				/**
+				 * Indicates we are inside a class
+				 */
+				json_writer_object,
+				/**
+				 * Indicates we are inside an array
+				 */
+				json_writer_array
+			};
+		} // namespace json_writer_details
 
 		template<typename WriterType, typename StackType, auto... PolicyFlags>
 		class json_writer_t {
@@ -50,13 +50,14 @@ namespace daw::json {
 			    std::declval<WriterType>( ) ) );
 
 			StackType m_stack{ };
-			json_writer_states m_current_state =
-			  json_writer_states::json_writer_nothing;
+			json_writer_details::json_writer_states m_current_state =
+			  json_writer_details::json_writer_states::json_writer_nothing;
 			bool m_is_first = true;
 			bool m_is_key_written = false;
 			iterator_t m_writer;
 
-			constexpr void push_state( json_writer_states new_state ) {
+			constexpr void
+			push_state( json_writer_details::json_writer_states new_state ) {
 				m_stack.push_back( m_current_state );
 				m_current_state = new_state;
 			}
@@ -78,16 +79,19 @@ namespace daw::json {
 			}
 
 			constexpr void prepare_value( ) {
-				if( m_current_state == json_writer_states::json_writer_nothing ) {
+				if( m_current_state ==
+				    json_writer_details::json_writer_states::json_writer_nothing ) {
 					daw_json_ensure( m_is_first, ErrorReason::OutputError );
 					return;
 				}
-				if( m_current_state == json_writer_states::json_writer_object ) {
+				if( m_current_state ==
+				    json_writer_details::json_writer_states::json_writer_object ) {
 					daw_json_ensure( m_is_key_written, ErrorReason::OutputError );
 					m_is_key_written = false;
 					return;
 				}
-				if( m_current_state != json_writer_states::json_writer_nothing ) {
+				if( m_current_state !=
+				    json_writer_details::json_writer_states::json_writer_nothing ) {
 					write_item_prefix( );
 				}
 			}
@@ -112,15 +116,16 @@ namespace daw::json {
 				if( m_is_key_written ) {
 					write_value( nullptr );
 				}
-				while( m_current_state != json_writer_states::json_writer_nothing ) {
+				while( m_current_state !=
+				       json_writer_details::json_writer_states::json_writer_nothing ) {
 					switch( m_current_state ) {
-					case json_writer_states::json_writer_object:
+					case json_writer_details::json_writer_states::json_writer_object:
 						close_object( );
 						break;
-					case json_writer_states::json_writer_array:
+					case json_writer_details::json_writer_states::json_writer_array:
 						close_array( );
 						break;
-					case json_writer_states::json_writer_nothing:
+					case json_writer_details::json_writer_states::json_writer_nothing:
 					default:
 						break;
 					}
@@ -129,7 +134,8 @@ namespace daw::json {
 
 			constexpr void reset( ) {
 				finalize( );
-				m_current_state = json_writer_states::json_writer_nothing;
+				m_current_state =
+				  json_writer_details::json_writer_states::json_writer_nothing;
 				m_is_first = true;
 				m_is_key_written = false;
 			}
@@ -141,16 +147,18 @@ namespace daw::json {
 
 			constexpr void open_object( ) {
 				prepare_value( );
-				push_state( json_writer_states::json_writer_object );
+				push_state(
+				  json_writer_details::json_writer_states::json_writer_object );
 				m_writer.put( '{' );
 				m_writer.add_indent( );
 				m_is_first = true;
 			}
 
 			constexpr void close_object( ) {
-				daw_json_ensure( m_current_state ==
-				                   json_writer_states::json_writer_object,
-				                 ErrorReason::OutputError );
+				daw_json_ensure(
+				  m_current_state ==
+				    json_writer_details::json_writer_states::json_writer_object,
+				  ErrorReason::OutputError );
 				if( m_is_key_written ) {
 					write_value( nullptr );
 				}
@@ -165,16 +173,18 @@ namespace daw::json {
 
 			constexpr void open_array( ) {
 				prepare_value( );
-				push_state( json_writer_states::json_writer_array );
+				push_state(
+				  json_writer_details::json_writer_states::json_writer_array );
 				m_is_first = true;
 				m_writer.add_indent( );
 				m_writer.put( '[' );
 			}
 
 			constexpr void close_array( ) {
-				daw_json_ensure( m_current_state ==
-				                   json_writer_states::json_writer_array,
-				                 ErrorReason::OutputError );
+				daw_json_ensure(
+				  m_current_state ==
+				    json_writer_details::json_writer_states::json_writer_array,
+				  ErrorReason::OutputError );
 				m_writer.del_indent( );
 				if( not m_is_first ) {
 					m_writer.next_member( );
@@ -184,18 +194,145 @@ namespace daw::json {
 				m_is_first = false;
 			}
 
-			// Write a value similar to to_json.
+			constexpr void write_value( std::nullptr_t ) {
+				write_null( );
+			}
+
+			template<typename T, typename... Ts>
+			constexpr void write_value( T const &value, Ts const &...values ) {
+				daw_json_ensure(
+				  m_current_state !=
+				      json_writer_details::json_writer_states::json_writer_object or
+				    m_is_key_written,
+				  ErrorReason::OutputError );
+				daw_json_ensure(
+				  m_current_state !=
+				      json_writer_details::json_writer_states::json_writer_nothing or
+				    m_is_first,
+				  ErrorReason::OutputError );
+				if constexpr( sizeof...( Ts ) == 0 ) {
+					do_write_value( value );
+				} else {
+					open_array( );
+					write_array_values( value, values... );
+					close_array( );
+				}
+			}
+
 			template<typename T>
-			constexpr void write_value( T const &value ) {
-				daw_json_ensure( m_current_state !=
-				                     json_writer_states::json_writer_object or
-				                   m_is_key_written,
-				                 ErrorReason::OutputError );
-				daw_json_ensure( m_current_state !=
-				                     json_writer_states::json_writer_nothing or
-				                   m_is_first,
-				                 ErrorReason::OutputError );
-				do_write_value( value );
+			constexpr void write_value( std::initializer_list<T> const &values ) {
+				daw_json_ensure(
+				  m_current_state !=
+				      json_writer_details::json_writer_states::json_writer_object or
+				    m_is_key_written,
+				  ErrorReason::OutputError );
+				daw_json_ensure(
+				  m_current_state !=
+				      json_writer_details::json_writer_states::json_writer_nothing or
+				    m_is_first,
+				  ErrorReason::OutputError );
+				open_array( );
+				write_array_values( values );
+				close_array( );
+			}
+
+			template<std::size_t N>
+			constexpr void write_value( char const ( &str )[N] ) {
+				daw_json_ensure(
+				  m_current_state !=
+				      json_writer_details::json_writer_states::json_writer_object or
+				    m_is_key_written,
+				  ErrorReason::OutputError );
+				daw_json_ensure(
+				  m_current_state !=
+				      json_writer_details::json_writer_states::json_writer_nothing or
+				    m_is_first,
+				  ErrorReason::OutputError );
+				do_write_value( daw::string_view( str, N - 1 ) );
+			}
+
+			constexpr void add_key( daw::string_view name ) {
+				if( m_is_key_written ) {
+					write_value( nullptr );
+				}
+				daw_json_ensure(
+				  m_current_state ==
+				    json_writer_details::json_writer_states::json_writer_object,
+				  ErrorReason::OutputError );
+
+				write_item_prefix( );
+				m_writer.write( "\"", name, "\":", m_writer.space );
+				m_is_key_written = true;
+			}
+
+			constexpr void write_key_value( daw::string_view name, std::nullptr_t ) {
+				add_key( name );
+				write_null( );
+			}
+
+			template<typename T>
+			constexpr void write_key_value( daw::string_view name,
+			                                std::initializer_list<T> const &values ) {
+				add_key( name );
+				open_array( );
+				write_array_values( values );
+				close_array( );
+			}
+
+			template<typename T, typename... Ts>
+			constexpr void write_key_value( daw::string_view name, T const &value,
+			                                Ts const &...values ) {
+				add_key( name );
+				if( sizeof...( Ts ) == 0 ) {
+					write_value( value );
+				} else {
+					open_array( );
+					write_array_values( value, values... );
+					close_array( );
+				}
+			}
+
+			template<std::size_t N>
+			constexpr void write_key_value( daw::string_view name,
+			                                char const ( &str )[N] ) {
+				add_key( name );
+				write_value( daw::string_view( str, N - 1 ) );
+			}
+
+			// Must be in array state
+			template<
+			  typename Range DAW_ENABLEIF( daw::traits::is_container_like_v<Range> )>
+			DAW_REQUIRES( daw::traits::is_container_like_v<Range> )
+			constexpr void write_array_values( Range const &values ) {
+				daw_json_ensure(
+				  m_current_state ==
+				    json_writer_details::json_writer_states::json_writer_array,
+				  ErrorReason::OutputError );
+				for( auto const &value : values ) {
+					do_write_value( value );
+				}
+			}
+
+			template<typename T>
+			constexpr void
+			write_array_values( std::initializer_list<T> const &values ) {
+				daw_json_ensure(
+				  m_current_state ==
+				    json_writer_details::json_writer_states::json_writer_array,
+				  ErrorReason::OutputError );
+				for( auto const &value : values ) {
+					write_value( value );
+				}
+			}
+
+			template<typename T, typename... Ts>
+			constexpr void write_array_values( T const &value, Ts const &...values ) {
+				daw_json_ensure(
+				  m_current_state ==
+				    json_writer_details::json_writer_states::json_writer_array,
+				  ErrorReason::OutputError );
+				write_value( value );
+				(void)( ( write_value( values ), true ) and ... );
 			}
 
 			constexpr void write_boolean( bool b ) {
@@ -203,10 +340,11 @@ namespace daw::json {
 			}
 
 			constexpr void write_null( ) {
-				daw_json_ensure( m_current_state !=
-				                     json_writer_states::json_writer_nothing or
-				                   m_is_first,
-				                 ErrorReason::OutputError );
+				daw_json_ensure(
+				  m_current_state !=
+				      json_writer_details::json_writer_states::json_writer_nothing or
+				    m_is_first,
+				  ErrorReason::OutputError );
 				prepare_value( );
 				m_writer.write( "null" );
 				m_is_first = false;
@@ -257,100 +395,12 @@ namespace daw::json {
 			constexpr void write_string( char const ( &str )[N] ) {
 				write_value( daw::string_view( str, N - 1 ) );
 			}
-
-			template<std::size_t N>
-			constexpr void write_value( char const ( &str )[N] ) {
-				daw_json_ensure( m_current_state !=
-				                     json_writer_states::json_writer_object or
-				                   m_is_key_written,
-				                 ErrorReason::OutputError );
-				daw_json_ensure( m_current_state !=
-				                     json_writer_states::json_writer_nothing or
-				                   m_is_first,
-				                 ErrorReason::OutputError );
-				do_write_value( daw::string_view( str, N - 1 ) );
-			}
-
-			constexpr void write_value( std::nullptr_t ) {
-				write_null( );
-			}
-
-			// Must be in array state
-			template<
-			  typename Range DAW_ENABLEIF( daw::traits::is_container_like_v<Range> )>
-			DAW_REQUIRES( daw::traits::is_container_like_v<Range> )
-			constexpr void write_values( Range const &values ) {
-				daw_json_ensure( m_current_state ==
-				                   json_writer_states::json_writer_array,
-				                 ErrorReason::OutputError );
-				for( auto const &value : values ) {
-					do_write_value( value );
-				}
-			}
-
-			template<typename T>
-			constexpr void write_values( std::initializer_list<T> const &values ) {
-				daw_json_ensure( m_current_state ==
-				                   json_writer_states::json_writer_array,
-				                 ErrorReason::OutputError );
-				for( auto const &value : values ) {
-					write_value( value );
-				}
-			}
-
-			template<typename... Ts>
-			constexpr void write_values( Ts const &...values ) {
-				daw_json_ensure( m_current_state ==
-				                   json_writer_states::json_writer_array,
-				                 ErrorReason::OutputError );
-				(void)( ( write_value( values ), true ) and ... );
-			}
-
-			constexpr void add_key( daw::string_view name ) {
-				if( m_is_key_written ) {
-					write_value( nullptr );
-				}
-				daw_json_ensure( m_current_state ==
-				                   json_writer_states::json_writer_object,
-				                 ErrorReason::OutputError );
-
-				write_item_prefix( );
-				m_writer.write( "\"", name, "\":", m_writer.space );
-				m_is_key_written = true;
-			}
-
-			template<typename T>
-			constexpr void write_key_value( daw::string_view name, T const &value ) {
-				add_key( name );
-				write_value( value );
-			}
-
-			constexpr void write_key_value( daw::string_view name, std::nullptr_t ) {
-				add_key( name );
-				write_value( nullptr );
-			}
-
-			template<typename T>
-			constexpr void write_key_value( daw::string_view name,
-			                                std::initializer_list<T> const &values ) {
-				add_key( name );
-				open_array( );
-				write_values( values );
-				close_array( );
-			}
-
-			template<std::size_t N>
-			constexpr void write_key_value( daw::string_view name,
-			                                char const ( &str )[N] ) {
-				add_key( name );
-				write_value( daw::string_view( str, N - 1 ) );
-			}
 		};
 
 		template<auto... PolicyFlags, typename WriterType>
 		constexpr auto json_writer( WriterType &writer ) {
 			return json_writer_t<WriterType,
-			                     std::vector<json_writer_states>,
+			                     std::vector<json_writer_details::json_writer_states>,
 			                     PolicyFlags...>( writer );
 		}
 	} // namespace DAW_JSON_VER

--- a/include/daw/json/daw_json_writer.h
+++ b/include/daw/json/daw_json_writer.h
@@ -15,6 +15,10 @@
 #include "daw/json/concepts/daw_writable_output.h"
 #include "daw/json/daw_json_link.h"
 
+#include <daw/daw_move.h>
+#include <daw/traits/daw_traits_remove_cvref.h>
+
+#include <type_traits>
 #include <vector>
 
 namespace daw::json {
@@ -43,11 +47,11 @@ namespace daw::json {
 			};
 		} // namespace json_writer_details
 
-		template<typename WriterType, typename StackType, auto... PolicyFlags>
+		template<typename WritableType, typename StackType, auto... PolicyFlags>
 		class json_writer_t {
 			using iterator_t =
 			  decltype( json_details::make_output_iterator<PolicyFlags...>(
-			    std::declval<WriterType>( ) ) );
+			    std::declval<WritableType>( ) ) );
 
 			StackType m_stack{ };
 			json_writer_details::json_writer_states m_current_state =
@@ -104,9 +108,10 @@ namespace daw::json {
 			}
 
 		public:
-			explicit constexpr json_writer_t( WriterType &writer )
-			  : m_writer(
-			      json_details::make_output_iterator<PolicyFlags...>( writer ) ) {}
+			template<typename W>
+			explicit constexpr json_writer_t( W &&writer )
+			  : m_writer( json_details::make_output_iterator<PolicyFlags...>(
+			      DAW_FWD( writer ) ) ) {}
 			json_writer_t( json_writer_t const & ) = delete;
 			json_writer_t &operator=( json_writer_t const & ) = delete;
 			json_writer_t( json_writer_t &&other ) = delete;
@@ -398,8 +403,8 @@ namespace daw::json {
 		};
 
 		template<auto... PolicyFlags, typename WriterType>
-		constexpr auto json_writer( WriterType &writer ) {
-			return json_writer_t<WriterType,
+		constexpr auto json_writer( WriterType &&writer ) {
+			return json_writer_t<daw::remove_cvref_t<WriterType>,
 			                     std::vector<json_writer_details::json_writer_states>,
 			                     PolicyFlags...>( writer );
 		}

--- a/include/daw/json/impl/version.h
+++ b/include/daw/json/impl/version.h
@@ -17,9 +17,9 @@
 #if not defined( DAW_JSON_VER_OVERRIDE )
 // Should be updated when a potential ABI break is anticipated
 #if defined( DEBUG ) or not defined( NDEBUG )
-#define DAW_JSON_VER v3_32_2d
+#define DAW_JSON_VER v3_33_0d
 #else
-#define DAW_JSON_VER v3_32_2
+#define DAW_JSON_VER v3_33_0
 #endif
 #else
 #define DAW_JSON_VER DAW_JSON_VER_OVERRIDE

--- a/tests/src/daw_json_writer_test.cpp
+++ b/tests/src/daw_json_writer_test.cpp
@@ -10,6 +10,7 @@
 
 #include <daw/json/daw_json_writer.h>
 
+#include <cstdio>
 #include <iostream>
 #include <string>
 
@@ -155,7 +156,7 @@ int main( ) {
 			for( int n = 1; n <= 3; ++n ) {
 				w.write_value( n * 2 );
 			}
-			w.write_values( { 1, 2, 3 } );
+			w.write_array_values( { 1, 2, 3 } );
 			w.close_array( );
 			w.close_object( );
 		}
@@ -168,9 +169,9 @@ int main( ) {
 			w.open_object( );
 			w.add_key( "a" );
 			w.open_array( );
-			w.write_values( 1, 2, "3", 4 );
+			w.write_array_values( 1, 2, "3", 4 );
 			w.write_value( "5" );
-			w.write_values( { 6, 7 } );
+			w.write_array_values( { 6, 7 } );
 			w.close_array( );
 			w.close_object( );
 		}
@@ -240,5 +241,21 @@ int main( ) {
 			w.write_string( "Hello" );
 		}
 		daw_ensure( out == R"json("Hello")json" );
+	}
+	{
+		auto w = daw::json::json_writer( stdout );
+		w.open_object( );
+		w.write_key_value( "a", 42 );
+		w.write_key_value( "b", 42, "Hello", 44 );
+		w.close_object( );
+		std::puts( "" );
+	}
+	{
+		auto w = daw::json::json_writer( std::cout );
+		w.open_object( );
+		w.write_key_value( "a", 42 );
+		w.write_key_value( "b", 42, "Hello", 44 );
+		w.close_object( );
+		std::cout << '\n';
 	}
 }

--- a/tests/src/daw_json_writer_test.cpp
+++ b/tests/src/daw_json_writer_test.cpp
@@ -6,9 +6,7 @@
 // Official repository: https://github.com/beached/daw_json_link
 //
 
-#include "daw/json/daw_json_switches.h"
-
-#include <daw/json/daw_json_writer.h>
+#include "daw/json/daw_json_writer.h"
 
 #include <cstdio>
 #include <iostream>
@@ -34,6 +32,23 @@ namespace daw::json {
 		}
 	};
 } // namespace daw::json
+
+#if defined( DAW_JSON_HAS_CPP20_CX_STRING )
+consteval bool constexpr_test( ) {
+	auto out = std::string{ };
+	{
+		auto w = daw::json::json_writer( out );
+		w.open_object( );
+		w.write_key_value( "a", 42 );
+		w.write_key_value( "b", { 1, 2, 3 } );
+		w.write_key_value( "c", nullptr );
+		daw_ensure( out == R"json({"a":42,"b":[1,2,3],"c":null)json" );
+	}
+	daw_ensure( out == R"json({"a":42,"b":[1,2,3],"c":null})json" );
+	return true;
+}
+static_assert( constexpr_test( ) );
+#endif
 
 int main( ) {
 	{
@@ -242,6 +257,7 @@ int main( ) {
 		}
 		daw_ensure( out == R"json("Hello")json" );
 	}
+#if not defined( _WIN32 )
 	{
 		auto w = daw::json::json_writer( stdout );
 		w.open_object( );
@@ -258,4 +274,5 @@ int main( ) {
 		w.close_object( );
 		std::cout << '\n';
 	}
+#endif
 }


### PR DESCRIPTION
Refactor `json_writer_t` to normalize the api of write_key_value/write_value/write_array_values.  Renamed write_values to write_array_values.  Moved state enum to private namespace