### PR TITLE
Improve quoted literal, nullable, and empty-class parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-				 VERSION "3.35.0"
+				 VERSION "3.36.0"
 				 DESCRIPTION "Static JSON parsing in C++"
 				 HOMEPAGE_URL "https://github.com/beached/daw_json_link"
 				 LANGUAGES C CXX )

--- a/docs/cookbook/aliases.md
+++ b/docs/cookbook/aliases.md
@@ -49,4 +49,16 @@ The data for this mapping could look like "12345/56789"
 The
 file [cookbook_aliases1_test.cpp](../../tests/src/cookbook_aliases1_test.cpp)
 shows an example share a type `MyClass` has a single member of type `std::string` that is serialized and deserialized as
-a string.
+a string using the deduced mapping `json_type_alias<std::string>`.
+
+The aliased type can also be a full, unnamed JSON mapping. For example, the
+equivalent explicit string mapping is:
+
+```cpp
+using type = json_type_alias<json_string_no_name<std::string>>;
+```
+
+The file
+[cookbook_aliases2_test.cpp](../../tests/src/cookbook_aliases2_test.cpp)
+shows this full-mapping form and verifies both deserialization and a serialized
+round trip.

--- a/docs/cookbook/class.md
+++ b/docs/cookbook/class.md
@@ -47,6 +47,24 @@ namespace daw::json {
 
 The above `json_data_contract` trait maps the JSON members to the constructor of `MyClass1` in the order specified. The arguments of type `std::string, int, bool` will be passed.
 
+## Empty classes
+
+An empty, default-constructible class without an explicit
+`json_data_contract` is automatically treated as an empty JSON object mapping.
+
+```c++
+struct EmptyClass {};
+
+auto value = daw::json::from_json<EmptyClass>( "{}" );
+auto json = daw::json::to_json( value );
+// json == "{}"
+```
+
+If an empty class has an explicit `json_data_contract`, that mapping is used
+instead. The automatic empty-object mapping is only a fallback. This allows an
+empty class to be used wherever an unnamed mapping can be deduced, such as an
+array element or variant alternative.
+
 ## Class as a member
 
 The serializing and deserializing is recursive. So if a class contains another class, the requirement is that that class has been mapped already. Assuming we already have the mapping above, lets embed that into another class

--- a/docs/cookbook/mapping_deduction.md
+++ b/docs/cookbook/mapping_deduction.md
@@ -1,8 +1,12 @@
-Many types can be deduced and not explicitly mapped to a JSON type(string, number, bool, object, array)
-This allows one to use them directly in places that don't require a member name(e.g. json_array's element type) or with
-the `json_link<Name, Type>` mapping type. The order of deduction is as follows
+Many types can be deduced without being explicitly mapped to a JSON type
+(string, number, bool, object, or array). This allows one to use them directly
+in places that don't require a member name (e.g. a `json_array` element type) or
+with the `json_link<Name, Type>` mapping type. The first matching mapping is
+used, in the following order:
 
-* types with existing json_data_contract's specialized for them
+* Types with an explicit `json_data_contract` specialization. An explicit
+  mapping always takes precedence over any deduced mapping, including the
+  default mapping for empty types.
 * Well known types
 
   | Type                  | Mapped To        | Notes                     |
@@ -16,6 +20,7 @@ the `json_link<Name, Type>` mapping type. The order of deduction is as follows
   | Associative Container |json_key_value_map| Has begin()/end()/key_type/mapped_type and constructable with two iterators|
   | readable values       |                  | The value_type in the readable mapping of T with a json_null wrapped around T's deduced mapping. See the readable value cookbook item |
   | Containers            |json_array        | Excluding associative containers. Uses value_type as the type for each element|
+  | Empty default-constructible types | Empty JSON object | Used only when no explicit mapping exists; serializes as `{}` |
 
 * Containers - map to json_array with the element type as the detected type of the value_type. Must have the methods
   begin(), end(), type alias value_type, and can be constructed with two iterators. Same Iterator requirements as std::

--- a/include/daw/json/daw_json_link_types.h
+++ b/include/daw/json/daw_json_link_types.h
@@ -835,6 +835,30 @@ namespace daw::json {
 				using type = json_details::json_result_t<member_type>;
 			};
 		} // namespace json_details
+
+		/// @brief Mark a member as nullable
+		/// @tparam T type of the value being mapped to(e.g. std::optional<Foo>)
+		/// @tparam JsonMember Json Type or type of value when present, deduced from
+		/// T if not specified
+		/// @tparam NullableType Whether an empty class member may be omitted or
+		/// must be emitted as null
+		/// @tparam Constructor Specify a Constructor type or use
+		/// the default nullable_constructor<T>
+		template<typename T, typename JsonMember = use_default,
+		         typename Constructor = use_default>
+		using json_nullable_no_name =
+		  json_base::json_nullable<T, JsonMember, JsonNullable::NullVisible,
+		                           Constructor>;
+
+		/// @brief Mark a member as nullable
+		/// @tparam Name name of JSON member
+		/// @tparam T type of the value being mapped to(e.g. std::optional<Foo>)
+		/// @tparam JsonMember Json Type or type of value when present, deduced from
+		/// T if not specified
+		/// @tparam NullableType Whether an empty class member may be omitted or
+		/// must be emitted as null
+		/// @tparam Constructor Specify a Constructor type or use
+		/// the default nullable_constructor<T>
 		template<JSONNAMETYPE Name, typename T, typename JsonMember,
 		         JsonNullable NullableType, typename Constructor>
 		struct json_nullable

--- a/include/daw/json/daw_json_link_types.h
+++ b/include/daw/json/daw_json_link_types.h
@@ -18,7 +18,7 @@
 
 #include <daw/daw_attributes.h>
 #include <daw/daw_callable.h>
-#include <daw/daw_fwd_pack_apply.h>
+#include <daw/daw_cpp_feature_check.h>
 #include <daw/daw_string_view.h>
 #include <daw/daw_traits.h>
 #include <daw/daw_visit.h>
@@ -26,10 +26,7 @@
 #include <daw/traits/daw_traits_first_type.h>
 #include <daw/traits/daw_traits_identity.h>
 
-#include <daw/daw_cpp_feature_check.h>
-
 #include <cstddef>
-#include <daw/stdinc/integer_sequence.h>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -88,7 +85,7 @@ namespace daw::json {
 			 *
 			 * Parse JSON data and construct a C++ class.  This is used by parse_value
 			 * to get back into a mode with a JsonMembers...
-			 * @tparam T The result of parsing json_class
+			 * @tparam JsonClass The result of parsing json_class
 			 * @tparam ParseState Input range type
 			 * @param parse_state JSON data to parse
 			 * @return A T object
@@ -321,7 +318,7 @@ namespace daw::json {
 			 *
 			 * Parse JSON data and construct a C++ class.  This is used by parse_value
 			 * to get back into a mode with a JsonMembers...
-			 * @tparam T The result of parsing json_class
+			 * @tparam JsonClass The result of parsing json_class
 			 * @tparam ParseState Input range type
 			 * @param parse_state JSON data to parse
 			 * @return A T object
@@ -394,7 +391,7 @@ namespace daw::json {
 			 *
 			 * Parse JSON data and construct a C++ class.  This is used by parse_value
 			 * to get back into a mode with a JsonMembers...
-			 * @tparam T The result of parsing json_class
+			 * @tparam JsonClass The result of parsing json_class
 			 * @tparam ParseState Input range type
 			 * @param parse_state JSON data to parse
 			 * @return A T object
@@ -1873,8 +1870,6 @@ namespace daw::json {
 		 * allows for delaying the parsing of this member until later
 		 * @tparam Name json member name
 		 * @tparam T type to hold raw JSON data, defaults to json_value
-		 * @tparam NullableType Whether an empty class member may be omitted or must
-		 * be emitted as null
 		 * @tparam Constructor A callable used to construct T.
 		 */
 		template<JSONNAMETYPE Name, typename T, typename Constructor>

--- a/include/daw/json/daw_json_writer.h
+++ b/include/daw/json/daw_json_writer.h
@@ -113,7 +113,7 @@ namespace daw::json {
 
 		public:
 			template<typename W>
-			explicit constexpr json_writer_t( W &&writer )
+			explicit constexpr json_writer_t( W &&writer DAW_LIFETIME_BOUND )
 			  : m_writer( json_details::make_output_iterator<PolicyFlags...>(
 			      DAW_FWD( writer ) ) ) {}
 			json_writer_t( json_writer_t const & ) = delete;
@@ -427,7 +427,7 @@ namespace daw::json {
 		};
 
 		template<auto... PolicyFlags, typename WriterType>
-		constexpr auto json_writer( WriterType &&writer ) {
+		constexpr auto json_writer( WriterType && writer DAW_LIFETIME_BOUND) {
 			return json_writer_t<daw::remove_cvref_t<WriterType>,
 			                     std::vector<json_writer_details::json_writer_states>,
 			                     PolicyFlags...>( writer );

--- a/include/daw/json/impl/daw_json_parse_value.h
+++ b/include/daw/json/impl/daw_json_parse_value.h
@@ -57,8 +57,8 @@ namespace daw::json {
 			 * @tparam ParseState ParseState idiom
 			 * @param parse_state Current parsing state
 			 */
-			template<options::LiteralAsStringOpt literal_as_string, bool AtEnd = false,
-			         typename ParseState>
+			template<options::LiteralAsStringOpt literal_as_string,
+			         bool AtEnd = false, typename ParseState>
 			DAW_ATTRIB_INLINE constexpr void
 			skip_quote_when_literal_as_string( ParseState &parse_state ) {
 				if constexpr( literal_as_string ==
@@ -171,8 +171,7 @@ namespace daw::json {
 						if constexpr( JsonMember::literal_as_string !=
 						              options::LiteralAsStringOpt::Never ) {
 							skip_quote_when_literal_as_string<JsonMember::literal_as_string,
-							                                  true>(
-							  parse_state );
+							                                  true>( parse_state );
 						}
 						daw_json_assert_weak(
 						  parse_state.empty( ) or
@@ -232,8 +231,7 @@ namespace daw::json {
 					if constexpr( JsonMember::literal_as_string !=
 					              options::LiteralAsStringOpt::Never ) {
 						skip_quote_when_literal_as_string<JsonMember::literal_as_string,
-						                                  true>(
-						  parse_state );
+						                                  true>( parse_state );
 					}
 					parse_state.trim_left( );
 					daw_json_assert_weak(
@@ -289,8 +287,7 @@ namespace daw::json {
 					if constexpr( JsonMember::literal_as_string !=
 					              options::LiteralAsStringOpt::Never ) {
 						skip_quote_when_literal_as_string<JsonMember::literal_as_string,
-						                                  true>(
-						  parse_state );
+						                                  true>( parse_state );
 					}
 					daw_json_assert_weak(
 					  not parse_state.has_more( ) or
@@ -436,8 +433,7 @@ namespace daw::json {
 					if constexpr( JsonMember::literal_as_string !=
 					              options::LiteralAsStringOpt::Never ) {
 						skip_quote_when_literal_as_string<JsonMember::literal_as_string,
-						                                  true>(
-						  parse_state );
+						                                  true>( parse_state );
 					}
 					parse_state.trim_left( );
 					daw_json_assert_weak(
@@ -613,7 +609,21 @@ namespace daw::json {
 				                      ErrorReason::UnexpectedEndOfData,
 				                      parse_state );
 
-				if constexpr( KnownBounds ) {
+				if constexpr( is_deduced_empty_class_v<JsonMember> ) {
+					if constexpr( not KnownBounds ) {
+						auto const old_class_pos = parse_state.get_class_position( );
+						parse_state.set_class_position( );
+						parse_state.remove_prefix( );
+						parse_state.trim_left( );
+						parse_state.trim_left_checked( );
+						parse_state.move_next_member_or_end( );
+						parse_state.move_to_next_class_member( );
+						(void)parse_state.skip_class( );
+						parse_state.trim_left_checked( );
+						parse_state.set_class_position( old_class_pos );
+					}
+					return json_result_t<JsonMember>{ };
+				} else if constexpr( KnownBounds ) {
 					return json_data_contract_trait_t<element_t>::
 					  template parse_to_class<JsonMember, KnownBounds>( parse_state );
 				} else if constexpr( is_pinned_type_v<element_t> ) {
@@ -623,9 +633,6 @@ namespace daw::json {
 					(void)run_after_parse;
 					return json_data_contract_trait_t<element_t>::
 					  template parse_to_class<JsonMember, KnownBounds>( parse_state );
-				} else if constexpr( is_deduced_empty_class_v<JsonMember> ) {
-					parse_state.trim_left_checked( );
-					return json_result_t<JsonMember>{ };
 				} else {
 					auto result = json_data_contract_trait_t<element_t>::
 					  template parse_to_class<JsonMember, KnownBounds>( parse_state );

--- a/include/daw/json/impl/daw_json_serialize_policy.h
+++ b/include/daw/json/impl/daw_json_serialize_policy.h
@@ -77,7 +77,7 @@ namespace daw::json {
 			}
 
 			DAW_ATTRIB_INLINE explicit constexpr serialization_policy(
-			  WritableType &writable )
+			  WritableType & writable DAW_LIFETIME_BOUND )
 			  : m_writable( std::addressof( writable ) ) {}
 
 			static constexpr options::SerializationFormat serialization_format =

--- a/include/daw/json/impl/daw_json_types_base.h
+++ b/include/daw/json/impl/daw_json_types_base.h
@@ -45,6 +45,9 @@ namespace daw::json {
 			template<typename T>
 			struct json_empty_class {
 				static_assert( std::is_empty_v<T>, "T is expected to empty" );
+				static_assert( std::is_default_constructible_v<T>,
+				               "T is expected to be default constructible" );
+
 				using i_am_a_json_type = void;
 				using i_am_a_deduced_empty_class = void;
 				using wrapped_type = T;

--- a/include/daw/json/impl/daw_json_value.h
+++ b/include/daw/json/impl/daw_json_value.h
@@ -23,6 +23,7 @@
 #include "daw/json/impl/daw_json_value_fwd.h"
 
 #include <daw/daw_algorithm.h>
+#include <daw/daw_attributes.h>
 #include <daw/daw_move.h>
 #include <daw/daw_utility.h>
 
@@ -386,13 +387,15 @@ namespace daw::json {
 			}
 
 			/// @brief Construct from char const *, std::size_t
-			explicit constexpr basic_json_value( char const *first, std::size_t sz )
+			explicit constexpr basic_json_value( char const *first DAW_LIFETIME_BOUND,
+			                                     std::size_t sz )
 			  : m_parse_state( first, first + static_cast<std::ptrdiff_t>( sz ) ) {
 				m_parse_state.trim_left( );
 			}
 
 			/// @brief Construct from char const *, char const *
-			explicit constexpr basic_json_value( char const *first, char const *last )
+			explicit constexpr basic_json_value( char const *first DAW_LIFETIME_BOUND,
+			                                     char const *last )
 			  : m_parse_state( first, last ) {
 				m_parse_state.trim_left( );
 			}

--- a/include/daw/json/impl/version.h
+++ b/include/daw/json/impl/version.h
@@ -17,9 +17,9 @@
 #if not defined( DAW_JSON_VER_OVERRIDE )
 // Should be updated when a potential ABI break is anticipated
 #if defined( DEBUG ) or not defined( NDEBUG )
-#define DAW_JSON_VER v3_35_0d
+#define DAW_JSON_VER v3_36_0d
 #else
-#define DAW_JSON_VER v3_35_0
+#define DAW_JSON_VER v3_36_0
 #endif
 #else
 #define DAW_JSON_VER DAW_JSON_VER_OVERRIDE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1055,6 +1055,18 @@ add_test( NAME variant_on_members_test COMMAND variant_on_members )
 add_dependencies( ci_tests variant_on_members )
 add_dependencies( full variant_on_members )
 
+add_executable( nullable_variant1 src/nullable_variant1.cpp )
+target_link_libraries( nullable_variant1 json_test )
+add_test( NAME nullable_variant1_test COMMAND nullable_variant1 )
+add_dependencies( ci_tests nullable_variant1 )
+add_dependencies( full nullable_variant1 )
+
+add_executable( nullable_variant2 src/nullable_variant2.cpp )
+target_link_libraries( nullable_variant2 json_test )
+add_test( NAME nullable_variant2_test COMMAND nullable_variant2 )
+add_dependencies( ci_tests nullable_variant2 )
+add_dependencies( full nullable_variant2 )
+
 add_executable( json_lines_test src/json_lines_test.cpp )
 target_link_libraries( json_lines_test json_test )
 add_test( NAME json_lines_test_test COMMAND json_lines_test )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1185,7 +1185,13 @@ add_test( NAME daw_json_writer_test_test COMMAND daw_json_writer_test )
 add_dependencies( ci_tests daw_json_writer_test )
 add_dependencies( full daw_json_writer_test )
 
-
+add_executable( daw_json_writer_mapping_test
+                src/daw_json_writer_mapping_test.cpp )
+target_link_libraries( daw_json_writer_mapping_test json_test )
+add_test( NAME daw_json_writer_mapping_test_test
+          COMMAND daw_json_writer_mapping_test )
+add_dependencies( ci_tests daw_json_writer_mapping_test )
+add_dependencies( full daw_json_writer_mapping_test )
 
 # **************************************************
 # JSON Benchmark

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -641,6 +641,12 @@ add_test( NAME cookbook_aliases1_test COMMAND cookbook_aliases1_test ./cookbook_
 add_dependencies( ci_tests cookbook_aliases1_test )
 add_dependencies( full cookbook_aliases1_test )
 
+add_executable( cookbook_aliases2_test src/cookbook_aliases2_test.cpp )
+target_link_libraries( cookbook_aliases2_test PRIVATE json_test )
+add_test( NAME cookbook_aliases2_test COMMAND cookbook_aliases2_test )
+add_dependencies( ci_tests cookbook_aliases2_test )
+add_dependencies( full cookbook_aliases2_test )
+
 add_executable( cookbook_class_alternate_test src/cookbook_class_alternate1_test.cpp )
 target_link_libraries( cookbook_class_alternate_test PRIVATE json_test )
 add_test( NAME cookbook_class_alternate_test COMMAND cookbook_class_alternate_test WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test_data/" )

--- a/tests/src/cookbook_aliases2_test.cpp
+++ b/tests/src/cookbook_aliases2_test.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+
+/***
+ * This example shows using a full JSON mapping with json_type_alias
+ */
+
+#include <daw/json/daw_json_link.h>
+
+#include <daw/daw_ensure.h>
+
+#include <iostream>
+#include <string>
+
+struct MyExplicitClass {
+	std::string value;
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<MyExplicitClass> {
+		using type = json_type_alias<json_string_no_name<std::string>>;
+
+		static auto to_json_data( MyExplicitClass const &v ) {
+			return v.value;
+		}
+	};
+} // namespace daw::json
+
+int main( )
+#if defined( DAW_USE_EXCEPTIONS )
+  try
+#endif
+{
+	MyExplicitClass const c0 =
+	  daw::json::from_json<MyExplicitClass>( R"json("Hello World")json" );
+	daw_ensure( c0.value == "Hello World" );
+	std::string const json0 = daw::json::to_json( c0 );
+	MyExplicitClass const c1 =
+	  daw::json::from_json<MyExplicitClass>( json0 );
+	daw_ensure( c1.value == c0.value );
+	std::cout << json0 << '\n';
+}
+#if defined( DAW_USE_EXCEPTIONS )
+catch( daw::json::json_exception const &jex ) {
+	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
+	exit( 1 );
+} catch( std::exception const &ex ) {
+	std::cerr << "Unknown exception thrown during testing: " << ex.what( )
+	          << '\n';
+	exit( 1 );
+} catch( ... ) {
+	std::cerr << "Unknown exception thrown during testing\n";
+	throw;
+}
+#endif

--- a/tests/src/cookbook_variant1_test.cpp
+++ b/tests/src/cookbook_variant1_test.cpp
@@ -42,16 +42,6 @@ namespace daw::cookbook_variant1 {
 
 namespace daw::json {
 	template<>
-	struct json_data_contract<daw::cookbook_variant1::SomeClass> {
-		using type = json_member_list<>;
-
-		static constexpr std::tuple<>
-		to_json_data( daw::cookbook_variant1::SomeClass ) {
-			return { };
-		}
-	};
-
-	template<>
 	struct json_data_contract<daw::cookbook_variant1::MyVariantStuff1> {
 #if defined( DAW_JSON_CNTTP_JSON_NAME )
 		using type = json_member_list<
@@ -105,6 +95,11 @@ int main( int argc, char **argv )
 	test_assert( stuff.front( ).member1.index( ) == 0, "Unexpected value" );
 	test_assert( ( std::get<0>( stuff.front( ).member1 ) == "hello" ),
 	             "Unexpected value" );
+	test_assert( stuff[2].member0.index( ) == 3,
+	             "Empty aggregate was not selected" );
+	test_assert(
+	  daw::json::to_json( daw::cookbook_variant1::SomeClass{ } ) == "{}",
+	  "Empty aggregate did not serialize as an empty mapping" );
 
 	auto const str = daw::json::to_json_array( stuff );
 	puts( "After" );

--- a/tests/src/cookbook_variant1_test.cpp
+++ b/tests/src/cookbook_variant1_test.cpp
@@ -21,7 +21,7 @@
 #include <optional>
 #include <string>
 
-namespace daw::cookbook_variant1 {
+namespace cookbook_variant1 {
 	struct SomeClass {};
 	constexpr bool operator==( SomeClass, SomeClass ) {
 		return true;
@@ -38,37 +38,27 @@ namespace daw::cookbook_variant1 {
 	bool operator==( MyVariantStuff1 const &lhs, MyVariantStuff1 const &rhs ) {
 		return lhs.member0 == rhs.member0 and lhs.member1 == rhs.member1;
 	}
-} // namespace daw::cookbook_variant1
+
+	bool operator!=( MyVariantStuff1 const &lhs, MyVariantStuff1 const &rhs ) {
+		return not( lhs == rhs );
+	}
+} // namespace cookbook_variant1
 
 namespace daw::json {
 	template<>
-	struct json_data_contract<daw::cookbook_variant1::MyVariantStuff1> {
-#if defined( DAW_JSON_CNTTP_JSON_NAME )
-		using type = json_member_list<
-		  json_variant<
-		    "member0",
-		    std::variant<int, std::string, bool, daw::cookbook_variant1::SomeClass,
-		                 std::vector<int>>,
-		    json_variant_type_list<int, std::string, bool,
-		                           daw::cookbook_variant1::SomeClass,
-		                           std::vector<int>>,
-		    std::vector<int>>,
-		  json_variant<"member1", std::variant<std::string, bool>>>;
-#else
-		static constexpr char const member0[] = "member0";
-		static constexpr char const member1[] = "member1";
+	struct json_data_contract<cookbook_variant1::MyVariantStuff1> {
+		static constexpr char member0[] = "member0";
+		static constexpr char member1[] = "member1";
 		using type = json_member_list<
 		  json_variant<
 		    member0,
-		    std::variant<int, std::string, bool, daw::cookbook_variant1::SomeClass,
+		    std::variant<int, std::string, bool, cookbook_variant1::SomeClass,
 		                 std::vector<int>>,
 		    json_variant_type_list<int, std::string, bool,
-		                           daw::cookbook_variant1::SomeClass,
-		                           std::vector<int>>>,
+		                           cookbook_variant1::SomeClass, std::vector<int>>>,
 		  json_variant<member1, std::variant<std::string, bool>>>;
-#endif
 		static auto
-		to_json_data( daw::cookbook_variant1::MyVariantStuff1 const &value ) {
+		to_json_data( cookbook_variant1::MyVariantStuff1 const &value ) {
 			return std::forward_as_tuple( value.member0, value.member1 );
 		}
 	};
@@ -87,7 +77,7 @@ int main( int argc, char **argv )
 	puts( "Original" );
 	puts( data.c_str( ) );
 	auto stuff =
-	  daw::json::from_json_array<daw::cookbook_variant1::MyVariantStuff1>( data );
+	  daw::json::from_json_array<cookbook_variant1::MyVariantStuff1>( data );
 	test_assert( stuff.size( ) == 4, "Unexpected size" );
 	test_assert( stuff.front( ).member0.index( ) == 0, "Unexpected value" );
 	test_assert( ( std::get<0>( stuff.front( ).member0 ) == 5 ),
@@ -97,15 +87,14 @@ int main( int argc, char **argv )
 	             "Unexpected value" );
 	test_assert( stuff[2].member0.index( ) == 3,
 	             "Empty aggregate was not selected" );
-	test_assert(
-	  daw::json::to_json( daw::cookbook_variant1::SomeClass{ } ) == "{}",
-	  "Empty aggregate did not serialize as an empty mapping" );
+	test_assert( daw::json::to_json( cookbook_variant1::SomeClass{ } ) == "{}",
+	             "Empty aggregate did not serialize as an empty mapping" );
 
 	auto const str = daw::json::to_json_array( stuff );
 	puts( "After" );
 	puts( str.c_str( ) );
 	auto stuff2 =
-	  daw::json::from_json_array<daw::cookbook_variant1::MyVariantStuff1>( str );
+	  daw::json::from_json_array<cookbook_variant1::MyVariantStuff1>( str );
 
 	test_assert( stuff == stuff2, "Unexpected round trip error" );
 	return 0;

--- a/tests/src/daw_json_link_test.cpp
+++ b/tests/src/daw_json_link_test.cpp
@@ -398,6 +398,35 @@ namespace daw::json {
 static_assert( daw::json::from_json<Empty2>( empty_class_data ).c == 5 );
 #endif
 
+struct DeducedEmptyClassTest {};
+
+static_assert( std::is_same_v<
+               daw::json::json_details::json_deduced_type<DeducedEmptyClassTest>,
+               daw::json::json_details::json_empty_class<
+                 DeducedEmptyClassTest>> );
+
+void test_deduced_empty_class( ) {
+	using daw::json::from_json;
+
+	(void)from_json<DeducedEmptyClassTest>( "{}" );
+	(void)from_json<DeducedEmptyClassTest, true>( "{}" );
+	(void)from_json<DeducedEmptyClassTest>( R"({"ignored":42})" );
+	(void)from_json<DeducedEmptyClassTest, true>( R"({"ignored":42})" );
+
+	auto const values = daw::json::from_json_array<DeducedEmptyClassTest>(
+	  R"([{}, {"ignored":42}])" );
+	daw_json_ensure( values.size( ) == 2, daw::json::ErrorReason::Unknown );
+
+	using nullable_empty_t = daw::json::json_nullable_no_name<
+	  std::optional<DeducedEmptyClassTest>,
+	  daw::json::json_details::json_empty_class<DeducedEmptyClassTest>>;
+	auto const value = from_json<nullable_empty_t>( "{}" );
+	daw_json_ensure( value.has_value( ), daw::json::ErrorReason::Unknown );
+	auto const null_value = from_json<nullable_empty_t>( "null" );
+	daw_json_ensure( not null_value.has_value( ),
+	                 daw::json::ErrorReason::Unknown );
+}
+
 struct OptionalOrdered {
 	int a = 0;
 	std::optional<int> b{ };
@@ -1001,6 +1030,7 @@ int main( ) {
 #if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
+		test_deduced_empty_class( );
 		constexpr daw::string_view foo2_json =
 		  R"json( { "m1": {}, "m2": 42  } )json";
 		DAW_CONSTEXPR auto foo1_val = daw::json::from_json<Foo1>( foo2_json, "m1" );

--- a/tests/src/daw_json_writer_mapping_test.cpp
+++ b/tests/src/daw_json_writer_mapping_test.cpp
@@ -119,10 +119,10 @@ namespace daw::json {
 	struct json_data_contract<SizedObject> {
 		static constexpr char size[] = "size";
 		static constexpr char values[] = "values";
-		using size_t = json_number<size, std::size_t>;
+		using size_type = json_number<size, std::size_t>;
 		using type = json_member_list<
-		  size_t, json_sized_array<values, int, size_t, std::vector<int>,
-		                           SizedVectorConstructor>>;
+		  size_type, json_sized_array<values, int, size_type, std::vector<int>,
+		                              SizedVectorConstructor>>;
 
 		static auto to_json_data( SizedObject const &object ) {
 			return std::forward_as_tuple( object.size, object.values );
@@ -133,10 +133,10 @@ namespace daw::json {
 	struct json_data_contract<IntrusiveA> {
 		static constexpr char kind[] = "kind";
 		static constexpr char value[] = "value";
-		using type = json_member_list<json_number<kind, int>,
-		                              json_number<value, int>>;
+		using type =
+		  json_member_list<json_number<kind, int>, json_number<value, int>>;
 
-		static auto to_json_data( IntrusiveA const &object ) {
+		static constexpr auto to_json_data( IntrusiveA const &object ) {
 			return std::forward_as_tuple( object.kind, object.value );
 		}
 	};
@@ -147,7 +147,7 @@ namespace daw::json {
 		static constexpr char value[] = "value";
 		using type = json_member_list<json_number<kind, int>, json_string<value>>;
 
-		static auto to_json_data( IntrusiveB const &object ) {
+		static constexpr auto to_json_data( IntrusiveB const &object ) {
 			return std::forward_as_tuple( object.kind, object.value );
 		}
 	};
@@ -168,29 +168,28 @@ int main( ) {
 	  std::string{ R"(line\nbreak)" }, R"("line\nbreak")" );
 
 	using timestamp_t = std::chrono::time_point<std::chrono::system_clock,
-	                                           std::chrono::milliseconds>;
+	                                            std::chrono::milliseconds>;
 	auto const timestamp =
 	  datetime::civil_to_time_point( 2024, 9, 2, 1, 14, 54, 0 );
 	ensure_write_value<json_date_no_name<timestamp_t>>(
 	  timestamp, R"("2024-09-02T01:14:54Z")" );
 
-	ensure_write_value<
-	  json_custom_no_name<int, CustomFromJson, CustomToJson>>( 42, R"("42")" );
+	ensure_write_value<json_custom_no_name<int, CustomFromJson, CustomToJson>>(
+	  42, R"("42")" );
 	ensure_write_value<
 	  json_custom_lit_no_name<int, CustomFromJson, CustomToJson>>( 42, "42" );
 
 	ensure_write_value<json_tuple_no_name<std::tuple<int, bool, std::string>>>(
 	  std::tuple{ 1, true, std::string{ "two" } }, R"([1,true,"two"])" );
 	ensure_write_value<json_key_value_no_name<std::map<std::string, int>>>(
-	  std::map<std::string, int>{ { "a", 1 }, { "b", 2 } },
-	  R"({"a":1,"b":2})" );
+	  std::map<std::string, int>{ { "a", 1 }, { "b", 2 } }, R"({"a":1,"b":2})" );
 	ensure_write_value<json_key_value_array_no_name<std::map<std::string, int>>>(
 	  std::map<std::string, int>{ { "a", 1 }, { "b", 2 } },
 	  R"([{"key":"a","value":1},{"key":"b","value":2}])" );
 
 	using Variant = std::variant<int, std::string, bool, std::vector<int>>;
-	ensure_write_value<json_variant_no_name<Variant>>( Variant{ std::string{ "x" } },
-	                                                 R"("x")" );
+	ensure_write_value<json_variant_no_name<Variant>>(
+	  Variant{ std::string{ "x" } }, R"("x")" );
 	ensure_write_value<json_variant_no_name<Variant>>(
 	  Variant{ std::vector<int>{ 1, 2 } }, "[1,2]" );
 
@@ -198,12 +197,12 @@ int main( ) {
 	  std::string{ R"({"raw":[1,2]})" }, R"({"raw":[1,2]})" );
 
 	ensure_write_value<json_class_no_name<TaggedObject>>(
-	  TaggedObject{ "tagged", 42 },
-	  R"({"type":1,"name":"tagged","value":42})" );
+	  TaggedObject{ "tagged", 42 }, R"({"type":1,"name":"tagged","value":42})" );
 	ensure_write_value<json_class_no_name<SizedObject>>(
 	  SizedObject{ 3, { 1, 2, 3 } }, R"({"size":3,"values":[1,2,3]})" );
 	ensure_write_value<json_intrusive_variant_no_name<
-	  IntrusiveValue, json_number<json_data_contract<IntrusiveValue>::kind, int>,
+	  IntrusiveValue,
+	  json_number<json_data_contract<IntrusiveValue>::kind, int>,
 	  IntrusiveSwitcher>>( IntrusiveValue{ IntrusiveB{ 1, "intrusive" } },
 	                       R"({"kind":1,"value":"intrusive"})" );
 
@@ -212,9 +211,10 @@ int main( ) {
 	  ReflectedObject{ 7, true }, R"({"number":7,"flag":true})" );
 #endif
 
-	using decimal_number = json_number_no_name<
-	  double,
-	  options::number_opt( options::FPOutputFormat::Decimal )>;
+	using decimal_number =
+	  json_number_no_name<double,
+	                      options::number_opt(
+	                        options::FPOutputFormat::Decimal )>;
 	{
 		auto out = std::string{ };
 		auto writer = json_writer( out );
@@ -234,8 +234,7 @@ int main( ) {
 		auto out = std::string{ };
 		auto writer = json_writer( out );
 		writer.open_array( );
-		writer.write_array_values<decimal_number>(
-		  std::array{ 10.0, 20.0 } );
+		writer.write_array_values<decimal_number>( std::array{ 10.0, 20.0 } );
 		writer.write_array_values<decimal_number>( { 30.0, 40.0 } );
 		writer.close_array( );
 		daw_ensure( out == "[10.0,20.0,30.0,40.0]" );

--- a/tests/src/daw_json_writer_mapping_test.cpp
+++ b/tests/src/daw_json_writer_mapping_test.cpp
@@ -1,0 +1,250 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+
+#include "daw/json/daw_json_writer.h"
+
+#include <daw/daw_ensure.h>
+
+#include <array>
+#include <chrono>
+#include <iostream>
+#include <map>
+#include <string>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+namespace {
+	template<typename JsonClass, typename T>
+	void ensure_write_value( T const &value, std::string_view expected ) {
+		auto out = std::string{ };
+		auto writer = daw::json::json_writer( out );
+		writer.template write_value<JsonClass>( value );
+		writer.finalize( );
+		if( out != expected ) {
+			std::cerr << "Expected: " << expected << "\nActual:   " << out << '\n';
+		}
+		daw_ensure( out == expected );
+	}
+
+	struct CustomFromJson {
+		[[maybe_unused]] int operator( )( std::string_view ) const {
+			return 0;
+		}
+	};
+
+	struct CustomToJson {
+		std::string operator( )( int value ) const {
+			return std::to_string( value );
+		}
+	};
+
+	using TaggedValue = std::variant<std::string, int, bool>;
+
+	struct TaggedObject {
+		std::string name;
+		TaggedValue value;
+	};
+
+	struct TaggedSwitcher {
+		[[maybe_unused]] constexpr std::size_t operator( )( int type ) const {
+			return static_cast<std::size_t>( type );
+		}
+
+		int operator( )( TaggedObject const &value ) const {
+			return static_cast<int>( value.value.index( ) );
+		}
+	};
+
+	struct SizedObject {
+		std::size_t size;
+		std::vector<int> values;
+	};
+
+	struct SizedVectorConstructor {
+		[[maybe_unused]] std::vector<int>
+		operator( )( int const *first, int const *last, std::size_t ) const {
+			return { first, last };
+		}
+	};
+
+	struct IntrusiveA {
+		int kind = 0;
+		int value = 0;
+	};
+
+	struct IntrusiveB {
+		int kind = 1;
+		std::string value;
+	};
+
+	using IntrusiveValue = std::variant<IntrusiveA, IntrusiveB>;
+
+	struct IntrusiveSwitcher {
+		[[maybe_unused]] constexpr std::size_t operator( )( int type ) const {
+			return static_cast<std::size_t>( type );
+		}
+	};
+
+#if defined( DAW_JSON_HAS_REFLECTION )
+	struct ReflectedObject {
+		int number;
+		bool flag;
+	};
+#endif
+} // namespace
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<TaggedObject> {
+		static constexpr char name[] = "name";
+		static constexpr char type_member[] = "type";
+		static constexpr char value[] = "value";
+		using type_t = json_number<type_member, int>;
+		using type = json_member_list<
+		  json_string<name>,
+		  json_tagged_variant<value, TaggedValue, type_t, TaggedSwitcher>>;
+
+		static auto to_json_data( TaggedObject const &object ) {
+			return std::forward_as_tuple( object.name, object.value );
+		}
+	};
+
+	template<>
+	struct json_data_contract<SizedObject> {
+		static constexpr char size[] = "size";
+		static constexpr char values[] = "values";
+		using size_t = json_number<size, std::size_t>;
+		using type = json_member_list<
+		  size_t, json_sized_array<values, int, size_t, std::vector<int>,
+		                           SizedVectorConstructor>>;
+
+		static auto to_json_data( SizedObject const &object ) {
+			return std::forward_as_tuple( object.size, object.values );
+		}
+	};
+
+	template<>
+	struct json_data_contract<IntrusiveA> {
+		static constexpr char kind[] = "kind";
+		static constexpr char value[] = "value";
+		using type = json_member_list<json_number<kind, int>,
+		                              json_number<value, int>>;
+
+		static auto to_json_data( IntrusiveA const &object ) {
+			return std::forward_as_tuple( object.kind, object.value );
+		}
+	};
+
+	template<>
+	struct json_data_contract<IntrusiveB> {
+		static constexpr char kind[] = "kind";
+		static constexpr char value[] = "value";
+		using type = json_member_list<json_number<kind, int>, json_string<value>>;
+
+		static auto to_json_data( IntrusiveB const &object ) {
+			return std::forward_as_tuple( object.kind, object.value );
+		}
+	};
+
+	template<>
+	struct json_data_contract<IntrusiveValue> {
+		static constexpr char kind[] = "kind";
+		using type = json_type_alias<json_intrusive_variant_no_name<
+		  IntrusiveValue, json_number<kind, int>, IntrusiveSwitcher>>;
+	};
+} // namespace daw::json
+
+int main( ) {
+	using namespace daw::json;
+
+	ensure_write_value<json_checked_number_no_name<int>>( 42, "42" );
+	ensure_write_value<json_string_raw_no_name<std::string>>(
+	  std::string{ R"(line\nbreak)" }, R"("line\nbreak")" );
+
+	using timestamp_t = std::chrono::time_point<std::chrono::system_clock,
+	                                           std::chrono::milliseconds>;
+	auto const timestamp =
+	  datetime::civil_to_time_point( 2024, 9, 2, 1, 14, 54, 0 );
+	ensure_write_value<json_date_no_name<timestamp_t>>(
+	  timestamp, R"("2024-09-02T01:14:54Z")" );
+
+	ensure_write_value<
+	  json_custom_no_name<int, CustomFromJson, CustomToJson>>( 42, R"("42")" );
+	ensure_write_value<
+	  json_custom_lit_no_name<int, CustomFromJson, CustomToJson>>( 42, "42" );
+
+	ensure_write_value<json_tuple_no_name<std::tuple<int, bool, std::string>>>(
+	  std::tuple{ 1, true, std::string{ "two" } }, R"([1,true,"two"])" );
+	ensure_write_value<json_key_value_no_name<std::map<std::string, int>>>(
+	  std::map<std::string, int>{ { "a", 1 }, { "b", 2 } },
+	  R"({"a":1,"b":2})" );
+	ensure_write_value<json_key_value_array_no_name<std::map<std::string, int>>>(
+	  std::map<std::string, int>{ { "a", 1 }, { "b", 2 } },
+	  R"([{"key":"a","value":1},{"key":"b","value":2}])" );
+
+	using Variant = std::variant<int, std::string, bool, std::vector<int>>;
+	ensure_write_value<json_variant_no_name<Variant>>( Variant{ std::string{ "x" } },
+	                                                 R"("x")" );
+	ensure_write_value<json_variant_no_name<Variant>>(
+	  Variant{ std::vector<int>{ 1, 2 } }, "[1,2]" );
+
+	ensure_write_value<json_raw_no_name<std::string>>(
+	  std::string{ R"({"raw":[1,2]})" }, R"({"raw":[1,2]})" );
+
+	ensure_write_value<json_class_no_name<TaggedObject>>(
+	  TaggedObject{ "tagged", 42 },
+	  R"({"type":1,"name":"tagged","value":42})" );
+	ensure_write_value<json_class_no_name<SizedObject>>(
+	  SizedObject{ 3, { 1, 2, 3 } }, R"({"size":3,"values":[1,2,3]})" );
+	ensure_write_value<json_intrusive_variant_no_name<
+	  IntrusiveValue, json_number<json_data_contract<IntrusiveValue>::kind, int>,
+	  IntrusiveSwitcher>>( IntrusiveValue{ IntrusiveB{ 1, "intrusive" } },
+	                       R"({"kind":1,"value":"intrusive"})" );
+
+#if defined( DAW_JSON_HAS_REFLECTION )
+	ensure_write_value<json_reflected_class_no_name<ReflectedObject>>(
+	  ReflectedObject{ 7, true }, R"({"number":7,"flag":true})" );
+#endif
+
+	using decimal_number = json_number_no_name<
+	  double,
+	  options::number_opt( options::FPOutputFormat::Decimal )>;
+	{
+		auto out = std::string{ };
+		auto writer = json_writer( out );
+		writer.write_value<decimal_number>( 10.0 );
+		writer.finalize( );
+		daw_ensure( out == "10.0" );
+	}
+	{
+		auto out = std::string{ };
+		auto writer = json_writer( out );
+		writer.open_object( );
+		writer.write_key_value<decimal_number>( "value", 10.0 );
+		writer.close_object( );
+		daw_ensure( out == R"({"value":10.0})" );
+	}
+	{
+		auto out = std::string{ };
+		auto writer = json_writer( out );
+		writer.open_array( );
+		writer.write_array_values<decimal_number>(
+		  std::array{ 10.0, 20.0 } );
+		writer.write_array_values<decimal_number>( { 30.0, 40.0 } );
+		writer.close_array( );
+		daw_ensure( out == "[10.0,20.0,30.0,40.0]" );
+	}
+	{
+		auto out = std::string{ };
+		auto writer = json_writer( out );
+		writer.write_string<json_bool_no_name<>>( true );
+		writer.finalize( );
+		daw_ensure( out == R"("true")" );
+	}
+}

--- a/tests/src/nullable_variant1.cpp
+++ b/tests/src/nullable_variant1.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+
+#include <daw/json/daw_json_link.h>
+
+#include <daw/daw_ensure.h>
+
+#include <string>
+#include <variant>
+
+struct Foo {
+	std::variant<std::monostate, int, std::string> member{ };
+};
+
+struct FooConstructor {
+	std::variant<std::monostate, int, std::string> operator( )( ) const {
+		return { };
+	}
+
+	std::variant<std::monostate, int, std::string>
+	operator( )( std::variant<std::monostate, int, std::string> &&v ) {
+		return v;
+	}
+
+	std::variant<std::monostate, int, std::string>
+	operator( )( char const *str, std::size_t str_sz ) const {
+		auto jv = daw::json::json_value( str, str_sz );
+		if( jv.is_number( ) ) {
+			return daw::json::from_json<int>( jv );
+		}
+		if( jv.is_string( ) ) {
+			return daw::json::from_json<std::string>( jv );
+		}
+		return { };
+	}
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<Foo> {
+		static constexpr char member[] = "member";
+		using type = json_member_list<json_nullable<
+		  member, std::variant<std::monostate, int, std::string>,
+		  json_raw_no_name<std::variant<std::monostate, int, std::string>,
+		                   FooConstructor>,
+		  JsonNullable::NullVisible, FooConstructor>>;
+	};
+} // namespace daw::json
+
+int main( ) {
+	constexpr daw::string_view doc0 = R"json({ "member":null})json";
+	auto v0 = daw::json::from_json<Foo>( doc0 );
+	daw_ensure( v0.member.index( ) == 0 );
+
+	constexpr daw::string_view doc1 = R"json({ "member":42})json";
+	auto v1 = daw::json::from_json<Foo>( doc1 );
+	daw_ensure( v1.member.index( ) == 1 );
+	daw_ensure( std::get<1>( v1.member ) == 42 );
+
+	constexpr daw::string_view doc2 = R"json({ "member":"Hello world"})json";
+	auto v2 = daw::json::from_json<Foo>( doc2 );
+	daw_ensure( v2.member.index( ) == 2 );
+	daw_ensure( std::get<2>( v2.member ) == "Hello world" );
+}

--- a/tests/src/nullable_variant2.cpp
+++ b/tests/src/nullable_variant2.cpp
@@ -1,0 +1,37 @@
+#include <daw/json/daw_json_link.h>
+
+#include <daw/daw_ensure.h>
+
+#include <string>
+#include <variant>
+
+struct Foo {
+	std::variant<std::monostate, int, std::string> member{ };
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<Foo> {
+		static constexpr char member[] = "member";
+		using type = json_member_list<json_nullable<
+		  member, std::variant<std::monostate, int, std::string>,
+		  json_variant_no_name<std::variant<std::monostate, int, std::string>,
+		                       json_variant_type_list<int, std::string>>>>;
+	};
+} // namespace daw::json
+
+int main( ) {
+	constexpr daw::string_view doc0 = R"json({ "member":null})json";
+	auto v0 = daw::json::from_json<Foo>( doc0 );
+	daw_ensure( v0.member.index( ) == 0 );
+
+	constexpr daw::string_view doc1 = R"json({ "member":42})json";
+	auto v1 = daw::json::from_json<Foo>( doc1 );
+	daw_ensure( v1.member.index( ) == 1 );
+	daw_ensure( std::get<1>( v1.member ) == 42 );
+
+	constexpr daw::string_view doc2 = R"json({ "member":"Hello world"})json";
+	auto v2 = daw::json::from_json<Foo>( doc2 );
+	daw_ensure( v2.member.index( ) == 2 );
+	daw_ensure( std::get<2>( v2.member ) == "Hello world" );
+}


### PR DESCRIPTION

| Area | Change | Effect |
|---|---|---|
| Quoted literals | Added an `AtEnd` template parameter to `skip_quote_when_literal_as_string` | Closing quotes are optional at end-of-input for `LiteralAsStringOpt::Maybe`, while opening quotes still require available input. |
| Numeric parsing | Real, signed, and unsigned parsers pass `AtEnd = true` when consuming trailing quotes | Prevents an incorrect `UnexpectedEndOfData` error after a valid optionally quoted value. |
| Boolean parsing | Trailing quote handling also uses `AtEnd = true` | Applies the same end-of-input behavior to quoted booleans. |
| Unsigned parsing | Removed a redundant `has_more()` assertion after handling the trailing quote | Allows a valid value to finish exactly at the input boundary. |
| Nullable values | Checked nullable parsing now tests `parse_state.is_null()` before examining input | Recognizes parse states already marked as null, in addition to textual `null`, empty input, and token boundaries. |
| Empty classes | `is_deduced_empty_class_v<JsonMember>` is handled before the `KnownBounds` and pinned-type branches | Ensures deduced empty classes consistently use their specialized parsing path. |
| Empty-class input consumption | For unknown bounds, the parser now skips the complete JSON object while preserving and restoring the enclosing class position | Correctly advances beyond an empty-class object instead of merely trimming whitespace and returning a default value. |
