### PR TITLE
Add `json_submember` type for parsing nested JSON paths

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -177,8 +177,9 @@ HTML_EXTRA_FILES       =	"docs/cookbook/aliases.md" \
 													"docs/cookbook/output_options.md" \
 													"docs/cookbook/parser_policies.md" \
 													"docs/cookbook/parsing_individual_members.md" \
-													"docs/cookbook/strings.md" \
-													"docs/cookbook/unknown_types_and_raw_parsing.md" \
+											"docs/cookbook/strings.md" \
+											"docs/cookbook/submember.md" \
+											"docs/cookbook/unknown_types_and_raw_parsing.md" \
 													"docs/cookbook/variant.md"
 HTML_COLORSTYLE_HUE    = 220
 HTML_COLORSTYLE_SAT    = 100

--- a/docs/cookbook/mapping_overview.md
+++ b/docs/cookbook/mapping_overview.md
@@ -69,6 +69,13 @@ Maps JSON string values to C++ string types. The string type will need to own th
 
 Maps JSON string values to C++ string types without processing. This allows for `string_view` mappings.
 
+### `json_submember`
+
+Maps a C++ member to a value below a named JSON object or array member. The
+relative path is searched while parsing. Serialization reconstructs the minimal
+path and supports only array index `[0]`. See [Submember Mappings](submember.md)
+for its invariants and error behavior.
+
 ### `json_tuple`
 
 Maps JSON tuples/arrays/heterogeneous arrays to C++ class types.  This requires that the order is significant.  This is useful to save space because member names are not needed.

--- a/docs/cookbook/parsing_individual_members.md
+++ b/docs/cookbook/parsing_individual_members.md
@@ -46,3 +46,6 @@ Too see a working example using this code, refer to [cookbook_parsing_individual
 ```c++
 int third_value = daw::json::from_json<int>( json_data, "member1[2]" );
 ```
+
+To apply a relative member path as part of a reusable `json_data_contract`, see
+[Submember Mappings](submember.md).

--- a/docs/cookbook/readme.md
+++ b/docs/cookbook/readme.md
@@ -27,5 +27,6 @@ This folder contains examples of various JSON constructs and how to create a C++
 * [Parsing Individual Members](parsing_individual_members.md)
 * [Reflection(*New*)](reflection.md)
 * [Strings](strings.md)
+* [Submember Mappings](submember.md) - Mapping a class member through a relative JSON path
 * [Unknown JSON and Raw Parsing](unknown_types_and_raw_parsing.md) - Browsing the JSON Document and delaying of parsing of specified members
 * [Variant](variant.md)

--- a/docs/cookbook/submember.md
+++ b/docs/cookbook/submember.md
@@ -1,0 +1,92 @@
+# Submember Mappings
+
+`json_submember<Name, JsonPath, JsonMember>` maps one C++ value to a value below
+a named JSON object or array member. `JsonPath` is relative to `Name` and uses
+the same dot and square-bracket syntax as the path overloads of `from_json`.
+
+For example, this JSON stores `reading` below two object members and the first
+element of an array.
+
+```json
+{
+  "payload": {
+    "readings": [
+      {
+        "value": 42
+      }
+    ]
+  }
+}
+```
+
+The mapping selects only the integer at `payload.readings[0].value`.
+
+```c++
+#include <daw/json/daw_json_link.h>
+
+#include <tuple>
+
+struct Sample {
+  int reading;
+};
+
+template<>
+struct daw::json::json_data_contract<Sample> {
+  using type = json_member_list<
+    json_submember<"payload", "readings[0].value", int>>;
+
+  static constexpr auto to_json_data( Sample const &sample ) {
+    return std::forward_as_tuple( sample.reading );
+  }
+};
+```
+
+Parsing finds `payload`, follows the relative path, and passes the selected JSON
+value to the mapping for `JsonMember`. `JsonMember` must be unnamed; it can be an
+explicit mapping such as `json_string_no_name<std::string>` or a type such as
+`int` for which an unnamed mapping can be deduced.
+
+```c++
+auto const sample = daw::json::from_json<Sample>( json_data );
+// sample.reading == 42
+```
+
+Serialization reconstructs the minimal hierarchy described by the path.
+
+```c++
+auto const json = daw::json::to_json( Sample{ 42 } );
+// json == R"({"payload":{"readings":[{"value":42}]}})"
+```
+
+This is a projection rather than preservation of the input document. Object
+members and array elements not represented by the mapping are discarded during
+parsing and cannot be recreated by `to_json`.
+
+## Invariants and errors
+
+The following invariants apply:
+
+* `JsonPath` must not be empty.
+* `JsonMember` must be an unnamed JSON mapping or have an unnamed deduced
+  mapping.
+* A member-name path step requires the current JSON value to be an object. An
+  array-index step requires it to be an array.
+* The outer member named by `Name` and the complete relative path must exist
+  while parsing. A nullable `JsonMember` does not make a missing path optional.
+* A `json_data_contract` must not contain multiple `json_submember` mappings
+  with the same outer `Name`.
+* Serialization can reconstruct only index `[0]` at every array step. Any other
+  index would require inventing preceding elements and is rejected.
+
+An invalid or mismatched container step reports `ErrorReason::InvalidJSONPath`.
+A well-formed path that is absent reports `ErrorReason::JSONPathNotFound`.
+Attempting to serialize a path containing an array index other than exactly
+`[0]` reports `ErrorReason::OutputError` through the configured JSON error
+handler.
+
+In C++17, declare both names as static character arrays and pass those arrays as
+the first two template arguments. C++20 and later permit the string-literal form
+shown above.
+
+A complete parsing, serialization, and error-handling example is exercised by
+[test_json_submember.cpp](../../tests/src/test_json_submember.cpp).

--- a/include/daw/json/daw_json_link_types.h
+++ b/include/daw/json/daw_json_link_types.h
@@ -1131,6 +1131,63 @@ namespace daw::json {
 		template<typename T, typename Constructor = use_default>
 		using json_class_no_name = json_base::json_class<T, Constructor>;
 
+		namespace json_base {
+			template<JSONNAMETYPE JsonPath, typename JsonMember>
+			struct json_submember {
+				using i_am_a_json_type = void;
+				static_assert(
+				  json_details::has_unnamed_default_type_mapping_v<JsonMember>,
+				  "Missing specialization of daw::json::json_data_contract for class "
+				  "mapping or specialization of daw::json::json_link_basic_type_map" );
+				using member_type = json_details::json_deduced_type<JsonMember>;
+
+				static_assert( json_details::is_a_json_type_v<member_type>,
+				               "JsonMember must be a JSON Link mapping or a type with a "
+				               "deduced mapping" );
+				static_assert( json_details::is_no_name_v<member_type>,
+				               "JsonMember must be an unnamed mapping" );
+
+				static constexpr daw::string_view json_path = JsonPath;
+				static_assert( not json_path.empty( ),
+				               "json_submember requires a non-empty JsonPath" );
+
+				using parse_to_t = json_details::json_result_t<member_type>;
+				static constexpr auto expected_type = JsonParseTypes::Submember;
+				static constexpr auto underlying_json_type = JsonBaseParseTypes::None;
+
+				template<JSONNAMETYPE NewName>
+				using with_name =
+				  daw::json::json_submember<NewName, JsonPath, JsonMember>;
+			};
+		} // namespace json_base
+
+		/**
+		 * Parse the value at JsonPath within the named JSON class/array member.
+		 * JsonPath uses the same syntax as the path overloads of from_json.
+		 *
+		 * @par Invariants
+		 * - JsonPath is non-empty and JsonMember is an unnamed mapping.
+		 * - Each path step must match its JSON container: member names require an
+		 *   object and indexes require an array.
+		 * - The outer member and the complete inner path must exist when parsing.
+		 * - Serialization emits only the minimal object/array hierarchy described
+		 *   by JsonPath; JSON members not represented by the mapping are not
+		 *   reconstructed.
+		 * - Serialization supports only array index `[0]`. Any other array index
+		 *   reports ErrorReason::OutputError.
+		 * - A contract must not use more than one json_submember with the same Name.
+		 *
+		 * A missing inner path reports ErrorReason::JSONPathNotFound. A path step
+		 * whose container type does not match reports ErrorReason::InvalidJSONPath.
+		 */
+		template<JSONNAMETYPE Name, JSONNAMETYPE JsonPath, typename JsonMember>
+		struct json_submember
+		  : json_base::json_submember<JsonPath, JsonMember> {
+			static constexpr daw::string_view name = Name;
+
+			using without_name = json_base::json_submember<JsonPath, JsonMember>;
+		};
+
 		template<typename T, typename Constructor = use_default>
 		using json_class_null_no_name = json_base::json_nullable<
 		  T, json_base::json_class<json_details::unwrapped_t<T>>,

--- a/include/daw/json/impl/daw_json_enums.h
+++ b/include/daw/json/impl/daw_json_enums.h
@@ -50,6 +50,7 @@ namespace daw::json {
 			ReflectedClass, /// A class that has no backing and falls back to C++26
 			                /// reflection
 #endif
+			Submember, /// Locate a path within a class/array member before parsing
 		};
 
 		/// The fundamental JSON types

--- a/include/daw/json/impl/daw_json_link_types_fwd.h
+++ b/include/daw/json/impl/daw_json_link_types_fwd.h
@@ -74,6 +74,16 @@ namespace daw::json {
 		struct json_class;
 
 		/**
+		 * Locate a path relative to a named JSON class/array member and parse the
+		 * value at that path using JsonMember.
+		 * @tparam Name name of the outer JSON member
+		 * @tparam JsonPath path relative to the outer member
+		 * @tparam JsonMember unnamed mapping for the value at JsonPath
+		 */
+		template<JSONNAMETYPE Name, JSONNAMETYPE JsonPath, typename JsonMember>
+		struct json_submember;
+
+		/**
 		 * Link to a JSON class without eagerly instantiating its data contract.
 		 * This permits recursive class mappings through containers and other
 		 * finite indirections.

--- a/include/daw/json/impl/daw_json_parse_name.h
+++ b/include/daw/json/impl/daw_json_parse_name.h
@@ -163,7 +163,17 @@ namespace daw::json {
 			                                   daw::string_view path ) {
 
 				auto pop_result = pop_json_path( path );
-				while( not pop_result.current.empty( ) ) {
+				while( not pop_result.current.empty( ) or
+				       pop_result.found_char != 0 ) {
+					// A path relative to an array starts with '['.  In that case the
+					// first popped component is empty and the index is the next one.
+					if( pop_result.current.empty( ) ) {
+						daw_json_assert_weak( pop_result.found_char == '[',
+						                      ErrorReason::InvalidJSONPath,
+						                      parse_state );
+						pop_result = pop_json_path( path );
+						continue;
+					}
 					if( pop_result.found_char == ']' ) {
 						// Array Index
 						daw_json_assert_weak( parse_state.is_opening_bracket_checked( ),
@@ -190,6 +200,10 @@ namespace daw::json {
 						                      parse_state );
 						parse_state.remove_prefix( );
 						parse_state.trim_left_unchecked( );
+						if( parse_state.empty( ) or
+						    parse_state.is_closing_brace_checked( ) ) {
+							return false;
+						}
 						auto name = parse_name( parse_state );
 						while( not json_path_compare( pop_result.current, name ) ) {
 							(void)skip_value( parse_state );

--- a/include/daw/json/impl/daw_json_parse_value.h
+++ b/include/daw/json/impl/daw_json_parse_value.h
@@ -1252,6 +1252,27 @@ namespace daw::json {
 				}
 			}
 
+			template<typename JsonMember, bool KnownBounds, typename ParseState>
+			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
+			parse_value_submember( ParseState &parse_state ) {
+				auto submember_state = [&] {
+					if constexpr( KnownBounds ) {
+						return parse_state;
+					} else {
+						return skip_value( parse_state );
+					}
+				}( );
+
+				auto const found =
+				  find_range2( submember_state, JsonMember::json_path );
+				daw_json_ensure( found, ErrorReason::JSONPathNotFound,
+				                 submember_state );
+
+				using member_type = typename JsonMember::member_type;
+				return parse_value<member_type, false, member_type::expected_type>(
+				  submember_state );
+			}
+
 			template<typename JsonMember, bool KnownBounds, JsonParseTypes PTag,
 			         typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr json_result_t<JsonMember>
@@ -1294,6 +1315,8 @@ namespace daw::json {
 					return parse_value_variant_intrusive<JsonMember>( parse_state );
 				} else if constexpr( PTag == JsonParseTypes::Tuple ) {
 					return parse_value_tuple<JsonMember, KnownBounds>( parse_state );
+				} else if constexpr( PTag == JsonParseTypes::Submember ) {
+					return parse_value_submember<JsonMember, KnownBounds>( parse_state );
 #if defined( DAW_JSON_HAS_REFLECTION )
 				} else if constexpr( PTag == JsonParseTypes::ReflectedClass ) {
 					return parse_value_reflected_class<JsonMember, KnownBounds>(

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -48,7 +48,7 @@
 
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
-		namespace json_details {
+			namespace json_details {
 			template<options::FPOutputFormat fp_output_format,
 			         unsigned Precision = daw::max_value<unsigned>, typename Real,
 			         typename WriteableType>
@@ -1382,6 +1382,90 @@ namespace daw::json {
 				return it;
 			}
 
+			template<typename JsonMember, typename WriteableType, typename T>
+			[[nodiscard]] static constexpr WriteableType
+			to_json_string_submember( WriteableType it, daw::string_view path,
+			                          T const &value );
+
+			template<typename JsonMember, typename WriteableType, typename T>
+			[[nodiscard]] static constexpr WriteableType
+			to_json_string_submember_array( WriteableType it, daw::string_view path,
+			                                T const &value ) {
+				auto const index = pop_json_path( path );
+				// Only index zero can be reconstructed without inventing preceding
+				// array elements. This is a runtime output error because serialization
+				// is the operation that requires this stronger path invariant.
+				daw_json_ensure( index.found_char == ']' and
+				                   index.current.size( ) == 1 and
+				                   index.current.front( ) == '0',
+				                 ErrorReason::OutputError );
+
+				it.put( '[' );
+				it.add_indent( );
+				it.next_member( );
+				if( path.empty( ) ) {
+					using member_type = typename JsonMember::member_type;
+					it = to_daw_json_string<member_type, member_type::expected_type>(
+					  it, value );
+				} else {
+					it = to_json_string_submember<JsonMember>( it, path, value );
+				}
+				it.del_indent( );
+				if constexpr( it.output_trailing_comma ==
+				              options::OutputTrailingComma::Yes ) {
+					it.put( ',' );
+				}
+				it.next_member( );
+				it.put( ']' );
+				return it;
+			}
+
+			template<typename JsonMember, typename WriteableType, typename T>
+			[[nodiscard]] static constexpr WriteableType
+			to_json_string_submember( WriteableType it, daw::string_view path,
+			                          T const &value ) {
+				auto const path_item = pop_json_path( path );
+				if( path_item.current.empty( ) ) {
+					daw_json_ensure( path_item.found_char == '[',
+					                 ErrorReason::OutputError );
+					return to_json_string_submember_array<JsonMember>( it, path,
+					                                                   value );
+				}
+
+				it.put( '{' );
+				it.add_indent( );
+				it.next_member( );
+				it.put( '"' );
+				auto name = path_item.current;
+				while( not name.empty( ) ) {
+					if( name.front( ) == '\\' ) {
+						name.remove_prefix( );
+						daw_json_ensure( not name.empty( ), ErrorReason::OutputError );
+					}
+					it.put( name.front( ) );
+					name.remove_prefix( );
+				}
+				it.write( "\":", it.space );
+
+				if( path_item.found_char == '[' ) {
+					it = to_json_string_submember_array<JsonMember>( it, path, value );
+				} else if( path.empty( ) ) {
+					using member_type = typename JsonMember::member_type;
+					it = to_daw_json_string<member_type, member_type::expected_type>(
+					  it, value );
+				} else {
+					it = to_json_string_submember<JsonMember>( it, path, value );
+				}
+				it.del_indent( );
+				if constexpr( it.output_trailing_comma ==
+				              options::OutputTrailingComma::Yes ) {
+					it.put( ',' );
+				}
+				it.next_member( );
+				it.put( '}' );
+				return it;
+			}
+
 			template<typename JsonMember, JsonParseTypes Tag, typename WriteableType,
 			         typename parse_to_t>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr WriteableType
@@ -1422,6 +1506,9 @@ namespace daw::json {
 					return to_json_string_variant_intrusive<JsonMember>( it, value );
 				} else if constexpr( Tag == JsonParseTypes::Tuple ) {
 					return to_json_string_tuple<JsonMember>( it, value );
+				} else if constexpr( Tag == JsonParseTypes::Submember ) {
+					return to_json_string_submember<JsonMember>(
+					  it, JsonMember::json_path, value );
 #if defined( DAW_JSON_HAS_REFLECTION )
 				} else if constexpr( Tag == JsonParseTypes::ReflectedClass ) {
 					return to_json_string_reflected_class<JsonMember>( it, value );

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@
     * [Parsing Individual Members](docs/cookbook/parsing_individual_members.md)
     * [Reflection(*New*)](docs/cookbook/reflection.md)
     * [Strings](docs/cookbook/strings.md)
+    * [Submember Mappings](docs/cookbook/submember.md)
     * [Unknown JSON and Raw Parsing](docs/cookbook/unknown_types_and_raw_parsing.md) - Browsing the JSON Document and delaying of parsing of specified members
     * [Variant](docs/cookbook/variant.md)
     * [Automatic Code Generation](docs/cookbook/automated_code_generation.md)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -951,6 +951,12 @@ add_test( test_json_array_test test_json_array )
 add_dependencies( ci_tests test_json_array )
 add_dependencies( full test_json_array )
 
+add_executable( test_json_submember src/test_json_submember.cpp )
+target_link_libraries( test_json_submember PRIVATE json_test )
+add_test( test_json_submember_test test_json_submember )
+add_dependencies( ci_tests test_json_submember )
+add_dependencies( full test_json_submember )
+
 add_executable( test_json_key_value_array src/test_json_key_value_array.cpp )
 target_link_libraries( test_json_key_value_array PRIVATE json_test )
 add_test( test_json_key_value_array_test test_json_key_value_array )

--- a/tests/src/test_json_submember.cpp
+++ b/tests/src/test_json_submember.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <daw/json/daw_json_link.h>
+
+#include <daw/daw_ensure.h>
+
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+
+struct Submember {
+	int object_value;
+	std::string_view array_value;
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<Submember> {
+		static constexpr char const object[] = "object";
+		static constexpr char const object_path[] = "nested.value";
+		static constexpr char const array[] = "array";
+		static constexpr char const array_path[] = "[1].name";
+
+		using type = json_member_list<
+		  json_submember<object, object_path, int>,
+		  json_submember<array, array_path,
+		                 json_string_raw_no_name<std::string_view>>>;
+
+		static constexpr auto to_json_data( Submember const &value ) {
+			return std::forward_as_tuple( value.object_value, value.array_value );
+		}
+	};
+} // namespace daw::json
+
+struct SerializableSubmember {
+	int value;
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<SerializableSubmember> {
+		static constexpr char const data[] = "data";
+		static constexpr char const value_path[] = "values[0].value";
+		using type =
+		  json_member_list<json_submember<data, value_path, int>>;
+
+		static constexpr auto
+		to_json_data( SerializableSubmember const &value ) {
+			return std::forward_as_tuple( value.value );
+		}
+	};
+} // namespace daw::json
+
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
+using literal_submember = daw::json::json_submember<"object", "value", int>;
+static_assert( std::is_same_v<literal_submember::parse_to_t, int> );
+#endif
+
+int main( ) {
+	auto const root_array_value = daw::json::from_json<int>( "[1,2,3]", "[1]" );
+	daw_ensure( root_array_value == 2 );
+
+	auto const value0 = daw::json::from_json<Submember>(
+	  R"json({"object":{"nested":{"value":42}},"array":[{"name":"first"},{"name":"second"}]})json" );
+	daw_ensure( value0.object_value == 42 );
+	daw_ensure( value0.array_value == "second" );
+
+	auto const value1 = daw::json::from_json<Submember>(
+	  R"json({"array":[{"name":"first"},{"name":"second"}],"ignored":true,"object":{"nested":{"value":42}}})json" );
+	daw_ensure( value1.object_value == 42 );
+	daw_ensure( value1.array_value == "second" );
+
+	auto const serialized =
+	  daw::json::to_json( SerializableSubmember{ 42 } );
+	daw_ensure( serialized == R"json({"data":{"values":[{"value":42}]}})json" );
+	daw_ensure(
+	  daw::json::from_json<SerializableSubmember>( serialized ).value == 42 );
+
+#if defined( DAW_USE_EXCEPTIONS )
+	bool nonzero_array_index_threw = false;
+	try {
+		(void)daw::json::to_json( value0 );
+	} catch( daw::json::json_exception const &ex ) {
+		nonzero_array_index_threw = true;
+		daw_ensure( ex.reason_type( ) == daw::json::ErrorReason::OutputError );
+	}
+	daw_ensure( nonzero_array_index_threw );
+
+	bool missing_path_threw = false;
+	try {
+		(void)daw::json::from_json<Submember>(
+		  R"json({"object":{"nested":{}},"array":[{},{}]})json" );
+	} catch( daw::json::json_exception const &ex ) {
+		missing_path_threw = true;
+		daw_ensure( ex.reason_type( ) == daw::json::ErrorReason::JSONPathNotFound );
+	}
+	daw_ensure( missing_path_threw );
+
+	bool scalar_outer_threw = false;
+	try {
+		(void)daw::json::from_json<Submember>(
+		  R"json({"object":42,"array":[{},{}]})json" );
+	} catch( daw::json::json_exception const &ex ) {
+		scalar_outer_threw = true;
+		daw_ensure( ex.reason_type( ) == daw::json::ErrorReason::InvalidJSONPath );
+	}
+	daw_ensure( scalar_outer_threw );
+#endif
+}


### PR DESCRIPTION
- Introduce `json_submember` to map C++ members to nested JSON paths.
- Add `test_json_submember.cpp` for parsing, serialization, and error handling.
- Document usage and constraints in `submember.md`. Update related JSON cookbook references and examples.
- Update parsing and serialization logic to support `json_submember`.
- Include new tests and examples in docs and build configuration.

Fixes #299