### PR TITLE
Documentation and testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-				 VERSION "3.34.1"
+				 VERSION "3.35.0"
 				 DESCRIPTION "Static JSON parsing in C++"
 				 HOMEPAGE_URL "https://github.com/beached/daw_json_link"
 				 LANGUAGES C CXX )

--- a/docs/cookbook/dates.md
+++ b/docs/cookbook/dates.md
@@ -140,7 +140,9 @@ namespace daw::json {
     using type = json_member_list<
       json_string<"title">, 
       json_number<"id", unsigned>,
-    json_number<"dateAdded", int64_t, LiteralAsStringOpt::Always>,
+      json_number<
+        "dateAdded", int64_t,
+        options::number_opt( options::LiteralAsStringOpt::Always )>,
     json_number<"lastModified", int64_t>>;
 
   static inline auto to_json_data( daw::cookbook_dates3::MyClass3 const &v ) {

--- a/docs/cookbook/graphs.md
+++ b/docs/cookbook/graphs.md
@@ -86,15 +86,21 @@ namespace daw::json {
   template<>
   struct json_data_contract<GraphNode> {
     using type = json_member_list<
-      json_number<"id", size_t, LiteralAsStringOpt::Always>,
+      json_number<
+        "id", size_t,
+        options::number_opt( options::LiteralAsStringOpt::Always )>,
       json_class<"metadata", Metadata>>;
   };
 
   template<>
   struct json_data_contract<GraphEdge> {
     using type = json_member_list<
-      json_number<"source", size_t, LiteralAsStringOpt::Always>,
-      json_number<"target", size_t, LiteralAsStringOpt::Always>>;
+      json_number<
+        "source", size_t,
+        options::number_opt( options::LiteralAsStringOpt::Always )>,
+      json_number<
+        "target", size_t,
+        options::number_opt( options::LiteralAsStringOpt::Always )>>;
   };
 } 
 

--- a/docs/cookbook/json_nullable.md
+++ b/docs/cookbook/json_nullable.md
@@ -2,6 +2,13 @@
 
 nullable types are supported by using the `json_nullable` mapping type or appending the type name with `_null` to use the convenience wrapper. The requirement of the underlying type is that it will be default constructable for null values or support the [Nullable Concept](nullable_value_concept.md).
 
+Named `_null` mappings accept a `JsonNullable` template argument that controls
+how an empty value is serialized when it is a class member:
+
+- `JsonNullable::Nullable` (the default) permits the entire member to be omitted.
+- `JsonNullable::NullVisible` always emits the member, using `null` for an empty
+  value.
+
 Take the following JSON
 
 ```json
@@ -37,7 +44,8 @@ namespace daw::json {
       json_bool_null<
         "member2", 
         std::unique_ptr<bool>, 
-        LiteralAsStringOpt::NoEscapedDblQuote, 
+        options::bool_opt( options::LiteralAsStringOpt::Never ),
+        JsonNullable::Nullable,
         UniquePtrConstructor<bool>
       >
     >;

--- a/docs/cookbook/mapping_overview.md
+++ b/docs/cookbook/mapping_overview.md
@@ -15,7 +15,7 @@ Maps JSON arrays to C++ container types.
 
 Maps JSON arrays/size member to C++ container types. This allows easier mapping to types like `unique_ptr`. Precautions should be taken that the input is trusted or validated in the Constructor type to prevent resource exhaustion.
 
-### `json_boolean`
+### `json_bool`
 
 Maps JSON boolean values to C++ boolean/integral types.
 
@@ -87,13 +87,74 @@ Maps JSON values that may be one of serveral types to C++ type(s). A switcher ty
 
 Maps JSON values that may be one of serveral types to C++ type(s). A switcher type that inspects a sub member to determine which alternative is required.
 
+## Mapping Template Parameters
+
+Named mappings use the JSON member name as their first template parameter.
+The remaining parameters are summarized below; parameters shown with `= ...`
+have defaults. `use_default` asks the library to deduce the mapping or use its
+standard constructor.
+
+| Mapping | Template parameters after `Name` |
+| --- | --- |
+| `json_class` | `T, Constructor = use_default` |
+| `json_number` | `T = double, Options = number_opts_def, Constructor = use_default` |
+| `json_checked_number` | `T = double, Options = number_opts_def, Constructor = use_default` |
+| `json_bool` | `T = bool, Options = bool_opts_def, Constructor = use_default` |
+| `json_string` | `String = std::string, Options = string_opts_def, Constructor = use_default` |
+| `json_string_raw` | `String = std::string, Options = string_raw_opts_def, Constructor = use_default` |
+| `json_date` | `T = system_clock time_point, Constructor = use_default` |
+| `json_array` | `JsonElement, Container = use_default, Constructor = use_default` |
+| `json_sized_array` | `JsonElement, SizeMember, Container = use_default, Constructor = use_default` |
+| `json_key_value` | `Container, JsonValueType = use_default, JsonKeyType = use_default, Constructor = use_default` |
+| `json_key_value_array` | `Container, JsonValueType = use_default, JsonKeyType = use_default, Constructor = use_default` |
+| `json_tuple` | `Tuple, JsonTupleTypesList = use_default, Constructor = use_default` |
+| `json_variant` | `Variant, JsonElements = use_default, Constructor = use_default` |
+| `json_tagged_variant` | `T, TagMember, Switcher, JsonElements = use_default, Constructor = use_default` |
+| `json_intrusive_variant` | `Variant, TagMember, Switcher, JsonElements = use_default, Constructor = use_default` |
+| `json_custom` | `T, FromJsonConverter = use_default, ToJsonConverter = use_default, Options = json_custom_opts_def` |
+| `json_raw` | `T = json_value, Constructor = use_default` |
+| `json_nullable` | `T, JsonMember = use_default, NullableType = JsonNullable::Nullable, Constructor = use_default` |
+
+`Options` is an encoded `json_options_t` value. Build it with the setter for
+the mapping family: `options::number_opt`, `bool_opt`, `string_opt`,
+`string_raw_opt`, or `json_custom_opt`. The available flags and defaults are
+listed in [Member Options/Type Options](member_options.md).
+
+`JsonElement`, `JsonValueType`, `JsonKeyType`, `JsonTupleTypesList`, and
+`JsonElements` accept explicit mappings when deduction is not appropriate.
+Array elements and object keys/values use unnamed mappings such as
+`json_number_no_name<int>`.
+
+`Constructor` is a callable used in place of the standard construction step.
+For scalar mappings it accepts the parsed scalar. Container and class mappings
+use the arguments described by that mapping's declaration. Nullable mappings
+use it to construct the outer nullable result.
+
+### Nullable convenience mappings
+
+Named aliases ending in `_null` add this parameter before `Constructor`:
+
+```cpp
+JsonNullable NullableType = JsonNullable::Nullable
+```
+
+Their value type is the wrapped/nullable type, such as `std::optional<int>`.
+`JsonNullable::Nullable` permits an empty class member to be omitted;
+`JsonNullable::NullVisible` emits that member as `null`. See
+[Nullable JSON Values](json_nullable.md).
+
+Unnamed nullable aliases ending in `_null_no_name` always preserve an empty
+value as the JSON literal `null`, because an array element or root value cannot
+be omitted. They therefore do not expose a `JsonNullable` parameter.
+
 ## Understanding _null and _no_name Variants
 
 ### Nullable mappings end in `_null`
 
 The `_null` variant allows the mapped value to be nullable.
 Useful when the JSON field may or may not be present.
-Maps to std::optional in C++, effectively allowing an absence of the value.
+The wrapped C++ type is supplied explicitly and may be `std::optional`, a smart
+pointer, or another type satisfying the nullable-value requirements.
 
 ### Unnamed mappings end in `_no_name`
 
@@ -103,4 +164,5 @@ These mappings provide robust and flexible ways to handle different JSON structu
 
 ### Unnamed nullable mappings `_null_no_name`
 
-The `_null_no_name` variants combine a nullable type without a name.
+The `_null_no_name` variants combine a nullable type without a name. Empty
+values serialize as `null`.

--- a/docs/cookbook/member_options.md
+++ b/docs/cookbook/member_options.md
@@ -20,6 +20,10 @@ Controls the ability to parse numbers that are encoded as strings.
 * `Maybe` - Allow parsing this member as a string or number.
 * `Always` - Only allow parsing this member as a string. It is an error for this member to not be encoded as a string.
 
+### Default
+
+* `Never`
+
 ## `JsonRangeCheck`
 
 ### Values
@@ -75,7 +79,7 @@ Controls the ability to parse booleans that are encoded as strings.
 ### Values
 
 * `Never` - Never allow parsing this member as a string. It is a parser error if this member is encoded as a string
-* `Maybe` - Allow parsing this member as a string or number.
+* `Maybe` - Allow parsing this member as a string or boolean literal.
 * `Always` - Only allow parsing this member as a string. It is an error for this member to not be encoded as a string.
 
 ### Default
@@ -152,9 +156,9 @@ Custom JSON types can be Strings(default), unquoted Literals, or a mix.
 
 * `String` - Parser always expects a JSON string. Will surround serialized value with double quotes
 * `Literal` - Parser will expect a valid JSON literal number, bool, null
-* `Any` (Experimental) Parser will return any valid JSON value excluding leading whitespace. strings will be quoted.
+* `Any` (Experimental) - Parser will return any valid JSON value excluding leading whitespace. Strings remain quoted.
   `Any` is suitable for constructing a `json_value` to allow adhoc parsing if `json_raw` is not suitable
 
 ### Default
 
-* String 
+* `String`

--- a/include/daw/json/daw_json_link_types.h
+++ b/include/daw/json/daw_json_link_types.h
@@ -507,11 +507,10 @@ namespace daw::json {
 
 		template<typename T = std::optional<double>,
 		         json_options_t Options = number_opts_def,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_number_null_no_name = json_base::json_nullable<
 		  T, json_base::json_number<json_details::unwrapped_t<T>, Options>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		/**
 		 * The member is a range checked number
@@ -535,7 +534,6 @@ namespace daw::json {
 		 */
 		template<typename T = std::optional<double>,
 		         json_options_t Options = number_opts_def,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_checked_number_null_no_name = json_base::json_nullable<
 		  T,
@@ -543,7 +541,7 @@ namespace daw::json {
 		    json_details::unwrapped_t<T>,
 		    json_details::number_opts_set<
 		      Options, options::JsonRangeCheck::CheckForNarrowing>>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			template<typename T, json_options_t Options, typename Constructor>
@@ -600,11 +598,10 @@ namespace daw::json {
 
 		template<typename T = std::optional<bool>,
 		         json_options_t Options = bool_opts_def,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_bool_null_no_name = json_base::json_nullable<
 		  T, json_base::json_bool<json_details::unwrapped_t<T>, Options>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			/// String - A raw string as is.  Escapes are left in.
@@ -667,11 +664,10 @@ namespace daw::json {
 
 		template<typename T = std::optional<std::string>,
 		         json_options_t Options = string_raw_opts_def,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_string_raw_null_no_name = json_base::json_nullable<
 		  T, json_base::json_string_raw<json_details::unwrapped_t<T>, Options>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			template<typename String, json_options_t Options, typename Constructor>
@@ -726,11 +722,10 @@ namespace daw::json {
 
 		template<typename T = std::optional<std::string>,
 		         json_options_t Options = string_opts_def,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_string_null_no_name = json_base::json_nullable<
 		  T, json_base::json_string<json_details::unwrapped_t<T>, Options>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			template<typename T, typename Constructor>
@@ -771,11 +766,10 @@ namespace daw::json {
 		template<typename T, typename Constructor = use_default>
 		using json_date_no_name = json_base::json_date<T, Constructor>;
 
-		template<typename T, JsonNullable NullableType = JsonNullable::Nullable,
-		         typename Constructor = use_default>
+		template<typename T, typename Constructor = use_default>
 		using json_date_null_no_name = json_base::json_nullable<
-		  T, json_base::json_date<json_details::unwrapped_t<T>>, NullableType,
-		  Constructor>;
+		  T, json_base::json_date<json_details::unwrapped_t<T>>,
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			/// @brief Mark a member as nullable
@@ -902,11 +896,10 @@ namespace daw::json {
 		template<typename T, typename Constructor = use_default>
 		using json_class_no_name = json_base::json_class<T, Constructor>;
 
-		template<typename T, JsonNullable NullableType = JsonNullable::Nullable,
-		         typename Constructor = use_default>
+		template<typename T, typename Constructor = use_default>
 		using json_class_null_no_name = json_base::json_nullable<
-		  T, json_base::json_class<json_details::unwrapped_t<T>>, NullableType,
-		  Constructor>;
+		  T, json_base::json_class<json_details::unwrapped_t<T>>,
+		  JsonNullable::NullVisible, Constructor>;
 
 #if defined( DAW_JSON_HAS_REFLECTION )
 		/**
@@ -1074,12 +1067,11 @@ namespace daw::json {
 		  json_base::json_variant<Variant, JsonElements, Constructor>;
 
 		template<typename Variant, typename JsonElements = use_default,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_variant_null_no_name = json_base::json_nullable<
 		  Variant,
 		  json_base::json_variant<json_details::unwrapped_t<Variant>, JsonElements>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			template<typename T, typename TagMember, typename Switcher,
@@ -1174,13 +1166,12 @@ namespace daw::json {
 
 		template<typename T, typename TagMember, typename Switcher,
 		         typename JsonElements = use_default,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_tagged_variant_null_no_name = json_base::json_nullable<
 		  T,
 		  json_base::json_tagged_variant<json_details::unwrapped_t<T>, TagMember,
 		                                 Switcher, JsonElements>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			template<typename T, typename FromJsonConverter, typename ToJsonConverter,
@@ -1260,18 +1251,16 @@ namespace daw::json {
 		template<typename T, typename FromJsonConverter = use_default,
 		         typename ToJsonConverter = use_default,
 		         json_options_t Options = json_custom_opts_def,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_custom_null_no_name = json_base::json_nullable<
 		  T,
 		  json_base::json_custom<json_details::unwrapped_t<T>, FromJsonConverter,
 		                         ToJsonConverter, Options>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		template<typename T, typename FromJsonConverter = use_default,
 		         typename ToJsonConverter = use_default,
 		         json_options_t Options = json_custom_opts_def,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_custom_lit_null_no_name = json_base::json_nullable<
 		  T,
@@ -1279,7 +1268,7 @@ namespace daw::json {
 		                         ToJsonConverter,
 		                         json_details::json_custom_opts_set<
 		                           Options, options::JsonCustomTypes::Literal>>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			template<typename JsonElement, typename Container, typename Constructor>
@@ -1343,13 +1332,12 @@ namespace daw::json {
 		  json_base::json_array<JsonElement, Container, Constructor>;
 
 		template<typename JsonElement, typename WrappedContainer,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_array_null_no_name = json_base::json_nullable<
 		  WrappedContainer,
 		  json_base::json_array<JsonElement,
 		                        json_details::unwrapped_t<WrappedContainer>>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			template<typename JsonElement, typename SizeMember,
@@ -1434,13 +1422,12 @@ namespace daw::json {
 
 		template<typename JsonElement, typename SizeMember,
 		         typename WrappedContainer,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_sized_array_null_no_name = json_base::json_nullable<
 		  WrappedContainer,
 		  json_base::json_sized_array<JsonElement, SizeMember,
 		                              json_details::unwrapped_t<WrappedContainer>>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			template<typename Container, typename JsonValueType, typename JsonKeyType,
@@ -1541,13 +1528,12 @@ namespace daw::json {
 		           WrappedContainer>::mapped_type,
 		         typename JsonKeyType =
 		           typename json_details::unwrapped_t<WrappedContainer>::key_type,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_key_value_null_no_name = json_base::json_nullable<
 		  WrappedContainer,
 		  json_base::json_key_value<json_details::unwrapped_t<WrappedContainer>,
 		                            JsonValueType, JsonKeyType>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			template<typename Container, typename JsonValueType, typename JsonKeyType,
@@ -1640,14 +1626,13 @@ namespace daw::json {
 
 		template<typename WrappedContainer, typename JsonValueType = use_default,
 		         typename JsonKeyType = use_default,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_key_value_array_null_no_name =
 		  json_base::json_nullable<WrappedContainer,
 		                           json_base::json_key_value_array<
 		                             json_details::unwrapped_t<WrappedContainer>,
 		                             JsonValueType, JsonKeyType>,
-		                           NullableType, Constructor>;
+		                           JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			template<typename Tuple, typename JsonTupleTypesList,
@@ -1699,12 +1684,10 @@ namespace daw::json {
 		  json_base::json_tuple<Tuple, Constructor, JsonTupleTypesList>;
 
 		template<typename WrappedTuple, typename JsonTupleTypesList = use_default,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_tuple_null_no_name = json_base::json_nullable<
 		  WrappedTuple, JsonTupleTypesList,
-		  //		  json_base::json_tuple<json_details::unwrapped_t<WrappedTuple>>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
 			template<typename Variant, typename TagMember, typename Switcher,
@@ -1807,13 +1790,12 @@ namespace daw::json {
 
 		template<typename T, typename TagMember, typename Switcher,
 		         typename JsonElements = use_default,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_intrusive_variant_null_no_name = json_base::json_nullable<
 		  T,
 		  json_base::json_intrusive_variant<json_details::unwrapped_t<T>, TagMember,
 		                                    Switcher, JsonElements>,
-		  NullableType, Constructor>;
+		  JsonNullable::NullVisible, Constructor>;
 
 		/***
 		 * A name/value pair of string_view/json_value.  This is used for iterating
@@ -1944,10 +1926,9 @@ namespace daw::json {
 		 * @tparam Constructor A callable used to construct T.
 		 */
 		template<typename T = std::optional<json_value>,
-		         JsonNullable NullableType = JsonNullable::Nullable,
 		         typename Constructor = use_default>
 		using json_raw_null_no_name = json_base::json_nullable<
-		  T, json_base::json_raw<json_details::unwrapped_t<T>>, NullableType,
+		  T, json_base::json_raw<json_details::unwrapped_t<T>>, JsonNullable::NullVisible,
 		  Constructor>;
 
 		template<json_options_t PolicyFlags, typename Allocator>

--- a/include/daw/json/daw_json_link_types.h
+++ b/include/daw/json/daw_json_link_types.h
@@ -1421,8 +1421,7 @@ namespace daw::json {
 		                              Constructor>;
 
 		template<typename JsonElement, typename SizeMember,
-		         typename WrappedContainer,
-		         typename Constructor = use_default>
+		         typename WrappedContainer, typename Constructor = use_default>
 		using json_sized_array_null_no_name = json_base::json_nullable<
 		  WrappedContainer,
 		  json_base::json_sized_array<JsonElement, SizeMember,
@@ -1678,15 +1677,27 @@ namespace daw::json {
 			  json_base::json_tuple<Tuple, JsonTupleTypesList, Constructor>;
 		};
 
-		template<typename Tuple, typename Constructor = use_default,
-		         typename JsonTupleTypesList = use_default>
+		/// @brief Map an unnamed tuple-like value to a JSON heterogeneous array
+		/// @tparam Tuple Tuple-like C++ type to parse to
+		/// @tparam JsonTupleTypesList Explicit element mappings, or use_default to
+		/// deduce them from Tuple
+		/// @tparam Constructor Callable used to construct Tuple
+		template<typename Tuple, typename JsonTupleTypesList = use_default,
+		         typename Constructor = use_default>
 		using json_tuple_no_name =
-		  json_base::json_tuple<Tuple, Constructor, JsonTupleTypesList>;
+		  json_base::json_tuple<Tuple, JsonTupleTypesList, Constructor>;
 
+		/// @brief Map an unnamed nullable tuple-like value
+		/// @tparam WrappedTuple Nullable tuple-like C++ type to parse to
+		/// @tparam JsonTupleTypesList Explicit element mappings, or use_default to
+		/// deduce them from WrappedTuple
+		/// @tparam Constructor Callable used to construct WrappedTuple
 		template<typename WrappedTuple, typename JsonTupleTypesList = use_default,
 		         typename Constructor = use_default>
 		using json_tuple_null_no_name = json_base::json_nullable<
-		  WrappedTuple, JsonTupleTypesList,
+		  WrappedTuple,
+		  json_base::json_tuple<json_details::unwrapped_t<WrappedTuple>,
+		                        JsonTupleTypesList>,
 		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
@@ -1845,6 +1856,8 @@ namespace daw::json {
 				static constexpr auto expected_type = JsonParseTypes::Unknown;
 				static constexpr auto base_expected_type = JsonParseTypes::Unknown;
 				static constexpr auto underlying_json_type = JsonBaseParseTypes::None;
+				static constexpr options::EightBitModes eight_bit_mode =
+				  options::EightBitModes::AllowFull;
 
 				template<JSONNAMETYPE NewName>
 				using with_name = daw::json::json_raw<NewName, T, Constructor>;
@@ -1860,6 +1873,8 @@ namespace daw::json {
 		 * allows for delaying the parsing of this member until later
 		 * @tparam Name json member name
 		 * @tparam T type to hold raw JSON data, defaults to json_value
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
 		 * @tparam Constructor A callable used to construct T.
 		 */
 		template<JSONNAMETYPE Name, typename T, typename Constructor>
@@ -1928,8 +1943,8 @@ namespace daw::json {
 		template<typename T = std::optional<json_value>,
 		         typename Constructor = use_default>
 		using json_raw_null_no_name = json_base::json_nullable<
-		  T, json_base::json_raw<json_details::unwrapped_t<T>>, JsonNullable::NullVisible,
-		  Constructor>;
+		  T, json_base::json_raw<json_details::unwrapped_t<T>>,
+		  JsonNullable::NullVisible, Constructor>;
 
 		template<json_options_t PolicyFlags, typename Allocator>
 		struct json_data_contract<basic_json_value<PolicyFlags, Allocator>> {

--- a/include/daw/json/daw_json_switches.h
+++ b/include/daw/json/daw_json_switches.h
@@ -286,7 +286,7 @@
 #define DAW_JSON_CPP26_CX_EXCEPT inline
 #endif
 
-#if defined( __cpp_lib_reflection )
+#if defined( __cpp_lib_reflection ) and not defined( DAW_JSON_NO_RELFECTION )
 #if __cpp_lib_reflection >= 202506L
 #define DAW_JSON_HAS_REFLECTION 1
 #endif

--- a/include/daw/json/daw_json_writer.h
+++ b/include/daw/json/daw_json_writer.h
@@ -15,6 +15,10 @@
 #include "daw/json/concepts/daw_writable_output.h"
 #include "daw/json/daw_json_link.h"
 
+#if defined( DAW_JSON_HAS_REFLECTION )
+#include <daw/daw_concepts.h>
+#endif
+
 #include <daw/daw_move.h>
 #include <daw/traits/daw_traits_remove_cvref.h>
 
@@ -415,6 +419,12 @@ namespace daw::json {
 			constexpr void write_string( char const ( &str )[N] ) {
 				write_value<JsonClass>( daw::string_view( str, N - 1 ) );
 			}
+
+#if defined( DAW_JSON_HAS_REFLECTION )
+			constexpr void write_enum_string( daw::EnumType auto e ) {
+				write_string( refl_details::enum_to_string( e ) );
+			}
+#endif
 		};
 
 		template<auto... PolicyFlags, typename WriterType>

--- a/include/daw/json/daw_json_writer.h
+++ b/include/daw/json/daw_json_writer.h
@@ -392,6 +392,7 @@ namespace daw::json {
 				}
 			}
 
+			/// When outputting a class, uses default to_json
 			template<typename JsonClass = use_default, typename T>
 			constexpr void write_string( T const &value ) {
 				using JsonMember =

--- a/include/daw/json/daw_json_writer.h
+++ b/include/daw/json/daw_json_writer.h
@@ -398,20 +398,18 @@ namespace daw::json {
 				  json_writer_details::json_write_value_class_t<JsonClass, T>;
 				constexpr JsonBaseParseTypes json_base_type =
 				  JsonMember::underlying_json_type;
-				static_assert(
-				  json_base_type == JsonBaseParseTypes::Number or
-				    json_base_type == JsonBaseParseTypes::Bool or
-				    json_base_type == JsonBaseParseTypes::String,
-				  "The underlying mapping must be a number, boolean, or string type" );
 				if constexpr( json_base_type == JsonBaseParseTypes::String ) {
 					write_value<JsonClass>( value );
-					return;
-				} else {
+				} else if constexpr( json_base_type == JsonBaseParseTypes::Bool or
+				                     json_base_type == JsonBaseParseTypes::Number ) {
 					prepare_value( );
 					m_writer.put( '"' );
 					to_json<JsonClass>( value, m_writer.get( ) );
 					m_writer.put( '"' );
 					m_is_first = false;
+				} else {
+					auto const tmp = to_json( value );
+					do_write_value<json_string_no_name<>>( tmp );
 				}
 			}
 

--- a/include/daw/json/impl/daw_json_link_types_fwd.h
+++ b/include/daw/json/impl/daw_json_link_types_fwd.h
@@ -46,6 +46,8 @@ namespace daw::json {
 		/// @tparam T type of the value being mapped to(e.g. std::optional<Foo>)
 		/// @tparam JsonMember Json Type or type of value when present, deduced from
 		/// T if not specified
+		/// @tparam NullableType Whether an empty class member may be omitted or must
+		/// be emitted as null
 		/// @tparam Constructor Specify a Constructor type or use
 		/// the default nullable_constructor<T>
 		template<JSONNAMETYPE Name, typename T, typename JsonMember = use_default,
@@ -87,6 +89,8 @@ namespace daw::json {
 		 * @tparam Name name of JSON member to link to
 		 * @tparam T type that has specialization of
 		 * daw::json::json_data_contract
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
 		 * @tparam Constructor A callable used to construct T.  The
 		 * default supports normal and aggregate construction
 		 */
@@ -103,10 +107,8 @@ namespace daw::json {
 		 * @tparam Name name of json member
 		 * @tparam T type of number(e.g. double, int, unsigned...) to pass to
 		 * Constructor
-		 * @tparam LiteralAsString Could this number be embedded in a string
+		 * @tparam Options Options created with options::number_opt
 		 * @tparam Constructor Callable used to construct result
-		 * @tparam RangeCheck Check if the value will fit in the result
-		 * @tparam Nullable Can the member be missing or have a null value
 		 */
 
 		template<JSONNAMETYPE Name, typename T = double,
@@ -119,9 +121,10 @@ namespace daw::json {
 		 * @tparam Name name of json member
 		 * @tparam T type of number(e.g. double, int, unsigned...) to pass to
 		 * Constructor
-		 * @tparam LiteralAsString Could this number be embedded in a string
+		 * @tparam Options Options created with options::number_opt
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
 		 * @tparam Constructor Callable used to construct result
-		 * @tparam RangeCheck Check if the value will fit in the result
 		 */
 		template<JSONNAMETYPE Name, typename T = std::optional<double>,
 		         json_options_t Options = number_opts_def,
@@ -135,9 +138,9 @@ namespace daw::json {
 		 * @tparam Name name of json member
 		 * @tparam T type of number(e.g. double, int, unsigned...) to pass to
 		 * Constructor
-		 * @tparam LiteralAsString Could this number be embedded in a string
+		 * @tparam Options Options created with options::number_opt; narrowing checks
+		 * are enabled by this alias
 		 * @tparam Constructor Callable used to construct result
-		 * @tparam Nullable Can the member be missing or have a null value
 		 */
 		template<JSONNAMETYPE Name, typename T = double,
 		         json_options_t Options = number_opts_def,
@@ -152,9 +155,8 @@ namespace daw::json {
 		 * The member is a boolean
 		 * @tparam Name name of json member
 		 * @tparam T result type to pass to Constructor
-		 * @tparam LiteralAsString Could this number be embedded in a string
+		 * @tparam Options Options created with options::bool_opt
 		 * @tparam Constructor Callable used to construct result
-		 * @tparam Nullable Can the member be missing or have a null value
 		 */
 		template<JSONNAMETYPE Name, typename T = bool,
 		         json_options_t Options = bool_opts_def,
@@ -165,7 +167,9 @@ namespace daw::json {
 		 * The member is a nullable boolean
 		 * @tparam Name name of json member
 		 * @tparam T result type to pass to Constructor
-		 * @tparam LiteralAsString Could this number be embedded in a string
+		 * @tparam Options Options created with options::bool_opt
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
 		 * @tparam Constructor Callable used to construct result
 		 */
 		template<JSONNAMETYPE Name, typename T = std::optional<bool>,
@@ -180,11 +184,9 @@ namespace daw::json {
 		 * Member is an escaped string and requires unescaping and escaping of
 		 * string data
 		 * @tparam Name of json member
-		 * @tparam String result type constructed by Constructor
-		 * @tparam Constructor a callable taking as arguments ( char const *,
-		 * std::size_t )
-		 * @tparam EightBitMode Allow filtering of characters with the MSB set
-		 * @tparam Nullable Can the member be missing or have a null value
+		 * @tparam T nullable result type constructed by Constructor
+		 * @tparam Options Options created with options::string_opt
+		 * @tparam Constructor Callable used to construct the result string
 		 */
 		template<JSONNAMETYPE Name, typename String = std::string,
 		         json_options_t Options = string_opts_def,
@@ -196,10 +198,10 @@ namespace daw::json {
 		 * of string data
 		 * @tparam Name of json member
 		 * @tparam String result type constructed by Constructor
-		 * @tparam Constructor a callable taking as arguments ( InputIterator,
-		 * InputIterator ).  If others are needed use the Constructor callable
-		 * convert
-		 * @tparam EightBitMode Allow filtering of characters with the MSB set
+		 * @tparam Options Options created with options::string_opt
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
+		 * @tparam Constructor Callable used to construct the result string
 		 */
 		template<JSONNAMETYPE Name, typename T = std::optional<std::string>,
 		         json_options_t Options = string_opts_def,
@@ -213,13 +215,8 @@ namespace daw::json {
 		 * string data
 		 * @tparam Name of json member
 		 * @tparam String result type constructed by Constructor
-		 * @tparam Constructor a callable taking as arguments ( char const *,
-		 * std::size_t )
-		 * @tparam EightBitMode Allow filtering of characters with the MSB set
-		 * arguments
-		 * @tparam Nullable Can the member be missing or have a null value
-		 * @tparam AllowEscape Tell parser if we know a \ or escape will be in the
-		 * data
+		 * @tparam Options Options created with options::string_raw_opt
+		 * @tparam Constructor Callable used to construct the result string
 		 */
 		template<JSONNAMETYPE Name, typename String = std::string,
 		         json_options_t Options = string_raw_opts_def,
@@ -231,12 +228,10 @@ namespace daw::json {
 		 * of string data.  Not all invalid codepoints are detected
 		 * @tparam Name of json member
 		 * @tparam T result type constructed by Constructor
-		 * @tparam Constructor a callable taking as arguments ( char const *,
-		 * std::size_t )
-		 * @tparam EightBitMode Allow filtering of characters with the MSB set
-		 * arguments
-		 * @tparam AllowEscape Tell parser if we know a \ or escape will be in the
-		 * data
+		 * @tparam Options Options created with options::string_raw_opt
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
+		 * @tparam Constructor Callable used to construct the result string
 		 */
 		template<JSONNAMETYPE Name, typename T = std::optional<std::string>,
 		         json_options_t Options = string_raw_opts_def,
@@ -251,7 +246,10 @@ namespace daw::json {
 		 * @tparam Name name of json member
 		 * @tparam T type of number(e.g. optional<double>, optional<int>,
 		 * optional<unsigned>...) to pass to Constructor
-		 * @tparam LiteralAsString Could this number be embedded in a string
+		 * @tparam Options Options created with options::number_opt; narrowing checks
+		 * are enabled by this alias
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
 		 * @tparam Constructor Callable used to construct result
 		 */
 		template<JSONNAMETYPE Name, typename T = std::optional<double>,
@@ -277,7 +275,6 @@ namespace daw::json {
 		 * basic types too
 		 *  @tparam Constructor A callable used to make Container, default will use
 		 * the Containers constructor.  Both normal and aggregate are supported
-		 * @tparam Nullable Can the member be missing or have a null value
 		 */
 		template<JSONNAMETYPE Name, typename Container,
 		         typename JsonValueType = use_default,
@@ -295,6 +292,8 @@ namespace daw::json {
 		 * mapped classes and enums(mapped to numbers)
 		 *  @tparam JsonKeyType type of key in kv pair.  As with value it supports
 		 * basic types too
+		 *  @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
 		 *  @tparam Constructor A callable used to make Container, default will use
 		 * the Containers constructor.  Both normal and aggregate are supported
 		 */
@@ -316,7 +315,6 @@ namespace daw::json {
 		 * @tparam Constructor A Callable used to construct a T.
 		 * Must accept a char pointer and size as argument to the date/time
 		 * string. The default is an iso8601 timestamp parser
-		 * @tparam Nullable Can the member be missing or have a null value
 		 */
 		template<JSONNAMETYPE Name,
 		         typename T = std::chrono::time_point<std::chrono::system_clock,
@@ -328,6 +326,8 @@ namespace daw::json {
 		 * Link to a JSON string representing a nullable date
 		 * @tparam Name name of JSON member to link to
 		 * @tparam T C++ type to construct, by default is a time_point
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
 		 * @tparam Constructor A Callable used to construct a T.
 		 * Must accept a char pointer and size as argument to the date/time string.
 		 */
@@ -357,14 +357,13 @@ namespace daw::json {
 		}
 		/** Link to a JSON array
 		 * @tparam Name name of JSON member to link to
-		 * @tparam Container type of C++ container being constructed(e.g.
-		 * vector<int>)
 		 * @tparam JsonElement Json type being parsed e.g. json_number,
 		 * json_string...
+		 * @tparam Container type of C++ container being constructed(e.g.
+		 * vector<int>); deduced from JsonElement by default
 		 * @tparam Constructor A callable used to make Container,
 		 * default will use the Containers constructor.  Both normal and aggregate
 		 * are supported
-		 * @tparam Nullable Can the member be missing or have a null value
 		 */
 		template<JSONNAMETYPE Name, typename JsonElement,
 		         typename Container = use_default,
@@ -373,10 +372,12 @@ namespace daw::json {
 
 		/** Link to a nullable JSON array
 		 * @tparam Name name of JSON member to link to
-		 * @tparam Container type of C++ container being constructed(e.g.
+		 * @tparam WrappedContainer nullable C++ container type being constructed(e.g.
 		 * vector<int>)
 		 * @tparam JsonElement Json type being parsed e.g. json_number,
 		 * json_string...
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
 		 * @tparam Constructor A callable used to make Container,
 		 * default will use the Containers constructor.  Both normal and aggregate
 		 * are supported
@@ -405,7 +406,6 @@ namespace daw::json {
 		 * type isn't specified, the key name defaults to "key"
 		 *  @tparam Constructor A callable used to make Container, default will use
 		 * the Containers constructor.  Both normal and aggregate are supported
-		 * @tparam Nullable Can the member be missing or have a null value
 		 */
 		template<JSONNAMETYPE Name, typename Container,
 		         typename JsonValueType = use_default,
@@ -424,6 +424,8 @@ namespace daw::json {
 		 * member name defaults to "value"
 		 *  @tparam JsonKeyType type of key in kv pair.  If specific json member
 		 * type isn't specified, the key name defaults to "key"
+		 *  @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
 		 *  @tparam Constructor A callable used to make Container, default will use
 		 * the Containers constructor.  Both normal and aggregate are supported
 		 */
@@ -449,8 +451,7 @@ namespace daw::json {
 		 * @tparam ToJsonConverter Returns a string from the value.  The default
 		 * requires a to_string( T const & ) overload that returns a String like
 		 * type
-		 * @tparam JsonRawType JSON type value is encoded as literal/string/any
-		 * @tparam Nullable Can the member be missing or have a null value
+		 * @tparam Options Options created with options::json_custom_opt
 		 */
 		template<JSONNAMETYPE Name, typename T,
 		         typename FromJsonConverter = use_default,
@@ -465,7 +466,10 @@ namespace daw::json {
 		 * @tparam FromJsonConverter Callable that accepts a std::string_view of the
 		 * range to parse
 		 * @tparam ToJsonConverter Returns a string from the value
-		 * @tparam JsonRawType JSON type value is encoded as literal/string
+		 * @tparam Options Options created with options::json_custom_opt
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
+		 * @tparam Constructor Callable used to construct the nullable result
 		 */
 		template<JSONNAMETYPE Name, typename WrappedT,
 		         typename FromJsonConverter = use_default,
@@ -481,6 +485,12 @@ namespace daw::json {
 
 		/***
 		 * @brief Allow parsing of a type that is a JSON literal and does not fit
+		 * @tparam Name Name of JSON member to link to
+		 * @tparam T type of value being constructed
+		 * @tparam FromJsonConverter Callable that converts the JSON text to T
+		 * @tparam ToJsonConverter Callable that converts T to JSON text
+		 * @tparam Options Options created with options::json_custom_opt; the literal
+		 * custom type is enabled by this alias
 		 */
 		template<JSONNAMETYPE Name, typename T,
 		         typename FromJsonConverter = use_default,
@@ -498,7 +508,11 @@ namespace daw::json {
 		 * @tparam FromJsonConverter Callable that accepts a std::string_view of the
 		 * range to parse
 		 * @tparam ToJsonConverter Returns a string from the value
-		 * @tparam JsonRawType JSON type value is encoded as literal/string
+		 * @tparam Options Options created with options::json_custom_opt; the literal
+		 * custom type is enabled by this alias
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
+		 * @tparam Constructor Callable used to construct the nullable result
 		 */
 		template<JSONNAMETYPE Name, typename WrappedT,
 		         typename FromJsonConverter = use_default,
@@ -606,11 +620,10 @@ namespace daw::json {
 		 * type(including their specialized keyvalue mappings) or
 		 * string-enum/int-enum.
 		 * @tparam Name name of JSON member to link to
-		 * @tparam T type of value to construct
+		 * @tparam Variant variant-like type to construct
 		 * @tparam JsonElements a json_variant_type_list
-		 * @tparam Constructor A callable used to construct T.  The
+		 * @tparam Constructor A callable used to construct Variant.  The
 		 * default supports normal and aggregate construction
-		 * @tparam Nullable Can the member be missing or have a null value	 *
 		 */
 		template<JSONNAMETYPE Name, typename Variant,
 		         typename JsonElements = use_default,
@@ -623,6 +636,8 @@ namespace daw::json {
 		 * @tparam WrappedVariant type that has specialization of
 		 * daw::json::json_data_contract
 		 * @tparam JsonElements a json_variant_type_list
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
 		 * @tparam Constructor A callable used to construct WrappedVariant.  The
 		 * default supports normal and aggregate construction
 		 */
@@ -642,6 +657,7 @@ namespace daw::json {
 		 * @tparam Name name of JSON member to link to
 		 * @tparam T type of value to construct
 		 * @tparam TagMember JSON element to pass to Switcher. Does not have to be
+		 * declared in the member list
 		 * declared in member list
 		 * @tparam Switcher A callable that returns an index into JsonElements when
 		 * passed the TagMember object in parent member list
@@ -649,7 +665,6 @@ namespace daw::json {
 		 * elements of T when T is a std::variant and they are all auto mappable
 		 * @tparam Constructor A callable used to construct T.  The
 		 * default supports normal and aggregate construction
-		 * @tparam Nullable Can the member be missing or have a null value	 *
 		 */
 		template<JSONNAMETYPE Name, typename T, typename TagMember,
 		         typename Switcher, typename JsonElements = use_default,
@@ -660,22 +675,29 @@ namespace daw::json {
 		 * Link to a variant like data type that is discriminated via another
 		 * member.
 		 * @tparam Name name of JSON member to link to
-		 * @tparam T type of value to construct
+		 * @tparam Variant variant-like type to construct
 		 * @tparam TagMember JSON element to pass to Switcher. Does not have to be
 		 * declared in member list
 		 * @tparam Switcher A callable that returns an index into JsonElements when
 		 * passed the TagMember object in parent member list
 		 * @tparam JsonElements a json_tagged_variant_type_list, defaults to type
-		 * elements of T when T is a std::variant and they are all auto mappable
-		 * @tparam Constructor A callable used to construct T.  The
+		 * elements of Variant when Variant is a std::variant and they are all auto
+		 * mappable
+		 * @tparam Constructor A callable used to construct Variant.  The
 		 * default supports normal and aggregate construction
-		 * @tparam Nullable Can the member be missing or have a null value	 *
 		 */
 		template<JSONNAMETYPE Name, typename Variant, typename TagMember,
 		         typename Switcher, typename JsonElements = use_default,
 		         typename Constructor = use_default>
 		struct json_intrusive_variant;
 
+		/** Link a JSON array to a container whose size is provided by another member
+		 * @tparam Name name of JSON member to link to
+		 * @tparam JsonElement JSON element type being parsed
+		 * @tparam SizeMember JSON member mapping that provides the array size
+		 * @tparam Container C++ container being constructed
+		 * @tparam Constructor Callable used to construct Container
+		 */
 		template<JSONNAMETYPE Name, typename JsonElement, typename SizeMember,
 		         typename Container = use_default,
 		         typename Constructor = use_default>
@@ -685,13 +707,16 @@ namespace daw::json {
 		 * Link to a nullable variant like data type that is discriminated via
 		 * another member.
 		 * @tparam Name name of JSON member to link to
-		 * @tparam T type of value to construct
+		 * @tparam WrappedVariant nullable variant-like type to construct
 		 * @tparam TagMember JSON element to pass to Switcher. Does not have to be
 		 * @tparam Switcher A callable that returns an index into JsonElements when
 		 * passed the TagMember object in parent member list
 		 * @tparam JsonElements a json_tagged_variant_type_list, defaults to type
-		 * elements of T when T is a std::variant and they are all auto mappable
-		 * @tparam Constructor A callable used to construct T.  The
+		 * elements of WrappedVariant when it is a std::variant and they are all auto
+		 * mappable
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
+		 * @tparam Constructor A callable used to construct WrappedVariant.  The
 		 * default supports normal and aggregate construction
 		 */
 		template<JSONNAMETYPE Name, typename WrappedVariant, typename TagMember,
@@ -704,6 +729,8 @@ namespace daw::json {
 		                                 TagMember, Switcher, JsonElements>,
 		  NullableType, Constructor>;
 
+		/// @brief A list of JSON element mappings for a tuple-like type
+		/// @tparam Ts C++ types or unnamed JSON mappings for the tuple elements
 		template<typename... Ts>
 		struct json_tuple_types_list {
 			static_assert( json_details::all_have_deduced_type_v<Ts...>,
@@ -714,15 +741,21 @@ namespace daw::json {
 		/// @brief Map a tuple like type to a a JSON tuple/heterogeneous array
 		/// @tparam Name JSON member name to map to
 		/// @tparam Tuple tuple like type to parse to
+		/// @tparam JsonTupleTypesList either deduced or a json_tuple_type_list
 		/// @tparam Constructor A callable used to construct Tuple. The default
 		/// supports normal and aggregate construction
-		/// @tparam Options
-		/// @tparam JsonTupleTypesList either deduced or a json_tuple_type_list
 		template<JSONNAMETYPE Name, typename Tuple,
 		         typename JsonTupleTypesList = use_default,
 		         typename Constructor = use_default>
 		struct json_tuple;
 
+		/// @brief Map a nullable tuple-like type to a JSON heterogeneous array
+		/// @tparam Name JSON member name to map to
+		/// @tparam WrappedTuple nullable tuple-like type to parse to
+		/// @tparam JsonTupleTypesList either deduced or a json_tuple_type_list
+		/// @tparam NullableType Whether an empty class member may be omitted or must
+		/// be emitted as null
+		/// @tparam Constructor A callable used to construct WrappedTuple
 		template<JSONNAMETYPE Name, typename WrappedTuple,
 		         typename JsonTupleTypesList = use_default,
 		         JsonNullable NullableType = JsonNullable::Nullable,

--- a/include/daw/json/impl/daw_json_option_bits.h
+++ b/include/daw/json/impl/daw_json_option_bits.h
@@ -91,6 +91,11 @@ namespace daw::json {
 			static constexpr json_options_t
 			set_bits_for( JsonOptionList<OptionList...>, Option e );
 
+			template<typename... OptionList, typename Option, typename... Options>
+			constexpr json_options_t set_bits( JsonOptionList<OptionList...>,
+			                                   json_options_t value, Option pol,
+			                                   Options... pols );
+
 			template<typename... JsonOptions>
 			struct JsonOptionList {
 				using OptionList = typename option_list_impl<JsonOptions...>::type;
@@ -123,11 +128,12 @@ namespace daw::json {
 				static constexpr json_options_t options( Options... options ) {
 					static_assert( json_details::are_option_flags<Options...>,
 					               "Only registered option types are allowed" );
-					auto result = default_option_flag;
 					if constexpr( sizeof...( Options ) > 0 ) {
-						result |= ( set_bits_for( options ) | ... );
+						return set_bits( JsonOptionList{ }, default_option_flag,
+						                 options... );
+					} else {
+						return default_option_flag;
 					}
-					return result;
 				}
 			};
 

--- a/include/daw/json/impl/daw_json_parse_common.h
+++ b/include/daw/json/impl/daw_json_parse_common.h
@@ -217,7 +217,7 @@ namespace daw::json {
 			} // namespace container_detect
 
 			template<typename String>
-			DAW_CPP20_CONCEPT is_string_v = std::is_convertible_v<
+			DAW_CPP20_CONCEPT is_string_v = std::is_same_v<
 			  char, daw::detected_t<container_detect::is_string_test, String>>;
 
 			DAW_JSON_MAKE_REQ_TRAIT(
@@ -467,9 +467,11 @@ namespace daw::json {
 					// Allow empty/default constructible types to work without mapping
 					using type = json_details::json_empty_class<T>;
 					return daw::traits::identity<type>{ };
+#if not defined( DAW_JSON_HAS_REFLECTION )
 				} else if constexpr( can_convert_to_tuple_v<T> ) {
 					using type = json_base::json_tuple<T>;
 					return daw::traits::identity<type>{ };
+#endif
 				} else {
 					static_assert( daw::deduced_false_v<T>,
 					               "Could not deduced data contract type and there is no "

--- a/include/daw/json/impl/daw_json_parse_real.h
+++ b/include/daw/json/impl/daw_json_parse_real.h
@@ -357,15 +357,19 @@ namespace daw::json {
 						switch( *exp_first ) {
 						case '-':
 							++exp_first;
-							daw_json_assert_weak( exp_first < exp_last,
-							                      ErrorReason::InvalidNumber );
+							daw_json_assert_weak(
+							  exp_first < exp_last and parse_digit( *exp_first ) < 10U,
+							  ErrorReason::InvalidNumber );
 							return -1;
 						case '+':
-							daw_json_assert_weak( exp_first < exp_last,
-							                      ErrorReason::InvalidNumber );
 							++exp_first;
+							daw_json_assert_weak(
+							  exp_first < exp_last and parse_digit( *exp_first ) < 10U,
+							  ErrorReason::InvalidNumber );
 							return 1;
 						default:
+							daw_json_assert_weak( parse_digit( *exp_first ) < 10U,
+							                      ErrorReason::InvalidNumber );
 							return 1;
 						}
 					}( );
@@ -460,8 +464,6 @@ namespace daw::json {
 
 				[[maybe_unused]] daw::not_null<char const *> const orig_first =
 				  parse_state.first;
-				[[maybe_unused]] daw::not_null<char const *> const orig_last =
-				  parse_state.last;
 
 				auto const sign = static_cast<Result>(
 				  parse_policy_details::validate_signed_first( parse_state ) );
@@ -666,7 +668,7 @@ namespace daw::json {
 						} else {
 							static_assert( std::is_same_v<Result, long double> );
 							return json_details::parse_with_strtod<Result>( orig_first,
-							                                                orig_last );
+							                                                first );
 						}
 					}
 				}

--- a/include/daw/json/impl/daw_json_parse_value.h
+++ b/include/daw/json/impl/daw_json_parse_value.h
@@ -52,10 +52,12 @@ namespace daw::json {
 			 * In checked input, ensures State has more data.
 			 * @tparam literal_as_string Is the literal being parsed enclosed in
 			 * quotes.
+			 * @tparam AtEnd Whether this call is consuming an optional closing quote
+			 * after the literal has been parsed
 			 * @tparam ParseState ParseState idiom
 			 * @param parse_state Current parsing state
 			 */
-			template<options::LiteralAsStringOpt literal_as_string,
+			template<options::LiteralAsStringOpt literal_as_string, bool AtEnd = false,
 			         typename ParseState>
 			DAW_ATTRIB_INLINE constexpr void
 			skip_quote_when_literal_as_string( ParseState &parse_state ) {
@@ -67,10 +69,12 @@ namespace daw::json {
 					parse_state.remove_prefix( );
 				} else if constexpr( literal_as_string ==
 				                     options::LiteralAsStringOpt::Maybe ) {
-					daw_json_assert_weak( parse_state.has_more( ),
-					                      ErrorReason::UnexpectedEndOfData,
-					                      parse_state );
-					if( parse_state.front( ) == '"' ) {
+					if constexpr( not AtEnd ) {
+						daw_json_assert_weak( parse_state.has_more( ),
+						                      ErrorReason::UnexpectedEndOfData,
+						                      parse_state );
+					}
+					if( parse_state.has_more( ) and parse_state.front( ) == '"' ) {
 						parse_state.remove_prefix( );
 					}
 				}
@@ -166,7 +170,8 @@ namespace daw::json {
 					} else {
 						if constexpr( JsonMember::literal_as_string !=
 						              options::LiteralAsStringOpt::Never ) {
-							skip_quote_when_literal_as_string<JsonMember::literal_as_string>(
+							skip_quote_when_literal_as_string<JsonMember::literal_as_string,
+							                                  true>(
 							  parse_state );
 						}
 						daw_json_assert_weak(
@@ -226,7 +231,8 @@ namespace daw::json {
 					    parse_state, static_cast<element_t>( parsed_val ) );
 					if constexpr( JsonMember::literal_as_string !=
 					              options::LiteralAsStringOpt::Never ) {
-						skip_quote_when_literal_as_string<JsonMember::literal_as_string>(
+						skip_quote_when_literal_as_string<JsonMember::literal_as_string,
+						                                  true>(
 						  parse_state );
 					}
 					parse_state.trim_left( );
@@ -282,13 +288,9 @@ namespace daw::json {
 					      parse_state ) );
 					if constexpr( JsonMember::literal_as_string !=
 					              options::LiteralAsStringOpt::Never ) {
-						skip_quote_when_literal_as_string<JsonMember::literal_as_string>(
+						skip_quote_when_literal_as_string<JsonMember::literal_as_string,
+						                                  true>(
 						  parse_state );
-						if constexpr( not ParseState::is_zero_terminated_string ) {
-							daw_json_assert_weak( parse_state.has_more( ),
-							                      ErrorReason::UnexpectedEndOfData,
-							                      parse_state );
-						}
 					}
 					daw_json_assert_weak(
 					  not parse_state.has_more( ) or
@@ -433,7 +435,8 @@ namespace daw::json {
 					// Trailing quotes
 					if constexpr( JsonMember::literal_as_string !=
 					              options::LiteralAsStringOpt::Never ) {
-						skip_quote_when_literal_as_string<JsonMember::literal_as_string>(
+						skip_quote_when_literal_as_string<JsonMember::literal_as_string,
+						                                  true>(
 						  parse_state );
 					}
 					parse_state.trim_left( );

--- a/include/daw/json/impl/daw_json_type_options.h
+++ b/include/daw/json/impl/daw_json_type_options.h
@@ -24,9 +24,7 @@ namespace daw::json {
 				/// if
 				/// this member is encoded as a string
 				Never,
-				/// Never allow parsing this member as a string.  It is a parser error
-				/// if
-				/// this member is encoded as a string.
+				/// Allow parsing this member as either a JSON literal or a string.
 				Maybe,
 				/// Only allow parsing this member as a string.  It is an error for this
 				/// member to not be encoded as a string.

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -921,7 +921,8 @@ namespace daw::json {
 			[[nodiscard]] static constexpr WriteableType
 			to_json_string_unknown( WriteableType it, parse_to_t const &value ) {
 
-				return utils::copy_to_iterator( it, value );
+				return utils::copy_to_iterator<false, JsonMember::eight_bit_mode>(
+				  it, value );
 			}
 
 			template<typename JsonMember, typename WriteableType, typename parse_to_t>
@@ -1447,8 +1448,10 @@ namespace daw::json {
 				visited_members.push_back( json_member_name );
 				static_assert( is_a_json_type_v<JsonMember>, "Unsupported data type" );
 				if constexpr( is_json_nullable_v<JsonMember> ) {
-					if( not concepts::nullable_value_has_value( get<pos>( tp ) ) ) {
-						return;
+					if constexpr( JsonMember::nullable == JsonNullable::Nullable ) {
+						if( not concepts::nullable_value_has_value( get<pos>( tp ) ) ) {
+							return;
+						}
 					}
 				}
 				if( not is_first ) {

--- a/include/daw/json/impl/version.h
+++ b/include/daw/json/impl/version.h
@@ -17,9 +17,9 @@
 #if not defined( DAW_JSON_VER_OVERRIDE )
 // Should be updated when a potential ABI break is anticipated
 #if defined( DEBUG ) or not defined( NDEBUG )
-#define DAW_JSON_VER v3_34_1d
+#define DAW_JSON_VER v3_35_0d
 #else
-#define DAW_JSON_VER v3_34_1
+#define DAW_JSON_VER v3_35_0
 #endif
 #else
 #define DAW_JSON_VER DAW_JSON_VER_OVERRIDE

--- a/tests/src/cookbook_unknown_types_and_raw_parsing2_test.cpp
+++ b/tests/src/cookbook_unknown_types_and_raw_parsing2_test.cpp
@@ -77,8 +77,9 @@ bool operator==( MyClass2 const &lhs, MyClass2 const &rhs ) {
 		return false;
 	}
 	using namespace daw::json;
-	return from_json<MyDelayedClass>( lhs.member_later ) ==
-	       from_json<MyDelayedClass>( rhs.member_later );
+	auto const l_mem_later = from_json<MyDelayedClass>( lhs.member_later );
+	auto const r_mem_later = from_json<MyDelayedClass>( rhs.member_later );
+	return l_mem_later == r_mem_later;
 }
 
 int main( int argc, char **argv )

--- a/tests/src/daw_json_link_test.cpp
+++ b/tests/src/daw_json_link_test.cpp
@@ -882,6 +882,121 @@ DAW_ATTRIB_NOINLINE void test_parse_real_hard_rounding_cases( ) {
 	}
 }
 
+struct OptInt {
+	std::optional<int> m;
+};
+
+namespace mapping_parameter_tests {
+	struct increment_int {
+		constexpr int operator( )( int value ) const {
+			return value + 1;
+		}
+	};
+
+	struct bool_to_int {
+		constexpr int operator( )( bool value ) const {
+			return value ? 1 : 0;
+		}
+	};
+
+	struct construct_string {
+		std::string operator( )( std::string value ) const {
+			return value;
+		}
+
+		std::string operator( )( char const *first, char const *last ) const {
+			return std::string( first, last );
+		}
+	};
+
+	struct copy_json_text {
+		std::string operator( )( std::string_view value ) const {
+			return std::string( value );
+		}
+	};
+
+	struct emit_json_text {
+		std::string operator( )( std::string const &value ) const {
+			return value;
+		}
+	};
+
+	using number = daw::json::json_number_no_name<
+	  int,
+	  daw::json::options::number_opt(
+	    daw::json::options::LiteralAsStringOpt::Always,
+	    daw::json::options::JsonRangeCheck::CheckForNarrowing,
+	    daw::json::options::FPOutputFormat::Scientific ),
+	  increment_int>;
+	static_assert( number::literal_as_string ==
+	               daw::json::options::LiteralAsStringOpt::Always );
+	static_assert( number::range_check ==
+	               daw::json::options::JsonRangeCheck::CheckForNarrowing );
+	static_assert( number::fp_output_format ==
+	               daw::json::options::FPOutputFormat::Scientific );
+	static_assert( std::is_same_v<number::constructor_t, increment_int> );
+
+	using boolean = daw::json::json_bool_no_name<
+	  bool,
+	  daw::json::options::bool_opt(
+	    daw::json::options::LiteralAsStringOpt::Always ),
+	  bool_to_int>;
+	static_assert( boolean::literal_as_string ==
+	               daw::json::options::LiteralAsStringOpt::Always );
+	static_assert( std::is_same_v<boolean::constructor_t, bool_to_int> );
+
+	using string = daw::json::json_string_no_name<
+	  std::string,
+	  daw::json::options::string_opt(
+	    daw::json::options::EightBitModes::DisallowHigh ),
+	  construct_string>;
+	static_assert( string::eight_bit_mode ==
+	               daw::json::options::EightBitModes::DisallowHigh );
+	static_assert( std::is_same_v<string::constructor_t, construct_string> );
+
+	using raw_string = daw::json::json_string_raw_no_name<
+	  std::string_view,
+	  daw::json::options::string_raw_opt(
+	    daw::json::options::EightBitModes::AllowFull,
+	    daw::json::options::AllowEscapeCharacter::NoEscapedDblQuote )>;
+	static_assert( raw_string::eight_bit_mode ==
+	               daw::json::options::EightBitModes::AllowFull );
+	static_assert(
+	  raw_string::allow_escape_character ==
+	  daw::json::options::AllowEscapeCharacter::NoEscapedDblQuote );
+
+	using custom_any = daw::json::json_custom_no_name<
+	  std::string, copy_json_text, emit_json_text,
+	  daw::json::options::json_custom_opt(
+	    daw::json::options::JsonCustomTypes::Any )>;
+	static_assert( custom_any::custom_json_type ==
+	               daw::json::options::JsonCustomTypes::Any );
+
+	using tuple_elements = daw::json::json_tuple_member_list<
+	  daw::json::json_number_no_name<int>, daw::json::json_bool_no_name<bool>>;
+	using tuple =
+	  daw::json::json_tuple_no_name<std::tuple<int, bool>, tuple_elements>;
+	using nullable_tuple = daw::json::json_tuple_null_no_name<
+	  std::optional<std::tuple<int, bool>>, tuple_elements>;
+	static_assert( std::is_same_v<daw::json::json_details::json_result_t<tuple>,
+	                              std::tuple<int, bool>> );
+	static_assert(
+	  std::is_same_v<daw::json::json_details::json_result_t<nullable_tuple>,
+	                 std::optional<std::tuple<int, bool>>> );
+} // namespace mapping_parameter_tests
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<OptInt> {
+		static constexpr char m[] = "m";
+		using type = json_member_list<json_number_null<m, std::optional<int>>>;
+
+		static constexpr auto to_json_data( OptInt const &v ) {
+			return std::forward_as_tuple( v.m );
+		}
+	};
+} // namespace daw::json
+
 int main( ) {
 #if defined( DAW_USE_EXCEPTIONS )
 	try {
@@ -1122,28 +1237,38 @@ int main( ) {
 		                5792711765526609591.9963073925412025509e-82 );
 		test_dblparse( "4891559871276714924261e222", true );
 		test_dblparse(
-		  "111111111111111111111111111111111111111111111111111111111111111111111111"
+		  "1111111111111111111111111111111111111111111111111111111111111111111111"
 		  "11"
-		  "111111111111111111111111111111111111111111111111111111111111111111111111"
 		  "11"
-		  "111111111111111111111111111111111111111111111111111111111111111111111111"
+		  "1111111111111111111111111111111111111111111111111111111111111111111111"
 		  "11"
-		  "111111111111111111111111111111111111111111111111111111111111111111111111"
 		  "11"
-		  "111111111111111111111111111111111111111111111111111111111111111111111111"
+		  "1111111111111111111111111111111111111111111111111111111111111111111111"
+		  "11"
+		  "11"
+		  "1111111111111111111111111111111111111111111111111111111111111111111111"
+		  "11"
+		  "11"
+		  "1111111111111111111111111111111111111111111111111111111111111111111111"
+		  "11"
 		  "11"
 		  "111111111111111111111111111111.0e-100",
 		  true );
 		test_dblparse(
-		  "111111111111111111111111111111111111111111111111111111111111111111111111"
+		  "1111111111111111111111111111111111111111111111111111111111111111111111"
 		  "11"
-		  "111111111111111111111111111111111111111111111111111111111111111111111111"
 		  "11"
-		  "111111111111111111111111111111111111111111111111111111111111111111111111"
+		  "1111111111111111111111111111111111111111111111111111111111111111111111"
 		  "11"
-		  "111111111111111111111111111111111111111111111111111111111111111111111111"
 		  "11"
-		  "111111111111111111111111111111111111111111111111111111111111111111111111"
+		  "1111111111111111111111111111111111111111111111111111111111111111111111"
+		  "11"
+		  "11"
+		  "1111111111111111111111111111111111111111111111111111111111111111111111"
+		  "11"
+		  "11"
+		  "1111111111111111111111111111111111111111111111111111111111111111111111"
+		  "11"
 		  "11"
 		  "111111111111111111111111111111.0e+100",
 		  true );
@@ -1178,25 +1303,35 @@ int main( ) {
 		test_dblparse( "10070988951557009.8178168006534510403e-302", true );
 		test_dblparse(
 		  "2."
-		  "225073858507201136057409796709131975934819546351645648023426109724822222"
-		  "02"
-		  "107694551652952390813508791414915891303962110687008643869459464552765720"
-		  "74"
-		  "078206217433799881410632673292535522868813721490129811224514518898490572"
+		  "2250738585072011360574097967091319759348195463516456480234261097248222"
 		  "22"
-		  "307285255133155755015914397476397983411801999323962548289017107081850690"
+		  "02"
+		  "1076945516529523908135087914149158913039621106870086438694594645527657"
+		  "20"
+		  "74"
+		  "0782062174337998814106326732925355228688137214901298112245145188984905"
+		  "72"
+		  "22"
+		  "3072852551331557550159143974763979834118019993239625482890171070818506"
+		  "90"
 		  "63"
-		  "066665599493827577257201576306269066333264756530000924588831643303777979"
+		  "0666655994938275772572015763062690663332647565300009245888316433037779"
+		  "79"
 		  "18"
-		  "696120494973903778297049050510806099407302629371289589500035837999672072"
+		  "6961204949739037782970490505108060994073026293712895895000358379996720"
+		  "72"
 		  "54"
-		  "304360284078895771796150945516748243471030702609144621572289880258182545"
-		  "18"
-		  "032570701886087211312807951223342628836862232150377566662250398253433597"
+		  "3043602840788957717961509455167482434710307026091446215722898802581825"
 		  "45"
-		  "688844239002654981983854879482922068947216898310996983658468140228542433"
+		  "18"
+		  "0325707018860872113128079512233426288368622321503775666622503982534335"
+		  "97"
+		  "45"
+		  "6888442390026549819838548794829220689472168983109969836584681402285424"
+		  "33"
 		  "30"
-		  "660339850886445804001034933970427567186443383770486037861622771738545623"
+		  "6603398508864458040010349339704275671864433837704860378616227717385456"
+		  "23"
 		  "06"
 		  "5874679014086723327636718751234567890123456789012345678901e-308",
 		  true );
@@ -1518,7 +1653,7 @@ int main( ) {
 		auto um9_str = daw::json::to_json( um9 );
 		ensure(
 		  um9_str ==
-		  R"json({"a0":0,"a1":1,"a2":2,"a3":3,"a4":4,"a5":5,"a6":6,"a7":7,"a8":8,})json" );
+		  R"json({"a0":0,"a1":1,"a2":2,"a3":3,"a4":4,"a5":5,"a6":6,"a7":7,"a8":8})json" );
 #endif
 		std::cout << "\n\nJSON Link Version: " << json_link_version( ) << '\n';
 		std::cout << "done\n\n";
@@ -1661,6 +1796,133 @@ int main( ) {
 			ensure( most_min == most_min_parsed );
 		}
 #endif
+		{
+			using namespace daw::json;
+			using maybe_number = json_number_no_name<
+			  int, options::number_opt( options::LiteralAsStringOpt::Maybe )>;
+			using always_number = json_number_no_name<
+			  int, options::number_opt( options::LiteralAsStringOpt::Always )>;
+			daw_ensure( from_json<maybe_number>( "42" ) == 42 );
+			daw_ensure( from_json<maybe_number>( R"("42")" ) == 42 );
+			daw_ensure( from_json<always_number>( R"("42")" ) == 42 );
+			daw_ensure( to_json<always_number>( 42 ) == R"("42")" );
+			daw_ensure(
+			  from_json<mapping_parameter_tests::number>( R"("41")" ) == 42 );
+		}
+		{
+			using namespace daw::json;
+			using maybe_bool = json_bool_no_name<
+			  bool, options::bool_opt( options::LiteralAsStringOpt::Maybe )>;
+			daw_ensure( from_json<maybe_bool>( "true" ) );
+			daw_ensure( from_json<maybe_bool>( R"("true")" ) );
+			daw_ensure(
+			  from_json<mapping_parameter_tests::boolean>( R"("true")" ) == 1 );
+			daw_ensure( to_json<json_bool_no_name<
+			              bool, options::bool_opt(
+			                      options::LiteralAsStringOpt::Always )>>( true ) ==
+			            R"("true")" );
+		}
+		{
+			using namespace daw::json;
+			daw_ensure( from_json<mapping_parameter_tests::string>(
+			              R"("four")" ) == "four" );
+			daw_ensure( from_json<mapping_parameter_tests::raw_string>(
+			              R"("raw text")" ) == "raw text" );
+		}
+		{
+			using namespace daw::json;
+			using custom_string = json_custom_no_name<
+			  std::string, mapping_parameter_tests::copy_json_text,
+			  mapping_parameter_tests::emit_json_text>;
+			using custom_literal = json_custom_lit_no_name<
+			  std::string, mapping_parameter_tests::copy_json_text,
+			  mapping_parameter_tests::emit_json_text>;
+			daw_ensure( from_json<custom_string>( R"("text")" ) == "text" );
+			daw_ensure( to_json<custom_string>( std::string( "text" ) ) ==
+			            R"("text")" );
+			daw_ensure( from_json<custom_literal>( "42" ) == "42" );
+			daw_ensure( to_json<custom_literal>( std::string( "42" ) ) == "42" );
+		}
+		{
+			using namespace daw::json;
+			auto const tuple =
+			  from_json<mapping_parameter_tests::tuple>( "[42,true]" );
+			daw_ensure( tuple == std::tuple<int, bool>( 42, true ) );
+			auto const nullable_tuple =
+			  from_json<mapping_parameter_tests::nullable_tuple>( "[42,true]" );
+			daw_ensure( nullable_tuple ==
+			            std::optional<std::tuple<int, bool>>( { 42, true } ) );
+			daw_ensure( to_json<mapping_parameter_tests::nullable_tuple>(
+			              std::optional<std::tuple<int, bool>>{ } ) == "null" );
+		}
+		{
+			using nullable_number =
+			  daw::json::json_number_null_no_name<std::optional<int>>;
+			auto const opt_int_str =
+			  daw::json::to_json<nullable_number>( std::optional<int>{ } );
+			daw_ensure( opt_int_str == "null" );
+		}
+		{
+			using namespace daw::json;
+			using maybe_number =
+			  json_number_no_name<double,
+			                      options::number_opt(
+			                        options::LiteralAsStringOpt::Maybe,
+			                        options::JsonNumberErrors::AllowNanInf )>;
+			daw_ensure( to_json<maybe_number>( 1.5 ) == "1.5" );
+			daw_ensure( to_json<maybe_number>(
+			              std::numeric_limits<double>::quiet_NaN( ) ) == R"("NaN")" );
+			daw_ensure(
+			  to_json<maybe_number>( std::numeric_limits<double>::infinity( ) ) ==
+			  R"("Infinity")" );
+			daw_ensure(
+			  to_json<maybe_number>( -std::numeric_limits<double>::infinity( ) ) ==
+			  R"("-Infinity")" );
+
+			using nan_number =
+			  json_number_no_name<double,
+			                      options::number_opt(
+			                        options::LiteralAsStringOpt::Maybe,
+			                        options::JsonNumberErrors::AllowNaN )>;
+			using inf_number =
+			  json_number_no_name<double,
+			                      options::number_opt(
+			                        options::LiteralAsStringOpt::Maybe,
+			                        options::JsonNumberErrors::AllowInf )>;
+			daw_ensure( to_json<nan_number>(
+			              std::numeric_limits<double>::quiet_NaN( ) ) == R"("NaN")" );
+			daw_ensure(
+			  to_json<inf_number>( std::numeric_limits<double>::infinity( ) ) ==
+			  R"("Infinity")" );
+#if defined( DAW_USE_EXCEPTIONS )
+			try {
+				(void)to_json<nan_number>( std::numeric_limits<double>::infinity( ) );
+				daw_ensure_error( true, "AllowNaN unexpectedly allowed Infinity" );
+			} catch( json_exception const &jex ) {
+				daw_ensure( jex.reason_type( ) == ErrorReason::NumberIsInf );
+			}
+			try {
+				(void)to_json<inf_number>( std::numeric_limits<double>::quiet_NaN( ) );
+				daw_ensure_error( true, "AllowInf unexpectedly allowed NaN" );
+			} catch( json_exception const &jex ) {
+				daw_ensure( jex.reason_type( ) == ErrorReason::NumberIsNaN );
+			}
+#endif
+		}
+		{
+			using escaped_ascii_string = daw::json::json_string_no_name<
+			  std::string,
+			  daw::json::options::string_opt(
+			    daw::json::options::EightBitModes::DisallowHigh )>;
+			std::string_view const ebh_in = "\xC3\xA9";
+			auto const ebh_out = daw::json::to_json<escaped_ascii_string>( ebh_in );
+			std::string_view const ebh_expected = R"("\u00E9")";
+			daw_ensure( ebh_out == ebh_expected );
+		}
+		{
+			auto const opt_int_str = daw::json::to_json( OptInt{ } );
+			daw_ensure( opt_int_str == "{}" );
+		}
 	}
 #if defined( DAW_USE_EXCEPTIONS )
 	catch( daw::json::json_exception const &jex ) {

--- a/tests/src/daw_json_link_test.cpp
+++ b/tests/src/daw_json_link_test.cpp
@@ -13,10 +13,6 @@
 #include <daw/json/daw_json_link.h>
 #include <daw/json/impl/daw_json_exec_modes.h>
 
-#if defined( DAW_JSON_USE_REFLECTION )
-#include <daw/json/daw_json_reflection.h>
-#endif
-
 #include <daw/daw_arith_traits.h>
 #include <daw/daw_benchmark.h>
 #include <daw/daw_bounded_vector.h>
@@ -1277,6 +1273,7 @@ int main( ) {
 		daw_ensure( ( from_json<json_array_no_name<char, std::string>>(
 		                "[97,98,99]"s ) == "abc" ) );
 #if not defined( DAW_JSON_USE_FULL_DEBUG_ITERATORS )
+		// DAW
 		static_assert( from_json<std::array<int, 4>>( "[1,2,3]"sv )[1] == 2 );
 #else
 	daw_ensure( ( from_json<std::array<int, 4>>( "[1,2,3]"sv )[1] == 2 ) );
@@ -1502,21 +1499,27 @@ int main( ) {
 		          << '\n';
 #endif
 #endif
+
+#if defined( DAW_JSON_HAS_REFLECTION )
 		struct Unmapped0 {};
 		constexpr auto um0 = daw::json::from_json<Unmapped0>( "{}" );
 		auto um0_str = daw::json::to_json( um0 );
 		ensure( um0_str == "{}" );
 
-		constexpr auto um1 = daw::json::from_json<Unmapped1>( "[5]" );
+		constexpr auto um1 =
+		  daw::json::from_json<Unmapped1>( R"json({"x":5})json" );
+		ensure( um1.x == 5 );
 		auto um1_str = daw::json::to_json( um1 );
-		ensure( um1_str == "[5]" );
+		ensure( um1_str == R"json({"x":5})json" );
 
-		constexpr auto um9 =
-		  daw::json::from_json<Unmapped9>( "[0,1,2,3,4,5,6,7,8]" );
+		constexpr auto um9 = daw::json::from_json<Unmapped9>(
+		  R"json({"a0":0,"a1":1,"a2":2,"a3":3,"a4":4,"a5":5,"a6":6,"a7":7,"a8":8,})json" );
 
 		auto um9_str = daw::json::to_json( um9 );
-		ensure( um9_str == "[0,1,2,3,4,5,6,7,8]" );
-
+		ensure(
+		  um9_str ==
+		  R"json({"a0":0,"a1":1,"a2":2,"a3":3,"a4":4,"a5":5,"a6":6,"a7":7,"a8":8,})json" );
+#endif
 		std::cout << "\n\nJSON Link Version: " << json_link_version( ) << '\n';
 		std::cout << "done\n\n";
 

--- a/tests/src/daw_json_writer_test.cpp
+++ b/tests/src/daw_json_writer_test.cpp
@@ -10,12 +10,18 @@
 
 #include <cstdio>
 #include <iostream>
+#include <optional>
 #include <string>
 
 struct Foo {
 	int a = 0;
 	std::string b = "";
 	std::vector<int> c = { };
+};
+
+struct NullableMembers {
+	std::optional<int> elided;
+	std::optional<int> visible;
 };
 
 namespace daw::json {
@@ -29,6 +35,20 @@ namespace daw::json {
 
 		static DAW_JSON_CX_STRVEC auto to_json_data( Foo const &f ) {
 			return std::forward_as_tuple( f.a, f.b, f.c );
+		}
+	};
+
+	template<>
+	struct json_data_contract<NullableMembers> {
+		static constexpr char elided[] = "elided";
+		static constexpr char visible[] = "visible";
+		using type = json_member_list<
+		  json_number_null<elided, std::optional<int>>,
+		  json_number_null<visible, std::optional<int>, number_opts_def,
+		                   JsonNullable::NullVisible>>;
+
+		static auto to_json_data( NullableMembers const &value ) {
+			return std::forward_as_tuple( value.elided, value.visible );
 		}
 	};
 } // namespace daw::json
@@ -290,12 +310,41 @@ int main( ) {
 	}
 #endif
 	{
-		auto const foo = Foo{ 42, "Hello", {1,2} };
-		auto out = std::string{};
+		auto const foo = Foo{ 42, "Hello", { 1, 2 } };
+		auto out = std::string{ };
 		auto w = daw::json::json_writer( out );
 		w.write_string( foo );
 		w.finalize( );
 		daw_ensure( out == R"json("{\"a\":42,\"b\":\"Hello\",\"c\":[1,2]}")json" );
 	}
+	{
+		auto out = std::string{ };
+		auto w = daw::json::json_writer( out );
+		w.write_value<daw::json::json_number_null_no_name<std::optional<int>>>(
+		  std::optional<int>{ } );
+		w.finalize( );
+		daw_ensure( out == "null" );
+	}
+	{
+		auto out = std::string{ };
+		auto w = daw::json::json_writer( out );
+		w.write_value<daw::json::json_number_null_no_name<std::optional<int>>>(
+		  { std::optional<int>{ } } );
+		w.finalize( );
+		daw_ensure( out == "[null]" );
+	}
+	{
+		auto out = std::string{ };
+		auto w = daw::json::json_writer( out );
+		w.write_value( NullableMembers{ } );
+		w.finalize( );
+		daw_ensure( out == R"json({"visible":null})json" );
+	}
+	{
+		auto out = std::string{ };
+		auto w = daw::json::json_writer( out );
+		w.write_value( NullableMembers{ 1, 2 } );
+		w.finalize( );
+		daw_ensure( out == R"json({"elided":1,"visible":2})json" );
+	}
 }
-

--- a/tests/src/daw_json_writer_test.cpp
+++ b/tests/src/daw_json_writer_test.cpp
@@ -289,4 +289,13 @@ int main( ) {
 		std::cout << out << '\n';
 	}
 #endif
+	{
+		auto const foo = Foo{ 42, "Hello", {1,2} };
+		auto out = std::string{};
+		auto w = daw::json::json_writer( out );
+		w.write_string( foo );
+		w.finalize( );
+		daw_ensure( out == R"json("{\"a\":42,\"b\":\"Hello\",\"c\":[1,2]}")json" );
+	}
 }
+

--- a/tests/src/daw_json_writer_test.cpp
+++ b/tests/src/daw_json_writer_test.cpp
@@ -275,4 +275,18 @@ int main( ) {
 		std::cout << '\n';
 	}
 #endif
+#if defined( DAW_JSON_HAS_REFLECTION )
+	{
+		auto out = std::string{ };
+		auto w = daw::json::json_writer( out );
+		enum FooEnum { a, b, c };
+		w.open_array( );
+		w.write_enum_string( FooEnum::a );
+		w.write_enum_string( FooEnum::b );
+		w.write_enum_string( FooEnum::c );
+		w.finalize( );
+		daw_ensure( out == R"json(["a","b","c"])json" );
+		std::cout << out << '\n';
+	}
+#endif
 }


### PR DESCRIPTION
* Added more documentation, clarified much of what is there
* Added more tests
* Changed the _null_no_name mappings to remove the JsonNullable parameter.  It was never as root values or those without a key that are not engaged are always serialized as `null`