### PR TITLE
Tests, bugfixes, and insitu string parsing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ build/
 ClientBin/
 cmake-build-*/
 cmake-build/
+build-*/
 test_data/
 CMakeFiles/
 CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required( VERSION 3.14 )
 
 project( "daw-json-link"
-				 VERSION "3.38.1"
+				 VERSION "3.39.0"
 				 DESCRIPTION "Static JSON parsing in C++"
 				 HOMEPAGE_URL "https://github.com/beached/daw_json_link"
 				 LANGUAGES C CXX )

--- a/docs/cookbook/parser_policies.md
+++ b/docs/cookbook/parser_policies.md
@@ -54,10 +54,17 @@ Are comments in whitespace allowed(defaults to no) and, if so, what kind
 Do a checked parse or not. If the data is known to be trustworthy and generated correctly, one can
 disable checking of a parse and gain performance(measured 15% in some documents).
 
+**Warning:** `no` is a memory-safety contract, not just a speed/strictness knob. Disabled checks
+include bounds checks on the parse cursor (e.g. scanning for the next member no longer verifies the
+cursor is still within the buffer), so malformed, truncated, or adversarial input can cause
+out-of-bounds reads (undefined behavior) rather than a catchable parse error. Only use `no` with
+input you fully trust and control, such as data your own code just serialized — never with input
+received from an external or untrusted source.
+
 ### Values
 
 * `yes` - All checks are performed
-* `no` - Disable many parse time checks, assumes perfect input
+* `no` - Disable many parse time checks, assumes perfect, trusted input; malformed input is undefined behavior, not just a wrong result
 
 ### Default
 

--- a/docs/cookbook/unknown_types_and_raw_parsing.md
+++ b/docs/cookbook/unknown_types_and_raw_parsing.md
@@ -15,7 +15,7 @@ When the data structure is unknown or partially known it can be parsed as a `jso
 
 The above JSON describes an array of mixed types, string and number.
 
-To see a working example using this code, refer to [cookbook_unknown_types_and_delayed_parsing1_test.cpp](../../tests/src/cookbook_unknown_types_and_raw_parsing1_test.cpp).
+To see a working example using this code, refer to [cookbook_unknown_types_and_raw_parsing1_test.cpp](../../tests/src/cookbook_unknown_types_and_raw_parsing1_test.cpp).
 
 Below is the C++ code to parse and use it.
 
@@ -50,7 +50,7 @@ It is possible to delay the parsing of json members until a later time. The `jso
 
 The above JSON class has 3 members, a number, a class to parse later, and a string.
 
-To see a working example using this code, refer to [cookbook_unknown_types_and_delayed_parsing2_test.cpp](../../tests/src/cookbook_unknown_types_and_raw_parsing2_test.cpp).
+To see a working example using this code, refer to [cookbook_unknown_types_and_raw_parsing2_test.cpp](../../tests/src/cookbook_unknown_types_and_raw_parsing2_test.cpp).
 
 Below is the C++ code to parse and use it.
 
@@ -108,7 +108,7 @@ MyDelayedClass delayed_val = cls2.member_layer.template parse<MyDelayedClass>( )
 Parsing to a raw JSON string can be done too. the `json_raw` mapping type allows for an optional type argument that specifies the destination/source type. It requires that the
 type be constructable from a char const * and a std::size_t.
 
-To see a working example using this code, refer to [cookbook_unknown_types_and_delayed_parsing3_test.cpp](../../tests/src/cookbook_unknown_types_and_raw_parsing3_test.cpp).
+To see a working example using this code, refer to [cookbook_unknown_types_and_raw_parsing3_test.cpp](../../tests/src/cookbook_unknown_types_and_raw_parsing3_test.cpp).
 
 ```c++
 struct Thing {

--- a/include/daw/json/daw_from_json.h
+++ b/include/daw/json/daw_from_json.h
@@ -59,8 +59,10 @@ namespace daw::json {
 			  String,
 			  options::ZeroTerminatedString::yes>;
 
-			auto first = daw::not_null<char const *>( std::data( json_data ) );
-			auto last = daw::not_null<char const *>( daw::data_end( json_data ) );
+			auto first =
+			  daw::not_null<typename ParsePolicy::iterator>( std::data( json_data ) );
+			auto last = daw::not_null<typename ParsePolicy::iterator>(
+			  daw::data_end( json_data ) );
 			if( first != last and last[-1] == 0 ) {
 				--last;
 			}
@@ -103,6 +105,28 @@ namespace daw::json {
 			  "String type must have a be a contiguous range of Characters" );
 			return from_json<JsonMember, KnownBounds>( DAW_FWD( json_data ),
 			                                           options::parse_flags<> );
+		}
+
+		/// @brief Parse a writable JSON buffer with string mutation enabled.
+		/// The buffer must remain alive and at a stable address while borrowed
+		/// results are used. Parsing may modify the buffer, including on failure.
+		template<typename JsonMember, bool KnownBounds, typename String,
+		         auto... PolicyFlags>
+		[[nodiscard]] constexpr auto
+		from_json_insitu( String &&json_data,
+		                  options::parse_flags_t<PolicyFlags...> ) {
+			static_assert( std::is_same_v<decltype( std::data( json_data ) ), char *>,
+			               "from_json_insitu requires a mutable character buffer" );
+			return from_json<JsonMember, KnownBounds>(
+			  DAW_FWD( json_data ),
+			  options::parse_flags<PolicyFlags...,
+			                       options::AllowStringMutation::yes> );
+		}
+
+		template<typename JsonMember, bool KnownBounds, typename String>
+		[[nodiscard]] constexpr auto from_json_insitu( String &&json_data ) {
+			return from_json_insitu<JsonMember, KnownBounds>(
+			  DAW_FWD( json_data ), options::parse_flags<> );
 		}
 
 		/// @brief Construct the JSONMember from the JSON document argument.

--- a/include/daw/json/daw_from_json_fwd.h
+++ b/include/daw/json/daw_from_json_fwd.h
@@ -47,6 +47,18 @@ namespace daw::json {
 		template<typename JsonMember, bool KnownBounds = false, typename String>
 		[[nodiscard]] constexpr auto from_json( String &&json_data );
 
+		/// @brief Parse a writable JSON buffer with string mutation enabled.
+		/// The buffer must outlive borrowed results and keep a stable address.
+		/// Parsing may modify the buffer, including on failure.
+		template<typename JsonMember, bool KnownBounds = false, typename String,
+		         auto... PolicyFlags>
+		[[nodiscard]] constexpr auto
+		from_json_insitu( String &&json_data,
+		                  options::parse_flags_t<PolicyFlags...> );
+
+		template<typename JsonMember, bool KnownBounds = false, typename String>
+		[[nodiscard]] constexpr auto from_json_insitu( String &&json_data );
+
 		/// @brief Construct the JSONMember from the JSON document argument.
 		/// @tparam JsonMember any bool, arithmetic, string, string_view,
 		/// daw::json::json_data_contract

--- a/include/daw/json/daw_json_event_parser.h
+++ b/include/daw/json/daw_json_event_parser.h
@@ -345,8 +345,26 @@ namespace daw::json {
 			long long class_depth = 0;
 			long long array_depth = 0;
 
+			// Complete means the caller deliberately stopped early, possibly from
+			// inside a nested array/class; the class_depth/array_depth invariant
+			// checked below no longer applies in that case.
+			bool user_completed = false;
+			auto const complete_now = [&]( ) {
+				parent_stack.clear( );
+				user_completed = true;
+			};
+
+			// Skip remaining elements/members of the current class/array without
+			// firing further value events, by walking (not jumping to end( ), which
+			// is a sentinel with no real position) until the raw cursor lands on
+			// the container's closing bracket. This is what lets the subsequent
+			// "container exhausted" check and the matching end event fire
+			// correctly, same as reaching the end normally would.
 			auto const move_to_last = [&]( ) {
-				parent_stack.back( ).value.first = parent_stack.back( ).value.second;
+				auto &top = parent_stack.back( );
+				while( top.value.first ) {
+					++top.value.first;
+				}
 			};
 
 			auto const process_value = [&]( json_value_t p ) {
@@ -354,7 +372,7 @@ namespace daw::json {
 					auto result = json_details::handle_on_value( handler, p );
 					switch( result.value ) {
 					case json_parse_handler_result::Complete:
-						parent_stack.clear( );
+						complete_now( );
 						return;
 					case json_parse_handler_result::SkipClassArray:
 						move_to_last( );
@@ -371,7 +389,7 @@ namespace daw::json {
 					auto result = json_details::handle_on_array_start( handler, jv );
 					switch( result.value ) {
 					case json_parse_handler_result::Complete:
-						parent_stack.clear( );
+						complete_now( );
 						return;
 					case json_parse_handler_result::SkipClassArray:
 						move_to_last( );
@@ -392,7 +410,7 @@ namespace daw::json {
 					auto result = json_details::handle_on_class_start( handler, jv );
 					switch( result.value ) {
 					case json_parse_handler_result::Complete:
-						parent_stack.clear( );
+						complete_now( );
 						return;
 					case json_parse_handler_result::SkipClassArray:
 						move_to_last( );
@@ -412,7 +430,7 @@ namespace daw::json {
 					auto result = json_details::handle_on_number( handler, jv );
 					switch( result.value ) {
 					case json_parse_handler_result::Complete:
-						parent_stack.clear( );
+						complete_now( );
 						return;
 					case json_parse_handler_result::SkipClassArray:
 						move_to_last( );
@@ -425,7 +443,7 @@ namespace daw::json {
 					auto result = json_details::handle_on_bool( handler, jv );
 					switch( result.value ) {
 					case json_parse_handler_result::Complete:
-						parent_stack.clear( );
+						complete_now( );
 						return;
 					case json_parse_handler_result::SkipClassArray:
 						move_to_last( );
@@ -438,7 +456,7 @@ namespace daw::json {
 					auto result = json_details::handle_on_string( handler, jv );
 					switch( result.value ) {
 					case json_parse_handler_result::Complete:
-						parent_stack.clear( );
+						complete_now( );
 						return;
 					case json_parse_handler_result::SkipClassArray:
 						move_to_last( );
@@ -451,7 +469,7 @@ namespace daw::json {
 					auto result = json_details::handle_on_null( handler, jv );
 					switch( result.value ) {
 					case json_parse_handler_result::Complete:
-						parent_stack.clear( );
+						complete_now( );
 						return;
 					case json_parse_handler_result::SkipClassArray:
 						move_to_last( );
@@ -465,7 +483,7 @@ namespace daw::json {
 					auto result = json_details::handle_on_error( handler, jv );
 					switch( result.value ) {
 					case json_parse_handler_result::Complete:
-						parent_stack.clear( );
+						complete_now( );
 						return;
 					case json_parse_handler_result::SkipClassArray:
 						move_to_last( );
@@ -495,7 +513,7 @@ namespace daw::json {
 						auto result = json_details::handle_on_class_end( handler );
 						switch( result.value ) {
 						case json_parse_handler_result::Complete:
-							parent_stack.clear( );
+							complete_now( );
 							return;
 						case json_parse_handler_result::SkipClassArray:
 						case json_parse_handler_result::Continue:
@@ -512,7 +530,7 @@ namespace daw::json {
 						auto result = json_details::handle_on_array_end( handler );
 						switch( result.value ) {
 						case json_parse_handler_result::Complete:
-							parent_stack.clear( );
+							complete_now( );
 							return;
 						case json_parse_handler_result::SkipClassArray:
 						case json_parse_handler_result::Continue:
@@ -530,7 +548,8 @@ namespace daw::json {
 				parent_stack.pop_back( );
 				process_range( v );
 			}
-			daw_json_ensure( class_depth == 0 and array_depth == 0,
+			daw_json_ensure( user_completed or
+			                   ( class_depth == 0 and array_depth == 0 ),
 			                 ErrorReason::InvalidEndOfValue );
 		}
 

--- a/include/daw/json/daw_json_event_parser.h
+++ b/include/daw/json/daw_json_event_parser.h
@@ -17,6 +17,7 @@
 #include <daw/daw_cpp20_concept.h>
 #include <daw/daw_move.h>
 #include <daw/daw_string_view.h>
+#include <daw/daw_utility.h>
 
 #include <cstddef>
 #include <daw/stdinc/declval.h>
@@ -315,8 +316,10 @@ namespace daw::json {
 			}
 		};
 
-		template<typename StackContainerPolicy = use_default, json_options_t P,
-		         typename A, typename Handler, auto... ParseFlags>
+		template<typename StackContainerPolicy = use_default,
+		         std::size_t MaxDepth = daw::max_value<std::size_t>,
+		         json_options_t P, typename A, typename Handler,
+		         auto... ParseFlags>
 		constexpr void json_event_parser( basic_json_value<P, A> bjv,
 		                                  Handler &&handler,
 		                                  options::parse_flags_t<ParseFlags...> ) {
@@ -376,6 +379,10 @@ namespace daw::json {
 					case json_parse_handler_result::Continue:
 						break;
 					}
+					daw_json_ensure(
+					  static_cast<std::size_t>( class_depth + array_depth ) <=
+					    MaxDepth,
+					  ErrorReason::MaxDepthExceeded );
 					parent_stack.push_back(
 					  { StackParseStateType::Array,
 					    std::pair<iterator, iterator>( jv.begin( ), jv.end( ) ) } );
@@ -393,6 +400,10 @@ namespace daw::json {
 					case json_parse_handler_result::Continue:
 						break;
 					}
+					daw_json_ensure(
+					  static_cast<std::size_t>( class_depth + array_depth ) <=
+					    MaxDepth,
+					  ErrorReason::MaxDepthExceeded );
 					parent_stack.push_back(
 					  { StackParseStateType::Class,
 					    std::pair<iterator, iterator>( jv.begin( ), jv.end( ) ) } );
@@ -523,29 +534,33 @@ namespace daw::json {
 			                 ErrorReason::InvalidEndOfValue );
 		}
 
-		template<typename StackContainerPolicy = use_default, json_options_t P,
-		         typename A, typename Handler>
+		template<typename StackContainerPolicy = use_default,
+		         std::size_t MaxDepth = daw::max_value<std::size_t>,
+		         json_options_t P, typename A, typename Handler>
 		DAW_ATTRIB_INLINE constexpr void
 		json_event_parser( basic_json_value<P, A> bjv, Handler &&handler ) {
-			json_event_parser<StackContainerPolicy>(
+			json_event_parser<StackContainerPolicy, MaxDepth>(
 			  std::move( bjv ), DAW_FWD( handler ), options::parse_flags<> );
 		}
 
-		template<typename StackContainerPolicy = use_default, typename Handler,
-		         auto... ParseFlags>
+		template<typename StackContainerPolicy = use_default,
+		         std::size_t MaxDepth = daw::max_value<std::size_t>,
+		         typename Handler, auto... ParseFlags>
 		DAW_ATTRIB_INLINE void
 		json_event_parser( daw::string_view json_document, Handler &&handler,
 		                   options::parse_flags_t<ParseFlags...> pflags ) {
 
-			return json_event_parser<StackContainerPolicy>(
+			return json_event_parser<StackContainerPolicy, MaxDepth>(
 			  basic_json_value( json_document ), DAW_FWD( handler ), pflags );
 		}
 
-		template<typename StackContainerPolicy = use_default, typename Handler>
+		template<typename StackContainerPolicy = use_default,
+		         std::size_t MaxDepth = daw::max_value<std::size_t>,
+		         typename Handler>
 		DAW_ATTRIB_INLINE void json_event_parser( daw::string_view json_document,
 		                                          Handler &&handler ) {
 
-			return json_event_parser<StackContainerPolicy>(
+			return json_event_parser<StackContainerPolicy, MaxDepth>(
 			  basic_json_value( json_document ),
 			  DAW_FWD( handler ),
 			  options::parse_flags<> );

--- a/include/daw/json/daw_json_exception.h
+++ b/include/daw/json/daw_json_exception.h
@@ -90,7 +90,8 @@ namespace daw::json {
 			ExpectedTokenNotFound,
 			UnexpectedJSONVariantType,
 			TrailingComma,
-			AttemptToCallOpStarOnConstIterator
+			AttemptToCallOpStarOnConstIterator,
+			MaxDepthExceeded
 		};
 
 		constexpr std::string_view reason_message( ErrorReason er ) {
@@ -192,6 +193,8 @@ namespace daw::json {
 				return "Trailing comma"sv;
 			case ErrorReason::AttemptToCallOpStarOnConstIterator:
 				return "Use of operator*( ) on const iterator";
+			case ErrorReason::MaxDepthExceeded:
+				return "Maximum nesting depth exceeded"sv;
 			}
 			DAW_UNREACHABLE( );
 		}

--- a/include/daw/json/daw_json_iterator.h
+++ b/include/daw/json/daw_json_iterator.h
@@ -55,6 +55,10 @@ namespace daw::json {
 		 * Iterator for iterating over JSON array's
 		 * @tparam JsonElement type under underlying element in array. If
 		 * heterogeneous, a basic_json_value_iterator may be more appropriate
+		 * @note An exception from dereferencing or incrementing invalidates the
+		 * iterator. Before using it again, restore it by assigning a valid copy
+		 * saved before the operation that threw. Incrementing an invalidated
+		 * iterator is not a supported way to recover from a parsing error.
 		 * @tparam ParseState Parsing policy type
 		 */
 		template<typename JsonElement, typename ParseState, typename = void>
@@ -102,6 +106,8 @@ namespace daw::json {
 
 				m_state.remove_prefix( );
 				m_state.trim_left( );
+				daw_json_assert_weak(
+				  m_state.has_more( ), ErrorReason::UnexpectedEndOfData, m_state );
 			}
 
 			explicit constexpr json_array_iterator_t( daw::string_view jd,
@@ -115,6 +121,8 @@ namespace daw::json {
 
 				m_state.remove_prefix( );
 				m_state.trim_left( );
+				daw_json_assert_weak(
+				  m_state.has_more( ), ErrorReason::UnexpectedEndOfData, m_state );
 			}
 
 			/// @return The iterator representing the beginning of the iteration.
@@ -167,7 +175,17 @@ namespace daw::json {
 				} else {
 					(void)json_details::skip_known_value<element_type>( m_state );
 				}
+				m_state.trim_left( );
+				daw_json_assert_weak( m_state.has_more( ) and
+				                        m_state.is_at_next_array_element( ),
+				                      ErrorReason::UnexpectedEndOfData,
+				                      m_state );
+
 				m_state.move_next_member_or_end( );
+				m_state.trim_left( );
+				daw_json_assert_weak(
+				  m_state.has_more( ), ErrorReason::UnexpectedEndOfData, m_state );
+
 				return *this;
 			}
 
@@ -198,10 +216,12 @@ namespace daw::json {
 			/// @return true when equivalent to rhs
 			[[nodiscard]] constexpr bool
 			operator==( json_array_iterator_t const &rhs ) const {
-				if( not( *this ) ) {
-					return not rhs;
+				auto const not_lhs = not( *this );
+				auto const not_rhs = not( rhs );
+				if( not_lhs ) {
+					return not_rhs;
 				}
-				if( not rhs ) {
+				if( not_rhs ) {
 					return false;
 				}
 				return ( m_state.first == rhs.m_state.first );
@@ -227,8 +247,12 @@ namespace daw::json {
 		  JsonElement,
 		  TryDefaultParsePolicy<BasicParsePolicy<
 		    options::details::make_parse_flags<PolicyFlags...>( ).value>>>;
-		/// Iterator for iterating over JSON array's. Requires that op
-		/// op++ be called in that sequence one time until end is reached
+		/// Iterator for iterating over JSON arrays. Requires that operator* and
+		/// operator++ be called in that sequence one time until end is reached.
+		/// @note An exception from dereferencing or incrementing invalidates the
+		/// iterator. Before using it again, restore it by assigning a valid copy
+		/// saved before the operation that threw. Incrementing an invalidated
+		/// iterator is not a supported way to recover from a parsing error.
 		/// @tparam JsonElement type under underlying element in array.If
 		/// *heterogeneous, a basic_json_value_iterator may be more appropriate
 		template<typename JsonElement, auto... PolicyFlags>
@@ -271,6 +295,8 @@ namespace daw::json {
 
 				m_state.remove_prefix( );
 				m_state.trim_left( );
+				daw_json_assert_weak(
+				  m_state.has_more( ), ErrorReason::UnexpectedEndOfData, m_state );
 			}
 
 			explicit constexpr json_array_iterator_once( daw::string_view jd,
@@ -284,6 +310,8 @@ namespace daw::json {
 
 				m_state.remove_prefix( );
 				m_state.trim_left( );
+				daw_json_assert_weak(
+				  m_state.has_more( ), ErrorReason::UnexpectedEndOfData, m_state );
 			}
 
 			/// @brief Parse the current element
@@ -304,10 +332,13 @@ namespace daw::json {
 			 * @return iterator after moving
 			 */
 			constexpr json_array_iterator_once &operator++( ) {
-				daw_json_assert_weak( m_state.has_more( ) and m_state.front( ) != ']',
+				daw_json_assert_weak( m_state.has_more( ) and
+				                        m_state.is_at_next_array_element( ),
 				                      ErrorReason::UnexpectedEndOfData,
 				                      m_state );
 				m_state.move_next_member_or_end( );
+				daw_json_assert_weak(
+				  m_state.has_more( ), ErrorReason::UnexpectedEndOfData, m_state );
 				return *this;
 			}
 
@@ -338,10 +369,12 @@ namespace daw::json {
 			/// @return true when equivalent to rhs
 			[[nodiscard]] constexpr bool
 			operator==( json_array_iterator_once const &rhs ) const {
-				if( not( *this ) ) {
-					return static_cast<bool>( rhs );
+				auto const not_lhs = not( *this );
+				auto const not_rhs = not( rhs );
+				if( not_lhs ) {
+					return not_rhs;
 				}
-				if( not rhs ) {
+				if( not_rhs ) {
 					return false;
 				}
 				return ( m_state.first == rhs.m_state.first );
@@ -352,10 +385,12 @@ namespace daw::json {
 			/// @return true when rhs is not equivalent
 			[[nodiscard]] constexpr bool
 			operator!=( json_array_iterator_once const &rhs ) const {
-				if( not( *this ) ) {
-					return not rhs;
+				auto const not_lhs = not( *this );
+				auto const not_rhs = not( rhs );
+				if( not_lhs ) {
+					return not not_rhs;
 				}
-				if( not rhs ) {
+				if( not_rhs ) {
 					return true;
 				}
 				return m_state.first != rhs.m_state.first;

--- a/include/daw/json/daw_json_iterator.h
+++ b/include/daw/json/daw_json_iterator.h
@@ -55,7 +55,7 @@ namespace daw::json {
 		 * Iterator for iterating over JSON array's
 		 * @tparam JsonElement type under underlying element in array. If
 		 * heterogeneous, a basic_json_value_iterator may be more appropriate
-		 * @tparam ParsePolicy Parsing policy type
+		 * @tparam ParseState Parsing policy type
 		 */
 		template<typename JsonElement, typename ParseState, typename = void>
 		class json_array_iterator_t {
@@ -231,7 +231,6 @@ namespace daw::json {
 		/// op++ be called in that sequence one time until end is reached
 		/// @tparam JsonElement type under underlying element in array.If
 		/// *heterogeneous, a basic_json_value_iterator may be more appropriate
-		/// @tparam ParsePolicy Parsing policy type
 		template<typename JsonElement, auto... PolicyFlags>
 		class json_array_iterator_once {
 			using ParseState = TryDefaultParsePolicy<BasicParsePolicy<
@@ -365,7 +364,6 @@ namespace daw::json {
 
 		/// @brief A range of json_array_iterators
 		/// @tparam JsonElement Type of each element in array
-		/// @tparam ParsePolicy parsing policy type
 		template<typename JsonElement, auto... PolicyFlags>
 		struct json_array_range {
 			using ParsePolicy = TryDefaultParsePolicy<BasicParsePolicy<
@@ -406,7 +404,6 @@ namespace daw::json {
 		/// @brief A range of json_array_iterator_onces.  Requires that op*/op++ be
 		/// called in that sequence one time untl end is reached
 		/// @tparam JsonElement Type of each element in array
-		/// @tparam ParsePolicy parsing policy type
 		template<typename JsonElement, auto... PolicyFlags>
 		struct json_array_range_once {
 			using ParsePolicy = TryDefaultParsePolicy<BasicParsePolicy<

--- a/include/daw/json/daw_json_iterator.h
+++ b/include/daw/json/daw_json_iterator.h
@@ -63,8 +63,7 @@ namespace daw::json {
 			static constexpr ParseState get_range( daw::string_view data,
 			                                       daw::string_view member_path ) {
 				auto [result, is_found] = json_details::find_range<ParseState>(
-				  DAW_FWD( data ),
-				  { std::data( member_path ), std::size( member_path ) } );
+				  data, { std::data( member_path ), std::size( member_path ) } );
 				daw_json_ensure( is_found, ErrorReason::JSONPathNotFound );
 				daw_json_ensure(
 				  result.front( ) == '[', ErrorReason::InvalidArrayStart, result );
@@ -241,8 +240,7 @@ namespace daw::json {
 			static constexpr ParseState get_range( daw::string_view data,
 			                                       daw::string_view member_path ) {
 				auto [result, is_found] = json_details::find_range<ParseState>(
-				  DAW_FWD( data ),
-				  { std::data( member_path ), std::size( member_path ) } );
+				  data, { std::data( member_path ), std::size( member_path ) } );
 				daw_json_ensure( is_found, ErrorReason::JSONPathNotFound );
 				daw_json_ensure(
 				  result.front( ) == '[', ErrorReason::InvalidArrayStart, result );

--- a/include/daw/json/daw_json_link_types.h
+++ b/include/daw/json/daw_json_link_types.h
@@ -936,6 +936,68 @@ namespace daw::json {
 		  JsonNullable::NullVisible, Constructor>;
 
 		namespace json_base {
+			template<typename String, json_options_t Options, typename Constructor>
+			struct json_string_insitu {
+				using i_am_a_json_type = void;
+
+				using constructor_t =
+				  daw::conditional_t<std::is_same_v<use_default, Constructor>,
+				                     default_constructor<String>, Constructor>;
+
+				static_assert(
+				  daw::is_callable_v<constructor_t, String>,
+				  "Constructor must support copy and/or move construction" );
+				using parse_to_t = std::invoke_result_t<constructor_t, String>;
+
+				static constexpr auto expected_type = JsonParseTypes::StringInsitu;
+
+				static constexpr options::EightBitModes eight_bit_mode =
+				  json_details::get_bits_for<options::EightBitModes>( string_opts,
+				                                                      Options );
+
+				static constexpr auto escape_output =
+				  json_details::get_bits_for<options::EscapeValidUTF8>( string_opts,
+				                                                        Options );
+
+				static constexpr auto underlying_json_type = JsonBaseParseTypes::String;
+
+				template<JSONNAMETYPE NewName>
+				using with_name =
+				  daw::json::json_string_insitu<NewName, String, Options, Constructor>;
+
+				using as_string = json_string_insitu;
+			};
+		} // namespace json_base
+
+		/**
+		 * Decode a JSON string in place and borrow its storage by default.
+		 * Requires AllowStringMutation::yes (normally via from_json_insitu).
+		 * The input is consumed: it must not be parsed again after mutation.
+		 * Keep its storage alive and at a stable address while using views.
+		 * No null terminator is written; embedded nulls are supported.
+		 * Constructor receives (char *, std::size_t).
+		 */
+
+		template<JSONNAMETYPE Name, typename String, json_options_t Options,
+		         typename Constructor>
+		struct json_string_insitu : json_base::json_string_insitu<String, Options, Constructor> {
+			static constexpr daw::string_view name = Name;
+
+			using without_name = json_base::json_string_insitu<String, Options, Constructor>;
+		};
+
+		template<typename T = std::string_view, json_options_t Options = string_opts_def,
+		         typename Constructor = use_default>
+		using json_string_insitu_no_name = json_base::json_string_insitu<T, Options, Constructor>;
+
+		template<typename T = std::optional<std::string_view>,
+		         json_options_t Options = string_opts_def,
+		         typename Constructor = use_default>
+		using json_string_insitu_null_no_name = json_base::json_nullable<
+		  T, json_base::json_string_insitu<json_details::unwrapped_t<T>, Options>,
+		  JsonNullable::NullVisible, Constructor>;
+
+		namespace json_base {
 			template<typename T, typename Constructor>
 			struct json_date {
 				using clock_type = typename T::clock;

--- a/include/daw/json/daw_json_parse_options.h
+++ b/include/daw/json/daw_json_parse_options.h
@@ -50,6 +50,14 @@ namespace daw::json {
 					yes
 				}; // 1bit
 
+				enum class AllowStringMutation : unsigned {
+					/// @brief String is not allowed to be mutated.
+					no,
+					/// @brief String maybe mutated during parsing.  This is useful for
+					/// json_string_insitu
+					yes
+				}; // 1 bit
+
 				///
 				/// @brief Allow comments in JSON.  The supported modes are none, C++
 				/// style comments, and # hash style comments.  Default is none, no

--- a/include/daw/json/daw_json_schema.h
+++ b/include/daw/json/daw_json_schema.h
@@ -167,6 +167,13 @@ namespace daw::json {
 
 			template<typename JsonMember, bool is_root = false, typename WritableType>
 			constexpr WritableType
+			to_json_schema( ParseTag<JsonParseTypes::StringInsitu>, WritableType out_it ) {
+				return to_json_schema<JsonMember, is_root>(
+				  ParseTag<JsonParseTypes::StringEscaped>{ }, out_it );
+			}
+
+			template<typename JsonMember, bool is_root = false, typename WritableType>
+			constexpr WritableType
 			to_json_schema( ParseTag<JsonParseTypes::StringRaw>,
 			                WritableType out_it ) {
 

--- a/include/daw/json/daw_json_serialize_options.h
+++ b/include/daw/json/daw_json_serialize_options.h
@@ -65,7 +65,7 @@ namespace daw::json {
 					/// When invalid UTF8 is encountered, throw an error
 					ErrorInvalidUTF8,
 					/* Restrict all string member values and all member names to 7bits.
-					   This will result in escaping all values >= 0x7F.  This can affect
+					   This will result in escaping all values >= 0x80.  This can affect
 					   round trips where the name contains high bits set*/
 					OnlyAllow7bitStrings
 				};

--- a/include/daw/json/daw_json_serialize_options.h
+++ b/include/daw/json/daw_json_serialize_options.h
@@ -56,7 +56,7 @@ namespace daw::json {
 				///
 				/// @brief Allow for restricting the output of strings to 7bits
 				///
-				/// default: None
+				/// default: ErrorInvalidUTF8
 				///
 				enum class RestrictedStringOutput : unsigned {
 					/* Do not impose any extra restrictions on string output during
@@ -67,7 +67,7 @@ namespace daw::json {
 					/* Restrict all string member values and all member names to 7bits.
 					   This will result in escaping all values >= 0x7F.  This can affect
 					   round trips where the name contains high bits set*/
-					OnlyAllow7bitsStrings
+					OnlyAllow7bitStrings
 				};
 
 				///

--- a/include/daw/json/daw_json_switches.h
+++ b/include/daw/json/daw_json_switches.h
@@ -120,7 +120,13 @@
 
 // Use strtod instead of from_chars when avialable by defining
 // DAW_JSON_USE_STRTOD
-#if not defined( DAW_JSON_USE_STRTOD ) and not defined( __cpp_lib_to_chars )
+#if defined( __cpp_lib_to_chars )
+#if __cpp_lib_to_chars >= 201611L
+#define DAW_HAS_CPP17_FP_FROM_CHARS 1
+#endif
+#endif
+#if not defined( DAW_JSON_USE_STRTOD ) and \
+  not defined( DAW_HAS_CPP17_FP_FROM_CHARS )
 #define DAW_JSON_USE_STRTOD
 #endif
 

--- a/include/daw/json/daw_json_value_state.h
+++ b/include/daw/json/daw_json_value_state.h
@@ -16,6 +16,7 @@
 #include "daw/json/impl/daw_json_value.h"
 #include "daw/json/impl/daw_murmur3.h"
 
+#include <daw/daw_arith_traits.h>
 #include <daw/daw_enable_requires.h>
 #include <daw/daw_move.h>
 #include <daw/daw_string_view.h>
@@ -242,7 +243,7 @@ namespace daw::json {
 				switch( current_type ) {
 				case JsonBaseParseTypes::Array:
 				case JsonBaseParseTypes::Class:
-					return move_to( ( daw::numeric_limits<std::size_t>::max )( ) );
+					return move_to( daw::max_value<std::size_t> );
 				case JsonBaseParseTypes::Number:
 				case JsonBaseParseTypes::Bool:
 				case JsonBaseParseTypes::String:

--- a/include/daw/json/daw_json_writer.h
+++ b/include/daw/json/daw_json_writer.h
@@ -391,7 +391,7 @@ namespace daw::json {
 			constexpr void write_number( T const &value ) {
 				using JsonMember =
 				  json_writer_details::json_write_value_class_t<JsonClass, T>;
-				constexpr JsonBaseParseTypes json_base_type =
+				DAW_CPP23_STATIC_LOCAL constexpr JsonBaseParseTypes json_base_type =
 				  JsonMember::underlying_json_type;
 				static_assert(
 				  json_base_type == JsonBaseParseTypes::Number or
@@ -410,7 +410,7 @@ namespace daw::json {
 			constexpr void write_string( T const &value ) {
 				using JsonMember =
 				  json_writer_details::json_write_value_class_t<JsonClass, T>;
-				constexpr JsonBaseParseTypes json_base_type =
+				DAW_CPP23_STATIC_LOCAL constexpr JsonBaseParseTypes json_base_type =
 				  JsonMember::underlying_json_type;
 				if constexpr( json_base_type == JsonBaseParseTypes::String ) {
 					write_value<JsonClass>( value );

--- a/include/daw/json/daw_json_writer.h
+++ b/include/daw/json/daw_json_writer.h
@@ -115,9 +115,9 @@ namespace daw::json {
 						m_writer.write( "null" );
 					} else {
 						if constexpr( std::is_convertible_v<T, char const *> ) {
-							m_writer =
-							  json_details::member_to_string<json_string_raw_no_name<daw::string_view>>(
-							    m_writer, daw::string_view( value ) );
+							m_writer = json_details::member_to_string<
+							  json_string_raw_no_name<daw::string_view>>(
+							  m_writer, daw::string_view( value ) );
 						} else {
 							m_writer =
 							  json_details::member_to_string<json_class_t>( m_writer, value );
@@ -192,6 +192,10 @@ namespace daw::json {
 				}
 				m_writer.del_indent( );
 				if( not m_is_first ) {
+					if constexpr( iterator_t::output_trailing_comma ==
+					              options::OutputTrailingComma::Yes ) {
+						m_writer.put( ',' );
+					}
 					m_writer.next_member( );
 				}
 				m_writer.put( '}' );
@@ -215,6 +219,10 @@ namespace daw::json {
 				  ErrorReason::OutputError );
 				m_writer.del_indent( );
 				if( not m_is_first ) {
+					if constexpr( iterator_t::output_trailing_comma ==
+					              options::OutputTrailingComma::Yes ) {
+						m_writer.put( ',' );
+					}
 					m_writer.next_member( );
 				}
 				m_writer.put( ']' );

--- a/include/daw/json/daw_json_writer.h
+++ b/include/daw/json/daw_json_writer.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-// Allow writing to a Writer incrementally
-
 #include "daw/json/impl/version.h"
 
 #include "daw/json/concepts/daw_writable_output.h"
@@ -106,19 +104,28 @@ namespace daw::json {
 
 			template<typename JsonClass = use_default, typename T>
 			constexpr void do_write_value( T const &value ) {
+				using json_class_t = typename daw::conditional_t<
+				  std::is_same_v<use_default, JsonClass>,
+				  json_details::ident_trait<json_details::json_deduced_type, T>,
+				  json_details::ident_trait<json_details::json_deduced_type,
+				                            JsonClass>>::type;
 				prepare_value( );
 				if constexpr( std::is_pointer_v<std::remove_reference_t<T>> ) {
 					if( not value ) {
 						m_writer.write( "null" );
 					} else {
 						if constexpr( std::is_convertible_v<T, char const *> ) {
-							to_json<JsonClass>( daw::string_view( value ), m_writer.get( ) );
+							m_writer =
+							  json_details::member_to_string<json_string_raw_no_name<daw::string_view>>(
+							    m_writer, daw::string_view( value ) );
 						} else {
-							to_json<JsonClass>( value, m_writer.get( ) );
+							m_writer =
+							  json_details::member_to_string<json_class_t>( m_writer, value );
 						}
 					}
 				} else {
-					to_json<JsonClass>( value, m_writer.get( ) );
+					m_writer =
+					  json_details::member_to_string<json_class_t>( m_writer, value );
 				}
 				m_is_first = false;
 			}
@@ -405,7 +412,20 @@ namespace daw::json {
 				}
 			}
 
-			/// When outputting a class, uses default to_json
+		private:
+			template<typename T>
+			DAW_CPP20_CX_ALLOC void write_string_class( T const &value ) {
+				using json_class_t = json_details::json_deduced_type<T>;
+				auto tmp = std::string{ };
+				auto tmp_iterator =
+				  json_details::make_output_iterator<PolicyFlags...>( tmp );
+				tmp_iterator.indentation_level = m_writer.indentation_level;
+				(void)json_details::member_to_string<json_class_t>( tmp_iterator,
+				                                                    value );
+				do_write_value<json_string_no_name<>>( tmp );
+			}
+
+		public:
 			template<typename JsonClass = use_default, typename T>
 			constexpr void write_string( T const &value ) {
 				using JsonMember =
@@ -418,12 +438,12 @@ namespace daw::json {
 				                     json_base_type == JsonBaseParseTypes::Number ) {
 					prepare_value( );
 					m_writer.put( '"' );
-					to_json<JsonClass>( value, m_writer.get( ) );
+					m_writer =
+					  json_details::member_to_string<JsonMember>( m_writer, value );
 					m_writer.put( '"' );
 					m_is_first = false;
 				} else {
-					auto const tmp = to_json( value );
-					do_write_value<json_string_no_name<>>( tmp );
+					write_string_class( value );
 				}
 			}
 

--- a/include/daw/json/daw_to_json.h
+++ b/include/daw/json/daw_to_json.h
@@ -69,8 +69,8 @@ namespace daw::json {
 			auto out_it =
 			  json_details::apply_policy_flags<output_t, PolicyFlags...>( it );
 
-			return json_details::member_to_string<json_class_t>( out_it, value )
-			  .get( );
+			out_it = json_details::member_to_string<json_class_t>( out_it, value );
+			return out_it.get( );
 		}
 
 		template<typename JsonClass, typename Value, auto... PolicyFlags>

--- a/include/daw/json/impl/daw_fp_fallback.h
+++ b/include/daw/json/impl/daw_fp_fallback.h
@@ -17,7 +17,7 @@
 #include <daw/daw_not_null.h>
 
 #include <cstdlib>
-#include <limits>
+#include <string>
 #include <system_error>
 #include <type_traits>
 
@@ -52,10 +52,17 @@ namespace daw::json {
 				Real result;
 				auto fc_res = std::from_chars( first, last, result );
 				if( fc_res.ec == std::errc::result_out_of_range ) {
-					if( *first == '-' ) {
-						return -std::numeric_limits<Real>::infinity( );
+					// from_chars reports the same error for overflow and underflow.
+					// Retry this cold path with a bounded, null-terminated token so
+					// subnormal values are not incorrectly returned as infinity.
+					auto const token = std::string( first.get( ), last.get( ) );
+					if constexpr( std::is_same_v<Real, float> ) {
+						return std::strtof( token.c_str( ), nullptr );
+					} else if constexpr( std::is_same_v<Real, double> ) {
+						return std::strtod( token.c_str( ), nullptr );
+					} else {
+						return std::strtold( token.c_str( ), nullptr );
 					}
-					return std::numeric_limits<Real>::infinity( );
 				}
 				daw_json_ensure( fc_res.ec == std::errc( ),
 				                 ErrorReason::InvalidNumber );

--- a/include/daw/json/impl/daw_json_allocator_wrapper.h
+++ b/include/daw/json/impl/daw_json_allocator_wrapper.h
@@ -38,10 +38,10 @@ namespace daw::json {
 			};
 
 			template<typename Alloc>
-			class AllocatorWrapperBase<Alloc, true /*is_empty*/> {
+			class AllocatorWrapperBase<Alloc, true /*is_empty*/>
+			  : std::remove_reference_t<Alloc> {
 				using has_stateless_allocator = void;
 				using allocator_t = std::remove_reference_t<Alloc>;
-				static constexpr allocator_t allocator{ };
 
 			public:
 				explicit AllocatorWrapperBase( ) = default;
@@ -49,7 +49,7 @@ namespace daw::json {
 				  allocator_t const & ) noexcept {}
 
 				[[nodiscard]] constexpr allocator_t const &get_allocator( ) const {
-					return allocator;
+					return *static_cast<allocator_t *>( this );
 				}
 			};
 

--- a/include/daw/json/impl/daw_json_assert.h
+++ b/include/daw/json/impl/daw_json_assert.h
@@ -34,7 +34,7 @@ namespace daw::json {
 	inline constexpr bool use_daw_json_exceptions_v = false;
 #endif
 
-	static thread_local void *daw_json_error_handler_data = nullptr;
+	inline thread_local void *daw_json_error_handler_data = nullptr;
 
 #if defined( DAW_USE_EXCEPTIONS )
 	[[noreturn, maybe_unused]] DAW_ATTRIB_NOINLINE inline void
@@ -57,10 +57,10 @@ namespace daw::json {
 	  daw::not_null<void ( * )( json_exception &&, void * )>;
 
 #if defined( DAW_USE_EXCEPTIONS )
-	static thread_local daw_json_error_handler_t daw_json_error_handler =
+	inline thread_local daw_json_error_handler_t daw_json_error_handler =
 	  default_error_handler_throwing;
 #else
-	static thread_local daw_json_error_handler_t daw_json_error_handler =
+	inline thread_local daw_json_error_handler_t daw_json_error_handler =
 	  default_error_handler_terminating;
 #endif
 

--- a/include/daw/json/impl/daw_json_default_constuctor.h
+++ b/include/daw/json/impl/daw_json_default_constuctor.h
@@ -70,7 +70,7 @@ namespace daw::json {
 			DAW_JSON_CPP23_STATIC_CALL_OP_DISABLE_WARNING DAW_ATTRIB_INLINE
 			  DAW_JSON_CPP23_STATIC_CALL_OP constexpr std::array<T, Sz>
 			  operator( )( std::array<T, Sz> &&v )
-			    DAW_JSON_CPP23_STATIC_CALL_OP_CONST noexcept {
+			    DAW_JSON_CPP23_STATIC_CALL_OP_CONST {
 				return std::move( v );
 			}
 

--- a/include/daw/json/impl/daw_json_default_constuctor.h
+++ b/include/daw/json/impl/daw_json_default_constuctor.h
@@ -135,7 +135,8 @@ namespace daw::json {
 					  json_details::iter_range_t{ std::move( first ), std::move( last ) },
 					  alloc );
 				} else {
-					using reserve_amount = daw::constant<4096U / ( sizeof( T ) * 8U )>;
+					using reserve_amount = daw::constant<
+					  ( 4096U / sizeof( T ) ) == 0 ? 1 : ( 4096U / sizeof( T ) )>;
 					auto result = std::vector<T, Alloc>( alloc );
 					// Lets use a WAG and go for a 4k page size
 					result.reserve( reserve_amount::value );

--- a/include/daw/json/impl/daw_json_enums.h
+++ b/include/daw/json/impl/daw_json_enums.h
@@ -50,6 +50,7 @@ namespace daw::json {
 			ReflectedClass, /// A class that has no backing and falls back to C++26
 			                /// reflection
 #endif
+			StringInsitu, /// String - Decoded into the mutable input buffer
 			Submember, /// Locate a path within a class/array member before parsing
 		};
 

--- a/include/daw/json/impl/daw_json_link_types_fwd.h
+++ b/include/daw/json/impl/daw_json_link_types_fwd.h
@@ -346,6 +346,30 @@ namespace daw::json {
 		using json_string_null = json_nullable<
 		  Name, T, json_base::json_string<json_details::unwrapped_t<T>, Options>,
 		  NullableType, Constructor>;
+		/// Decode string values in the writable input buffer.
+
+		template<JSONNAMETYPE Name, typename String = std::string_view,
+		         json_options_t Options = string_opts_def,
+		         typename Constructor = use_default>
+		struct json_string_insitu;
+
+		/**
+		 * Member is a nullable escaped string and requires unescaping and escaping
+		 * of string data
+		 * @tparam Name of json member
+		 * @tparam String result type constructed by Constructor
+		 * @tparam Options Options created with options::string_opt
+		 * @tparam NullableType Whether an empty class member may be omitted or must
+		 * be emitted as null
+		 * @tparam Constructor Callable used to construct the result string
+		 */
+		template<JSONNAMETYPE Name, typename T = std::optional<std::string_view>,
+		         json_options_t Options = string_opts_def,
+		         JsonNullable NullableType = JsonNullable::Nullable,
+		         typename Constructor = use_default>
+		using json_string_insitu_null = json_nullable<
+		  Name, T, json_base::json_string_insitu<json_details::unwrapped_t<T>, Options>,
+		  NullableType, Constructor>;
 		/**
 		 * Member is an escaped string and requires unescaping and escaping of
 		 * string data

--- a/include/daw/json/impl/daw_json_location_info.h
+++ b/include/daw/json/impl/daw_json_location_info.h
@@ -34,12 +34,13 @@
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
 		namespace json_details {
+			template<typename Iterator = char const *>
 			struct location_info_t {
 				daw::string_view name;
-				char const *first = nullptr;
-				char const *last = nullptr;
-				char const *class_first = nullptr;
-				char const *class_last = nullptr;
+				Iterator first = nullptr;
+				Iterator last = nullptr;
+				Iterator class_first = nullptr;
+				Iterator class_last = nullptr;
 				std::size_t counter = 0;
 
 				[[nodiscard]] constexpr bool missing( ) const {
@@ -66,9 +67,10 @@ namespace daw::json {
 			 * Contains an array of member location_info mapped in a json_class
 			 * @tparam MemberCount Number of mapped members from json_class
 			 */
-			template<std::size_t MemberCount, bool DoFullNameMatch = true>
+			template<std::size_t MemberCount, bool DoFullNameMatch = true,
+			         typename Iterator = char const *>
 			struct locations_info_t {
-				using value_type = location_info_t;
+				using value_type = location_info_t<Iterator>;
 				using reference = value_type &;
 				using const_reference = value_type const &;
 				static constexpr bool do_full_name_match = DoFullNameMatch;
@@ -139,9 +141,9 @@ namespace daw::json {
 				                     do_hashes_collide<JsonMembers...>( )>;
 #endif
 				return locations_info_t<sizeof...( JsonMembers ),
-				                        do_full_name_match::value>{
+				                        do_full_name_match::value, typename ParseState::iterator>{
 				  /*hashes*/ { daw::name_hash<false>( JsonMembers::name )... },
-				  /*names*/ { location_info_t{ JsonMembers::name }... } };
+				  /*names*/ { location_info_t<typename ParseState::iterator>{ JsonMembers::name }... } };
 			}
 
 			/***
@@ -160,7 +162,7 @@ namespace daw::json {
 			         bool B>
 			[[nodiscard]] DAW_ATTRIB_INLINE static constexpr find_result<ParseState>
 			find_class_member( ParseState &parse_state,
-			                   locations_info_t<N, B> &locations, bool is_nullable,
+			                   locations_info_t<N, B, typename ParseState::iterator> &locations, bool is_nullable,
 			                   daw::string_view member_name ) {
 
 				// silencing gcc9 warning as these are selectively used

--- a/include/daw/json/impl/daw_json_parse_class.h
+++ b/include/daw/json/impl/daw_json_parse_class.h
@@ -154,7 +154,7 @@ namespace daw::json {
 			         typename ParseState, std::size_t N, bool B>
 			[[nodiscard]] DAW_ATTRIB_INLINE constexpr json_result_t<JsonMember>
 			parse_class_member( ParseState &parse_state,
-			                    locations_info_t<N, B> &locations ) {
+			                    locations_info_t<N, B, typename ParseState::iterator> &locations ) {
 				parse_state.move_next_member_or_end( );
 
 				daw_json_assert_weak( not parse_state.empty( ) and

--- a/include/daw/json/impl/daw_json_parse_common.h
+++ b/include/daw/json/impl/daw_json_parse_common.h
@@ -334,6 +334,12 @@ namespace daw::json {
 						} else {
 							return json_link_quick_map_type<json_base::json_string<T>>{ };
 						}
+					} else if constexpr( parse_type::value == JsonParseTypes::StringInsitu ) {
+						if constexpr( is_null::value ) {
+							return json_link_quick_map_type<json_base::json_string_null<T>>{ };
+						} else {
+							return json_link_quick_map_type<json_base::json_string<T>>{ };
+						}
 					} else if constexpr( parse_type::value == JsonParseTypes::Bool ) {
 						if constexpr( is_null::value ) {
 							return json_link_quick_map_type<json_base::json_bool_null<T>>{ };

--- a/include/daw/json/impl/daw_json_parse_iso8601_utils.h
+++ b/include/daw/json/impl/daw_json_parse_iso8601_utils.h
@@ -198,6 +198,18 @@ namespace daw::json {
 				}
 				result.year =
 				  datetime_details::parse_number<std::int_least32_t>( timestamp_str );
+				auto max_day = std::uint32_t{ 31 };
+				if( result.month == 2 ) {
+					auto const is_leap_year =
+					  result.year % 4 == 0 and
+					  ( result.year % 100 != 0 or result.year % 400 == 0 );
+					max_day = is_leap_year ? 29U : 28U;
+				} else if( result.month == 4 or result.month == 6 or
+				           result.month == 9 or result.month == 11 ) {
+					max_day = 30;
+				}
+				daw_json_ensure( result.day <= max_day,
+				                 ErrorReason::InvalidTimestamp );
 				return result;
 			}
 
@@ -221,6 +233,8 @@ namespace daw::json {
 				  std::data( timestamp_str.pop_front( 2 ) ) );
 				daw_json_ensure( result.minute <= 59, ErrorReason::InvalidTimestamp );
 				if( timestamp_str.empty( ) ) {
+					daw_json_ensure( result.hour != 24 or result.minute == 0,
+					                 ErrorReason::InvalidTimestamp );
 					return result;
 				}
 				if( not parse_utils::is_number( timestamp_str.front( ) ) ) {
@@ -230,6 +244,9 @@ namespace daw::json {
 				  std::data( timestamp_str.pop_front( 2 ) ) );
 				daw_json_ensure( result.second <= 60, ErrorReason::InvalidTimestamp );
 				if( timestamp_str.empty( ) ) {
+					daw_json_ensure( result.hour != 24 or
+					                   ( result.minute == 0 and result.second == 0 ),
+					                 ErrorReason::InvalidTimestamp );
 					return result;
 				}
 				daw_json_ensure( timestamp_str.front( ) == '.',
@@ -247,6 +264,11 @@ namespace daw::json {
 				result.attosecond =
 				  datetime_details::parse_number<std::uint64_t>( attosecond_str );
 				result.attosecond *= daw::cxmath::pow10( 18 - precision );
+				daw_json_ensure(
+				  result.hour != 24 or
+				    ( result.minute == 0 and result.second == 0 and
+				      result.attosecond == 0 ),
+				  ErrorReason::InvalidTimestamp );
 				return result;
 			}
 
@@ -255,65 +277,94 @@ namespace daw::json {
 				DAW_CPP23_STATIC_LOCAL constexpr daw::string_view t_str = "T";
 				auto const date_str = ts.pop_front_until( t_str );
 				if( ts.empty( ) ) {
-					daw_json_error(
-					  true,
-					  ErrorReason::InvalidTimestamp ); // Invalid timestamp,
-					                                   // missing T separator
+					daw_json_error( true,
+					                ErrorReason::InvalidTimestamp ); // Invalid timestamp,
+					// missing T separator
 				}
 
 				date_parts const ymd = parse_iso_8601_date( date_str );
-				auto time_str =
-				  ts.pop_front_until( []( char c ) DAW_JSON_CPP23_STATIC_CALL_OP {
+				auto time_str = ts.pop_front_until(
+				  []( char c ) DAW_JSON_CPP23_STATIC_CALL_OP {
 					  return not( parse_utils::is_number( c ) | ( c == ':' ) |
 					              ( c == '.' ) );
-				  } );
+				  },
+				  nodiscard );
 				// TODO: verify or parse timezone
-				auto hms = parse_iso_8601_time( time_str );
-				if( not( ts.empty( ) or ts.front( ) == 'Z' ) ) {
-					daw_json_ensure( std::size( ts ) == 5 or std::size( ts ) == 6,
-					                 ErrorReason::InvalidTimestamp );
-					// The format will be (+|-)hh[:]mm
-					bool sign = false;
-					daw_json_ensure( not ts.empty( ), ErrorReason::InvalidTimestamp );
-					switch( ts.front( ) ) {
-					case '+':
-						sign = true;
-						break;
-					case '-':
-						break;
-					default:
-						daw_json_error( true, daw::json::ErrorReason::InvalidTimestamp );
-					}
-					ts.remove_prefix( );
-					auto hr_offset = parse_utils::parse_unsigned<std::uint_least32_t, 2>(
-					  std::data( ts ) );
-					daw_json_ensure( hr_offset <= 24,
-					                 daw::json::ErrorReason::InvalidTimestamp );
-					if( ts.front( ) == ':' ) {
-						ts.remove_prefix( );
-					}
-					auto mn_offset = parse_utils::parse_unsigned<std::uint_least32_t, 2>(
-					  std::data( ts ) );
-					daw_json_ensure( mn_offset <= 61,
-					                 daw::json::ErrorReason::InvalidTimestamp );
-					// Want to subtract offset from current time, we are converting to UTC
-					if( sign ) {
-						// Positive offset
-						hms.hour -= hr_offset;
-						hms.minute -= mn_offset;
-					} else {
-						// Negative offset
-						hms.hour += hr_offset;
-						hms.minute += mn_offset;
-					}
+				auto const hms = parse_iso_8601_time( time_str );
+
+				auto const local_tp = civil_to_time_point<TP>( ymd.year,
+				                                               ymd.month,
+				                                               ymd.day,
+				                                               hms.hour,
+				                                               hms.minute,
+				                                               hms.second,
+				                                               hms.attosecond );
+				if( ts.empty( ) or ts.front( ) == 'Z' ) {
+					return local_tp;
 				}
-				return civil_to_time_point<TP>( ymd.year,
-				                                ymd.month,
-				                                ymd.day,
-				                                hms.hour,
-				                                hms.minute,
-				                                hms.second,
-				                                hms.attosecond );
+				daw_json_ensure( std::size( ts ) == 5 or std::size( ts ) == 6,
+				                 ErrorReason::InvalidTimestamp );
+				// The format will be (+|-)hh[:]mm
+				bool sign = false;
+				switch( ts.front( ) ) {
+				case '+':
+					sign = true;
+					break;
+				case '-':
+					break;
+				default:
+					daw_json_error( true, ErrorReason::InvalidTimestamp );
+				}
+				ts.remove_prefix( );
+				auto hr_offset_str = ts.pop_front( 2 );
+				auto mn_offset_str = daw::string_view{ };
+				if( hr_offset_str.size( ) == 4 ) {
+					mn_offset_str = hr_offset_str.pop_back( 2 );
+				}
+				daw_json_ensure( hr_offset_str.size( ) == 2 and
+				                   parse_utils::is_number( hr_offset_str[0] ) and
+				                   parse_utils::is_number( hr_offset_str[1] ),
+				                 ErrorReason::InvalidTimestamp );
+
+				auto const hr_offset =
+				  parse_utils::parse_unsigned<std::uint_least32_t, 2>(
+				    std::data( hr_offset_str ) );
+				daw_json_ensure( hr_offset <= 24, ErrorReason::InvalidTimestamp );
+				if( not ts.empty( ) and ts.front( ) == ':' ) {
+					ts.remove_prefix( );
+				}
+				if( mn_offset_str.empty( ) ) {
+					mn_offset_str = ts.pop_front( 2 );
+				}
+				daw_json_ensure( mn_offset_str.size( ) == 2 and ts.empty( ) and
+				                   parse_utils::is_number( mn_offset_str[0] ) and
+				                   parse_utils::is_number( mn_offset_str[1] ),
+				                 ErrorReason::InvalidTimestamp );
+				auto const mn_offset =
+				  parse_utils::parse_unsigned<std::uint_least32_t, 2>(
+				    std::data( mn_offset_str ) );
+				daw_json_ensure( mn_offset <= 61, ErrorReason::InvalidTimestamp );
+
+				if( hr_offset == 0 and mn_offset == 0 ) {
+					return std::chrono::time_point_cast<typename TP::duration>(
+					  local_tp );
+				}
+				// Apply the offset as a duration on the time_point so that
+				// borrowing across hour/day boundaries (e.g. 01:14 - 02:30)
+				// is handled by chrono instead of wrapping unsigned fields.
+				auto const offset = std::chrono::seconds{
+				  static_cast<std::chrono::seconds::rep>( hr_offset ) * 3600 +
+				  static_cast<std::chrono::seconds::rep>( mn_offset ) * 60 };
+				// Want to subtract offset from current time, we are converting to UTC
+				if( sign ) {
+					// Positive offset
+					return std::chrono::time_point_cast<typename TP::duration>(
+					         local_tp ) -
+					       std::chrono::duration_cast<typename TP::duration>( offset );
+				}
+				// Negative offset
+				return std::chrono::time_point_cast<typename TP::duration>( local_tp ) +
+				       std::chrono::duration_cast<typename TP::duration>( offset );
 			}
 			struct ymdhms {
 				std::int_least32_t year;

--- a/include/daw/json/impl/daw_json_parse_iso8601_utils.h
+++ b/include/daw/json/impl/daw_json_parse_iso8601_utils.h
@@ -242,7 +242,7 @@ namespace daw::json {
 					                 ErrorReason::InvalidTimestamp );
 				}
 				auto const precision =
-				  std::min( timestamp_str.size( ), std::size_t{ 18 } );
+				  (std::min)( { timestamp_str.size( ), std::size_t{ 18 } } );
 				auto const attosecond_str = timestamp_str.substr( 0, precision );
 				result.attosecond =
 				  datetime_details::parse_number<std::uint64_t>( attosecond_str );

--- a/include/daw/json/impl/daw_json_parse_name.h
+++ b/include/daw/json/impl/daw_json_parse_name.h
@@ -50,7 +50,7 @@ namespace daw::json {
 						trim_end_of_name( parse_state );
 						return daw::string_view( std::data( r ), std::size( r ) );
 					} else {
-						char const *const ptr = parse_state.first;
+						auto const ptr = parse_state.first;
 						if constexpr( ParseState::is_unchecked_input ) {
 							parse_state.template move_to_next_of_unchecked<'"'>( );
 						} else {

--- a/include/daw/json/impl/daw_json_parse_options_impl.h
+++ b/include/daw/json/impl/daw_json_parse_options_impl.h
@@ -63,6 +63,15 @@ namespace daw::json {
 
 			template<>
 			inline constexpr unsigned
+			  json_option_bits_width<options::AllowStringMutation> = 1;
+
+			template<>
+			inline constexpr auto
+			  default_json_option_value<options::AllowStringMutation> =
+			    options::AllowStringMutation::no;
+
+			template<>
+			inline constexpr unsigned
 			  json_option_bits_width<options::PolicyCommentTypes> = 2;
 
 			template<>
@@ -163,11 +172,12 @@ namespace daw::json {
 
 			using policy_list = typename option_list_impl<
 			  options::ExecModeTypes, options::ZeroTerminatedString,
-			  options::PolicyCommentTypes, options::CheckedParseMode,
-			  options::AllowEscapedNames, options::IEEE754Precise,
-			  options::ForceFullNameCheck, options::MinifiedDocument,
-			  options::UseExactMappingsByDefault, options::MustVerifyEndOfDataIsValid,
-			  options::ExcludeSpecialEscapes, options::ExpectLongNames>::type;
+			  options::AllowStringMutation, options::PolicyCommentTypes,
+			  options::CheckedParseMode, options::AllowEscapedNames,
+			  options::IEEE754Precise, options::ForceFullNameCheck,
+			  options::MinifiedDocument, options::UseExactMappingsByDefault,
+			  options::MustVerifyEndOfDataIsValid, options::ExcludeSpecialEscapes,
+			  options::ExpectLongNames>::type;
 
 			template<typename Policy, typename Policies>
 			inline constexpr unsigned basic_policy_bits_start =
@@ -258,11 +268,8 @@ namespace daw::json {
 		DAW_CONSTEVAL json_options_t parse_options( Policies... policies ) {
 			static_assert( json_details::are_option_flags<Policies...>,
 			               "Only registered policy types are allowed" );
-			auto result = json_details::default_policy_flag;
-			if constexpr( sizeof...( Policies ) > 0 ) {
-				result |= ( json_details::set_bits_for( policies ) | ... );
-			}
-			return result;
+			return json_details::set_bits( json_details::default_policy_flag,
+			                               policies... );
 		}
 	} // namespace DAW_JSON_VER
 } // namespace daw::json

--- a/include/daw/json/impl/daw_json_parse_policy.h
+++ b/include/daw/json/impl/daw_json_parse_policy.h
@@ -59,8 +59,6 @@ namespace daw::json {
 				return PolicyFlags;
 			}
 
-			using iterator = char const *;
-
 			/***
 			 * see options::CheckedParseMode
 			 */
@@ -98,6 +96,13 @@ namespace daw::json {
 			static constexpr bool is_zero_terminated_string =
 			  json_details::get_bits_for<options::ZeroTerminatedString>(
 			    PolicyFlags ) == options::ZeroTerminatedString::yes;
+
+			/***
+			 * see options::AllowStringMutation
+			 */
+			static constexpr bool allow_string_mutation =
+			  json_details::get_bits_for<options::AllowStringMutation>(
+			    PolicyFlags ) == options::AllowStringMutation::yes;
 
 			/***
 			 * See options::IEEE754Precise
@@ -141,6 +146,8 @@ namespace daw::json {
 			           NoCommentSkippingPolicy, CppCommentSkippingPolicy,
 			           HashCommentSkippingPolicy>;
 
+			using iterator = std::conditional_t<allow_string_mutation ,
+			                                    char *, char const *>;
 			iterator first{ };
 			iterator last{ };
 			iterator class_first{ };
@@ -331,17 +338,20 @@ namespace daw::json {
 
 			template<char c>
 			DAW_ATTRIB_INLINE constexpr void move_to_next_of_unchecked( ) {
-				first =
+				auto const position =
 				  json_details::memchr_unchecked<c, exec_tag_t, expect_long_strings>(
-				    daw::not_null{ daw::never_null, first },
-				    daw::not_null{ daw::never_null, last } );
+				    daw::not_null<char const *>{ daw::never_null, first },
+				    daw::not_null<char const *>{ daw::never_null, last } );
+				first = json_details::input_pointer( first, position.get( ) );
 			}
 
 			template<char c>
 			DAW_ATTRIB_INLINE constexpr void move_to_next_of_checked( ) {
-				first =
+				auto const position =
 				  json_details::memchr_checked<c, exec_tag_t, expect_long_strings>(
-				    daw::not_null{ first }, daw::not_null{ last } );
+				    daw::not_null<char const *>{ first },
+				    daw::not_null<char const *>{ last } );
+				first = json_details::input_pointer( first, position.get( ) );
 			}
 
 			template<char c>
@@ -386,8 +396,8 @@ namespace daw::json {
 			}
 
 			struct class_pos_t {
-				char const *f;
-				char const *l;
+				iterator f;
+				iterator l;
 			};
 
 			constexpr void set_class_position( class_pos_t new_pos ) {
@@ -561,17 +571,25 @@ namespace daw::json {
 		BasicParsePolicy( ) -> BasicParsePolicy<>;
 
 		BasicParsePolicy( char const *, char const * ) -> BasicParsePolicy<>;
+		BasicParsePolicy( char *, char * ) -> BasicParsePolicy<>;
 
 		template<typename Allocator>
 		BasicParsePolicy( char const *, char const *, Allocator const & )
 		  -> BasicParsePolicy<json_details::default_policy_flag, Allocator>;
+		template<typename Allocator>
+		BasicParsePolicy( char *, char *, Allocator const & )
+		  -> BasicParsePolicy<json_details::default_policy_flag, Allocator>;
 
 		BasicParsePolicy( char const *, char const *, char const *, char const * )
 		  -> BasicParsePolicy<>;
+		BasicParsePolicy( char *, char *, char *, char * ) -> BasicParsePolicy<>;
 
 		template<typename Allocator>
 		BasicParsePolicy( char const *, char const *, char const *, char const *,
 		                  Allocator const & )
+		  -> BasicParsePolicy<json_details::default_policy_flag, Allocator>;
+		template<typename Allocator>
+		BasicParsePolicy( char *, char *, char *, char *, Allocator const & )
 		  -> BasicParsePolicy<json_details::default_policy_flag, Allocator>;
 
 		struct DefaultParsePolicy

--- a/include/daw/json/impl/daw_json_parse_policy_cpp_comments.h
+++ b/include/daw/json/impl/daw_json_parse_policy_cpp_comments.h
@@ -150,7 +150,7 @@ namespace daw::json {
 			         typename ParseState>
 			DAW_ATTRIB_FLATINLINE static constexpr ParseState
 			skip_bracketed_item_checked( ParseState &parse_state ) {
-				constexpr char PrimLeft =
+				DAW_CPP23_STATIC_LOCAL constexpr char PrimLeft =
 				  BracketedType == json_details::SkipBracketedType::Class ? '{' : '[';
 				using PrimRight = daw::constant<PrimLeft == '{' ? '}' : ']'>;
 				using SecLeft = daw::constant<PrimLeft == '{' ? '[' : '{'>;
@@ -262,7 +262,7 @@ namespace daw::json {
 			         typename ParseState>
 			DAW_ATTRIB_FLATINLINE static constexpr ParseState
 			skip_bracketed_item_unchecked( ParseState &parse_state ) {
-				constexpr char PrimLeft =
+				DAW_CPP23_STATIC_LOCAL constexpr char PrimLeft =
 				  BracketedType == json_details::SkipBracketedType::Class ? '{' : '[';
 				using PrimRight = daw::constant<PrimLeft == '{' ? '}' : ']'>;
 				using SecLeft = daw::constant<PrimLeft == '{' ? '[' : '{'>;

--- a/include/daw/json/impl/daw_json_parse_policy_cpp_comments.h
+++ b/include/daw/json/impl/daw_json_parse_policy_cpp_comments.h
@@ -155,14 +155,13 @@ namespace daw::json {
 				using PrimRight = daw::constant<PrimLeft == '{' ? '}' : ']'>;
 				using SecLeft = daw::constant<PrimLeft == '{' ? '[' : '{'>;
 				using SecRight = daw::constant<SecLeft::value == '{' ? '}' : ']'>;
-
 				// Not checking for Left as it is required to be skipped already
 				auto result = parse_state;
 				std::size_t cnt = 0;
 				std::uint32_t prime_bracket_count = 1;
 				std::uint32_t second_bracket_count = 0;
-				auto ptr_first = daw::not_null<char const *>( parse_state.first );
-				auto const ptr_last = daw::not_null<char const *>( parse_state.last );
+				auto ptr_first = daw::not_null( parse_state.first );
+				auto const ptr_last = daw::not_null( parse_state.last );
 				if( DAW_UNLIKELY( ptr_first >= ptr_last ) ) {
 					return result;
 				}
@@ -176,9 +175,18 @@ namespace daw::json {
 						break;
 					case '"':
 						++ptr_first;
-						ptr_first = json_details::mem_skip_until_end_of_string<
-						  ParseState::is_unchecked_input,
-						  typename ParseState::exec_tag_t>( ptr_first, ptr_last );
+						if constexpr( std::is_same_v<char *,
+						                             typename ParseState::iterator> ) {
+							auto skip_ptr = json_details::mem_skip_until_end_of_string<
+							  ParseState::is_unchecked_input,
+							  typename ParseState::exec_tag_t>( ptr_first.get( ),
+							                                    ptr_last.get( ) );
+							ptr_first += skip_ptr - ptr_first.get( );
+						} else {
+							ptr_first = json_details::mem_skip_until_end_of_string<
+							  ParseState::is_unchecked_input,
+							  typename ParseState::exec_tag_t>( ptr_first, ptr_last );
+						}
 						daw_json_ensure( ptr_first < ptr_last,
 						                 ErrorReason::UnexpectedEndOfData,
 						                 parse_state );
@@ -265,10 +273,9 @@ namespace daw::json {
 				std::size_t cnt = 0;
 				std::uint32_t prime_bracket_count = 1;
 				std::uint32_t second_bracket_count = 0;
-				auto ptr_first =
-				  daw::not_null<char const *>( daw::never_null, parse_state.first );
+				auto ptr_first = daw::not_null( daw::never_null, parse_state.first );
 				auto const ptr_last =
-				  daw::not_null<char const *>( daw::never_null, parse_state.last );
+				  daw::not_null( daw::never_null, parse_state.last );
 				if( *ptr_first == PrimLeft ) {
 					++ptr_first;
 				}
@@ -279,9 +286,18 @@ namespace daw::json {
 						break;
 					case '"':
 						++ptr_first;
-						ptr_first = json_details::mem_skip_until_end_of_string<
-						  ParseState::is_unchecked_input,
-						  typename ParseState::exec_tag_t>( ptr_first, ptr_last );
+						if constexpr( std::is_same_v<char *,
+						                             typename ParseState::iterator> ) {
+							auto skip_ptr = json_details::mem_skip_until_end_of_string<
+							  ParseState::is_unchecked_input,
+							  typename ParseState::exec_tag_t>( ptr_first.get( ),
+							                                    ptr_last.get( ) );
+							ptr_first += skip_ptr - ptr_first.get( );
+						} else {
+							ptr_first = json_details::mem_skip_until_end_of_string<
+							  ParseState::is_unchecked_input,
+							  typename ParseState::exec_tag_t>( ptr_first, ptr_last );
+						}
 						break;
 					case ',':
 						if( prime_bracket_count == 1 and second_bracket_count == 0 ) {

--- a/include/daw/json/impl/daw_json_parse_policy_hash_comments.h
+++ b/include/daw/json/impl/daw_json_parse_policy_hash_comments.h
@@ -122,8 +122,8 @@ namespace daw::json {
 				std::size_t cnt = 0;
 				std::uint32_t prime_bracket_count = 1;
 				std::uint32_t second_bracket_count = 0;
-				auto ptr_first = daw::not_null<char const *>( parse_state.first );
-				auto const ptr_last = daw::not_null<char const *>( parse_state.last );
+				auto ptr_first = daw::not_null( parse_state.first );
+				auto const ptr_last = daw::not_null( parse_state.last );
 				if( DAW_UNLIKELY( ptr_first >= ptr_last ) ) {
 					return result;
 				}
@@ -138,9 +138,18 @@ namespace daw::json {
 						break;
 					case '"':
 						++ptr_first;
-						ptr_first = json_details::mem_skip_until_end_of_string<
-						  ParseState::is_unchecked_input,
-						  typename ParseState::exec_tag_t>( ptr_first, ptr_last );
+						if constexpr( std::is_same_v<char *,
+						                             typename ParseState::iterator> ) {
+							auto skip_ptr = json_details::mem_skip_until_end_of_string<
+							  ParseState::is_unchecked_input,
+							  typename ParseState::exec_tag_t>( ptr_first.get( ),
+							                                    ptr_last.get( ) );
+							ptr_first += skip_ptr - ptr_first.get( );
+						} else {
+							ptr_first = json_details::mem_skip_until_end_of_string<
+							  ParseState::is_unchecked_input,
+							  typename ParseState::exec_tag_t>( ptr_first, ptr_last );
+						}
 						daw_json_ensure( ptr_first < ptr_last,
 						                 ErrorReason::UnexpectedEndOfData,
 						                 parse_state );
@@ -213,10 +222,9 @@ namespace daw::json {
 				std::size_t cnt = 0;
 				std::uint32_t prime_bracket_count = 1;
 				std::uint32_t second_bracket_count = 0;
-				auto ptr_first =
-				  daw::not_null<char const *>( daw::never_null, parse_state.first );
+				auto ptr_first = daw::not_null( daw::never_null, parse_state.first );
 				auto const ptr_last =
-				  daw::not_null<char const *>( daw::never_null, parse_state.last );
+				  daw::not_null( daw::never_null, parse_state.last );
 				if( *ptr_first == PrimLeft ) {
 					++ptr_first;
 				}
@@ -227,9 +235,19 @@ namespace daw::json {
 						break;
 					case '"':
 						++ptr_first;
-						ptr_first = json_details::mem_skip_until_end_of_string<
-						  ParseState::is_unchecked_input,
-						  typename ParseState::exec_tag_t>( ptr_first, ptr_last );
+
+						if constexpr( std::is_same_v<char *,
+						                             typename ParseState::iterator> ) {
+							auto skip_ptr = json_details::mem_skip_until_end_of_string<
+							  ParseState::is_unchecked_input,
+							  typename ParseState::exec_tag_t>( ptr_first.get( ),
+							                                    ptr_last.get( ) );
+							ptr_first += skip_ptr - ptr_first.get( );
+						} else {
+							ptr_first = json_details::mem_skip_until_end_of_string<
+							  ParseState::is_unchecked_input,
+							  typename ParseState::exec_tag_t>( ptr_first, ptr_last );
+						}
 						break;
 					case ',':
 						if( prime_bracket_count == 1 and second_bracket_count == 0 ) {

--- a/include/daw/json/impl/daw_json_parse_policy_hash_comments.h
+++ b/include/daw/json/impl/daw_json_parse_policy_hash_comments.h
@@ -111,7 +111,7 @@ namespace daw::json {
 			         typename ParseState>
 			DAW_ATTRIB_FLATINLINE static constexpr ParseState
 			skip_bracketed_item_checked( ParseState &parse_state ) {
-				constexpr char PrimLeft =
+				DAW_CPP23_STATIC_LOCAL constexpr char PrimLeft =
 				  BracketedType == json_details::SkipBracketedType::Class ? '{' : '[';
 				using PrimRight = daw::constant<PrimLeft == '{' ? '}' : ']'>;
 				using SecLeft = daw::constant<PrimLeft == '{' ? '[' : '{'>;
@@ -211,7 +211,7 @@ namespace daw::json {
 			         typename ParseState>
 			DAW_ATTRIB_FLATINLINE static constexpr ParseState
 			skip_bracketed_item_unchecked( ParseState &parse_state ) {
-				constexpr char PrimLeft =
+				DAW_CPP23_STATIC_LOCAL constexpr char PrimLeft =
 				  BracketedType == json_details::SkipBracketedType::Class ? '{' : '[';
 				// Not checking for Left as it is required to be skipped already
 				using PrimRight = daw::constant<PrimLeft == '{' ? '}' : ']'>;

--- a/include/daw/json/impl/daw_json_parse_policy_no_comments.h
+++ b/include/daw/json/impl/daw_json_parse_policy_no_comments.h
@@ -35,7 +35,8 @@ namespace daw::json {
 			trim_left_checked( ParseState &parse_state ) {
 				if constexpr( not ParseState::minified_document ) {
 					// SIMD here was much slower, most JSON has very minimal whitespace
-					auto first = daw::not_null<char const *>( parse_state.first );
+					auto first =
+					  daw::not_null<typename ParseState::iterator>( parse_state.first );
 					auto const last = daw::not_null<char const *>( parse_state.last );
 
 					// only used when not zero terminated string and gcc9 warns
@@ -57,7 +58,7 @@ namespace daw::json {
 							++first;
 						}
 					}
-					parse_state.first = first;
+					parse_state.first = json_details::input_pointer( parse_state.first, first.get( ) );
 				}
 			}
 
@@ -65,28 +66,29 @@ namespace daw::json {
 			DAW_ATTRIB_FLATINLINE static constexpr void
 			trim_left_unchecked( ParseState &parse_state ) {
 				if constexpr( not ParseState::minified_document ) {
-					auto first =
-					  daw::not_null<char const *>( daw::never_null, parse_state.first );
+					auto first = daw::not_null<typename ParseState::iterator>(
+					  daw::never_null, parse_state.first );
 					while( DAW_UNLIKELY(
 					  ( static_cast<unsigned>( static_cast<unsigned char>( *first ) ) -
 					    1U ) <= 0x1F ) ) {
 
 						++first;
 					}
-					parse_state.first = first;
+					parse_state.first = json_details::input_pointer( parse_state.first, first.get( ) );
 				}
 			}
 
 			template<typename ParseState>
 			DAW_ATTRIB_FLATINLINE static constexpr void
 			move_next_member_unchecked( ParseState &parse_state ) {
-				auto pf = daw::not_null( daw::never_null, parse_state.first );
-				auto pl = daw::not_null( daw::never_null, parse_state.last );
-				parse_state.first =
+				auto pf = daw::not_null<char const *>( daw::never_null, parse_state.first );
+				auto pl = daw::not_null<char const *>( daw::never_null, parse_state.last );
+				auto const position =
 				  json_details::memchr_unchecked<'"',
 				                                 typename ParseState::exec_tag_t,
 				                                 ParseState::expect_long_strings>( pf,
 				                                                                   pl );
+				parse_state.first = json_details::input_pointer( parse_state.first, position.get( ) );
 			}
 
 			template<char... keys, typename ParseState>
@@ -99,11 +101,12 @@ namespace daw::json {
 				      typename ParseState::exec_tag_t>( ) ) {
 					auto pf = daw::not_null<char const *>{ parse_state.first };
 					auto pl = daw::not_null<char const *>{ parse_state.last };
-					parse_state.first =
+					auto const position =
 					  json_details::mempbrk<ParseState::is_unchecked_input,
 					                        typename ParseState::exec_tag_t,
 					                        ParseState::expect_long_strings,
 					                        keys...>( pf, pl );
+					parse_state.first = json_details::input_pointer( parse_state.first, position.get( ) );
 				} else {
 					auto first = daw::not_null<char const *>( parse_state.first );
 					auto const last = daw::not_null<char const *>( parse_state.last );
@@ -130,7 +133,7 @@ namespace daw::json {
 							  first < last, ErrorReason::UnexpectedEndOfData, parse_state );
 						}
 					}
-					parse_state.first = first;
+					parse_state.first = json_details::input_pointer( parse_state.first, first.get( ) );
 				}
 			}
 
@@ -192,9 +195,9 @@ namespace daw::json {
 							daw_json_ensure( second_bracket_count == 0,
 							                 ErrorReason::InvalidBracketing,
 							                 parse_state );
-							result.last = ptr_first;
+							result.last = json_details::input_pointer( result.first, ptr_first.get( ) );
 							result.counter = cnt;
-							parse_state.first = ptr_first;
+							parse_state.first = json_details::input_pointer( parse_state.first, ptr_first.get( ) );
 							return result;
 						}
 						break;
@@ -213,9 +216,9 @@ namespace daw::json {
 				                 parse_state );
 				// We include the close primary bracket in the range so that subsequent
 				// parsers have a terminator inside their range
-				result.last = ptr_first;
+				result.last = json_details::input_pointer( result.first, ptr_first.get( ) );
 				result.counter = cnt;
-				parse_state.first = ptr_first;
+				parse_state.first = json_details::input_pointer( parse_state.first, ptr_first.get( ) );
 				return result;
 			}
 
@@ -266,9 +269,9 @@ namespace daw::json {
 							++ptr_first;
 							// We include the close primary bracket in the range so that
 							// subsequent parsers have a terminator inside their range
-							result.last = ptr_first;
+							result.last = json_details::input_pointer( result.first, ptr_first.get( ) );
 							result.counter = cnt;
-							parse_state.first = ptr_first;
+							parse_state.first = json_details::input_pointer( parse_state.first, ptr_first.get( ) );
 							return result;
 						}
 						break;

--- a/include/daw/json/impl/daw_json_parse_policy_no_comments.h
+++ b/include/daw/json/impl/daw_json_parse_policy_no_comments.h
@@ -145,7 +145,7 @@ namespace daw::json {
 			         typename ParseState>
 			DAW_ATTRIB_FLATTEN static constexpr ParseState
 			skip_bracketed_item_checked( ParseState &parse_state ) {
-				constexpr char PrimLeft =
+				DAW_CPP23_STATIC_LOCAL constexpr char PrimLeft =
 				  BracketedType == json_details::SkipBracketedType::Class ? '{' : '[';
 				using PrimRight = daw::constant<PrimLeft == '{' ? '}' : ']'>;
 				using SecLeft = daw::constant<PrimLeft == '{' ? '[' : '{'>;
@@ -226,7 +226,7 @@ namespace daw::json {
 			         typename ParseState>
 			DAW_ATTRIB_NOINLINE static constexpr ParseState
 			skip_bracketed_item_unchecked( ParseState &parse_state ) {
-				constexpr char PrimLeft =
+				DAW_CPP23_STATIC_LOCAL constexpr char PrimLeft =
 				  BracketedType == json_details::SkipBracketedType::Class ? '{' : '[';
 				// Not checking for Left as it is required to be skipped already
 				using PrimRight = daw::constant<PrimLeft == '{' ? '}' : ']'>;

--- a/include/daw/json/impl/daw_json_parse_policy_policy_details.h
+++ b/include/daw/json/impl/daw_json_parse_policy_policy_details.h
@@ -13,10 +13,22 @@
 #include "daw_json_assert.h"
 
 #include <daw/daw_attributes.h>
+#include <type_traits>
 
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
 		namespace json_details {
+			// Translate a read-only scanner result back into the input range's
+			// pointer type. Non-null positions must belong to the same buffer.
+			template<typename Char>
+			[[nodiscard]] constexpr Char *input_pointer( Char *origin, char const *position ) {
+				if constexpr( std::is_const_v<Char> ) {
+					return position;
+				} else {
+					return position ? origin + ( position - origin ) : nullptr;
+				}
+			}
+
 			enum class SkipBracketedType { Array, Class };
 		} // namespace json_details
 

--- a/include/daw/json/impl/daw_json_parse_real.h
+++ b/include/daw/json/impl/daw_json_parse_real.h
@@ -428,19 +428,24 @@ namespace daw::json {
 				              ParseState::precise_ieee754 ) {
 					// On std floating point types, check for conditions that cannot be
 					// precisely calculated using the normal method and use the fallback
-					// method(usually strtod/from_chars)
+					// method(usually strtod/from_chars).  long double that shares
+					// double's size/precision/exponent range (e.g. MSVC) is computed
+					// as double instead, since Eisel-Lemire only supports
+					// binary32/binary64.
+					constexpr bool is_lemire_capable =
+					  std::is_same_v<Result, float> or std::is_same_v<Result, double> or
+					  is_double_sized_long_double_v<Result>;
+					constexpr bool is_extended_long_double =
+					  std::is_same_v<Result, long double> and not is_lemire_capable;
 					use_fallback |= exponent > 22;
 					use_fallback |= exponent < -22;
-					if constexpr( std::is_same_v<Result, float> or
-					              std::is_same_v<Result, double> ) {
+					if constexpr( is_lemire_capable ) {
 						use_fallback |=
 						  significant_digits >
 						  ( std::uint64_t{ 1 } << std::numeric_limits<Result>::digits );
 					}
-					if( std::is_same_v<Result, long double> or
-					    DAW_UNLIKELY( use_fallback ) ) {
-						if constexpr( std::is_same_v<Result, float> or
-						              std::is_same_v<Result, double> ) {
+					if( is_extended_long_double or DAW_UNLIKELY( use_fallback ) ) {
+						if constexpr( is_lemire_capable ) {
 							bool discarded_nonzero = append_discarded_digits(
 							  whole_last, all_whole_last, significant_digits, exponent );
 							if( all_fract_first != nullptr ) {
@@ -452,14 +457,19 @@ namespace daw::json {
 								                           significant_digits,
 								                           exponent );
 							}
-							return parse_truncated_lemire<Result>( sign < Result{ 0 },
-							                                       exponent,
-							                                       significant_digits,
-							                                       discarded_nonzero,
-							                                       parse_state.first,
-							                                       parse_state.last );
+							using compute_t =
+							  std::conditional_t<std::is_same_v<Result, long double>,
+							                     double,
+							                     Result>;
+							return static_cast<Result>(
+							  parse_truncated_lemire<compute_t>( sign < Result{ 0 },
+							                                     exponent,
+							                                     significant_digits,
+							                                     discarded_nonzero,
+							                                     parse_state.first,
+							                                     parse_state.last ) );
 						} else {
-							static_assert( std::is_same_v<Result, long double> );
+							static_assert( is_extended_long_double );
 							return json_details::parse_with_strtod<Result>(
 							  parse_state.first, parse_state.last );
 						}
@@ -670,17 +680,21 @@ namespace daw::json {
 
 				if constexpr( std::is_floating_point_v<Result> and
 				              ParseState::precise_ieee754 ) {
+					// long double that shares double's size/precision/exponent range
+					// (e.g. MSVC) is computed as double instead, since Eisel-Lemire
+					// only supports binary32/binary64.
+					constexpr bool is_lemire_capable =
+					  std::is_same_v<Result, float> or std::is_same_v<Result, double> or
+					  is_double_sized_long_double_v<Result>;
 					use_strtod |= DAW_UNLIKELY( exponent > 22 );
 					use_strtod |= DAW_UNLIKELY( exponent < -22 );
-					if constexpr( std::is_same_v<Result, float> or
-					              std::is_same_v<Result, double> ) {
+					if constexpr( is_lemire_capable ) {
 						use_strtod |= DAW_UNLIKELY(
 						  significant_digits >
 						  ( std::uint64_t{ 1 } << std::numeric_limits<Result>::digits ) );
 					}
 					if( DAW_UNLIKELY( use_strtod ) ) {
-						if constexpr( std::is_same_v<Result, float> or
-						              std::is_same_v<Result, double> ) {
+						if constexpr( is_lemire_capable ) {
 							bool discarded_nonzero =
 							  append_discarded_digits( discarded_whole_first,
 							                           discarded_whole_last,
@@ -691,12 +705,17 @@ namespace daw::json {
 							                           discarded_fract_last,
 							                           significant_digits,
 							                           exponent );
-							return parse_truncated_lemire<Result>( sign < 0,
-							                                       exponent,
-							                                       significant_digits,
-							                                       discarded_nonzero,
-							                                       orig_first.get( ),
-							                                       first.get( ) );
+							using compute_t =
+							  std::conditional_t<std::is_same_v<Result, long double>,
+							                     double,
+							                     Result>;
+							return static_cast<Result>(
+							  parse_truncated_lemire<compute_t>( sign < 0,
+							                                     exponent,
+							                                     significant_digits,
+							                                     discarded_nonzero,
+							                                     orig_first.get( ),
+							                                     first.get( ) ) );
 						} else {
 							static_assert( std::is_same_v<Result, long double> );
 							return json_details::parse_with_strtod<Result>( orig_first.get( ),

--- a/include/daw/json/impl/daw_json_parse_real.h
+++ b/include/daw/json/impl/daw_json_parse_real.h
@@ -657,13 +657,13 @@ namespace daw::json {
 
 							return exponent_p1 + exponent_p2;
 						}
-						auto const s = exponent_p1 < 0 ? signed_t{ -1 } : signed_t{ 1 };
+						signed_t const s = exponent_p1 < 0 ? signed_t{ -1 } : signed_t{ 1 };
 						if( s < 0 ) {
-							if( DAW_UNLIKELY( ( daw::min_value<signed_t> - exponent_p1 ) >
+							if( DAW_UNLIKELY( ( daw::lowest_value<signed_t> - exponent_p1 ) >
 							                  exponent_p2 ) ) {
 								// We don't have inf, but we can just saturate it to min as it
 								// will be 0 anyways for the other result
-								return daw::min_value<signed_t>;
+								return daw::lowest_value<signed_t>;
 							}
 							return exponent_p1 + exponent_p2;
 						}

--- a/include/daw/json/impl/daw_json_parse_real.h
+++ b/include/daw/json/impl/daw_json_parse_real.h
@@ -706,8 +706,19 @@ namespace daw::json {
 					DAW_CPP23_STATIC_LOCAL constexpr bool is_lemire_capable =
 					  std::is_same_v<Result, float> or std::is_same_v<Result, double> or
 					  is_double_sized_long_double_v<Result>;
-					use_strtod |= DAW_UNLIKELY( exponent > 22 );
-					use_strtod |= DAW_UNLIKELY( exponent < -22 );
+					DAW_CPP23_STATIC_LOCAL constexpr bool is_80bit_long_double_v =
+					  std::is_same_v<Result, long double> and
+					  std::numeric_limits<long double>::digits == 64;
+					DAW_CPP23_STATIC_LOCAL constexpr bool is_128bit_long_double_v =
+					  std::is_same_v<Result, long double> and
+					  std::numeric_limits<long double>::digits == 113;
+
+					DAW_CPP23_STATIC_LOCAL constexpr int pow10_threshold =
+					  is_80bit_long_double_v    ? 27
+					  : is_128bit_long_double_v ? 48
+					                            : 22;
+					use_strtod |= DAW_UNLIKELY( exponent > pow10_threshold );
+					use_strtod |= DAW_UNLIKELY( exponent < -pow10_threshold );
 					if constexpr( is_lemire_capable ) {
 						use_strtod |= DAW_UNLIKELY(
 						  significant_digits > (std::uint64_t{ 1 } << daw::digits<Result>));

--- a/include/daw/json/impl/daw_json_parse_real.h
+++ b/include/daw/json/impl/daw_json_parse_real.h
@@ -243,7 +243,7 @@ namespace daw::json {
 						if( significant_digits != 0 ) {
 							++retained_digits;
 						}
-						if( exponent > std::numeric_limits<Signed>::lowest( ) ) {
+						if( exponent > daw::lowest_value<Signed> ) {
 							--exponent;
 						}
 					} else {
@@ -440,9 +440,8 @@ namespace daw::json {
 					use_fallback |= exponent > 22;
 					use_fallback |= exponent < -22;
 					if constexpr( is_lemire_capable ) {
-						use_fallback |=
-						  significant_digits >
-						  ( std::uint64_t{ 1 } << std::numeric_limits<Result>::digits );
+						use_fallback |= significant_digits >
+						                ( std::uint64_t{ 1 } << daw::digits<Result> );
 					}
 					if( is_extended_long_double or DAW_UNLIKELY( use_fallback ) ) {
 						if constexpr( is_lemire_capable ) {
@@ -690,8 +689,7 @@ namespace daw::json {
 					use_strtod |= DAW_UNLIKELY( exponent < -22 );
 					if constexpr( is_lemire_capable ) {
 						use_strtod |= DAW_UNLIKELY(
-						  significant_digits >
-						  ( std::uint64_t{ 1 } << std::numeric_limits<Result>::digits ) );
+						  significant_digits > (std::uint64_t{ 1 } << daw::digits<Result>));
 					}
 					if( DAW_UNLIKELY( use_strtod ) ) {
 						if constexpr( is_lemire_capable ) {

--- a/include/daw/json/impl/daw_json_parse_real.h
+++ b/include/daw/json/impl/daw_json_parse_real.h
@@ -427,18 +427,32 @@ namespace daw::json {
 					// double's size/precision/exponent range (e.g. MSVC) is computed
 					// as double instead, since Eisel-Lemire only supports
 					// binary32/binary64.
-					constexpr bool is_lemire_capable =
+					DAW_CPP23_STATIC_LOCAL constexpr bool is_lemire_capable =
 					  std::is_same_v<Result, float> or std::is_same_v<Result, double> or
 					  is_double_sized_long_double_v<Result>;
-					constexpr bool is_extended_long_double =
+					DAW_CPP23_STATIC_LOCAL constexpr bool is_extended_long_double =
 					  std::is_same_v<Result, long double> and not is_lemire_capable;
-					use_fallback |= exponent > 22;
-					use_fallback |= exponent < -22;
+					DAW_CPP23_STATIC_LOCAL constexpr bool is_80bit_long_double_v =
+					  std::is_same_v<Result, long double> and
+					  std::numeric_limits<long double>::digits == 64;
+
+					DAW_CPP23_STATIC_LOCAL constexpr bool is_128bit_long_double_v =
+					  std::is_same_v<Result, long double> and
+					  std::numeric_limits<long double>::digits == 113;
+
+					// Extended long double (80-bit) can exactly represent 10^k for
+					// |k| <= 27 (5^27 < 2^64); Eisel-Lemire types are limited to 22.
+					DAW_CPP23_STATIC_LOCAL constexpr int pow10_threshold =
+					  is_80bit_long_double_v    ? 27
+					  : is_128bit_long_double_v ? 48
+					                            : 22;
+					use_fallback |= exponent > pow10_threshold;
+					use_fallback |= exponent < -pow10_threshold;
 					if constexpr( is_lemire_capable ) {
 						use_fallback |= significant_digits >
 						                ( std::uint64_t{ 1 } << daw::digits<Result> );
 					}
-					if( is_extended_long_double or DAW_UNLIKELY( use_fallback ) ) {
+					if( DAW_UNLIKELY( use_fallback ) ) {
 						if constexpr( is_lemire_capable ) {
 							bool discarded_nonzero = append_discarded_digits(
 							  whole_last, all_whole_last, significant_digits, exponent );
@@ -591,7 +605,7 @@ namespace daw::json {
 						auto const fract_stored_cap = static_cast<std::ptrdiff_t>(
 						  daw::digits10<unsigned_t> - stored_whole_digit_count );
 						exponent_p1 -= static_cast<signed_t>(
-						  ( std::min )( { last_char - first, fract_stored_cap } ) );
+						  (std::min)( { last_char - first, fract_stored_cap } ) );
 						if constexpr( std::is_floating_point_v<Result> and
 						              ParseState::precise_ieee754 ) {
 							// If we silently dropped fractional digits, the power10 result
@@ -689,7 +703,7 @@ namespace daw::json {
 					// long double that shares double's size/precision/exponent range
 					// (e.g. MSVC) is computed as double instead, since Eisel-Lemire
 					// only supports binary32/binary64.
-					constexpr bool is_lemire_capable =
+					DAW_CPP23_STATIC_LOCAL constexpr bool is_lemire_capable =
 					  std::is_same_v<Result, float> or std::is_same_v<Result, double> or
 					  is_double_sized_long_double_v<Result>;
 					use_strtod |= DAW_UNLIKELY( exponent > 22 );

--- a/include/daw/json/impl/daw_json_parse_real.h
+++ b/include/daw/json/impl/daw_json_parse_real.h
@@ -162,16 +162,14 @@ namespace daw::json {
 				daw::not_null const new_last = std::next( first.get( ), last_pos );
 
 				auto value = v;
-				bool parsed_eight_digits = false;
 				if( new_last - first >= 8 and
 				    is_made_of_eight_digits_cx( first.get( ) ) ) {
 					value *= static_cast<Unsigned>( 100'000'000U );
 					value += static_cast<Unsigned>( parse_8_digits( first.get( ) ) );
 					first += 8;
-					parsed_eight_digits = true;
 				}
 
-				unsigned dig = parsed_eight_digits and first == new_last ? 0U : 10U;
+				unsigned dig = 10U;
 				if( first < new_last ) {
 					do {
 						dig = parse_digit( *first );
@@ -182,9 +180,6 @@ namespace daw::json {
 						value += dig;
 						++first;
 					} while( first < new_last );
-				}
-				if( first < last and dig < 10U ) {
-					++first;
 				}
 				while( first < last ) {
 					dig = parse_digit( *first );
@@ -590,7 +585,19 @@ namespace daw::json {
 						                                       fract_last.get( ),
 						                                       significant_digits,
 						                                       stored_whole_digit_count );
-						exponent_p1 -= static_cast<signed_t>( last_char - first );
+						// Only count the digits actually stored in significant_digits;
+						// parse_digits_while_number skips overflow digits up to last_char
+						// but those must not adjust the decimal-point exponent.
+						auto const fract_stored_cap = static_cast<std::ptrdiff_t>(
+						  daw::digits10<unsigned_t> - stored_whole_digit_count );
+						exponent_p1 -= static_cast<signed_t>(
+						  ( std::min )( { last_char - first, fract_stored_cap } ) );
+						if constexpr( std::is_floating_point_v<Result> and
+						              ParseState::precise_ieee754 ) {
+							// If we silently dropped fractional digits, the power10 result
+							// may be incorrectly rounded — fall back to strtod.
+							use_strtod |= ( last_char - first ) > fract_stored_cap;
+						}
 						first = last_char;
 						if( daw::nsc_and( first >= fract_last, first < last ) ) {
 							auto new_first =

--- a/include/daw/json/impl/daw_json_parse_real.h
+++ b/include/daw/json/impl/daw_json_parse_real.h
@@ -499,8 +499,8 @@ namespace daw::json {
 				  ErrorReason::InvalidNumberStart,
 				  parse_state );
 
-				using iterator = typename ParseState::iterator;
-				[[maybe_unused]] daw::not_null<iterator> const orig_first =
+				using iterator_t = typename ParseState::iterator;
+				[[maybe_unused]] daw::not_null<iterator_t> const orig_first =
 				  parse_state.first;
 
 				auto const sign =
@@ -519,19 +519,20 @@ namespace daw::json {
 				                     std::int64_t,
 				                     Result>;
 
-				daw::not_null<iterator> first = parse_state.first;
-				daw::not_null<iterator> const last = parse_state.last;
-				daw::not_null<iterator> const whole_last =
+				daw::not_null<iterator_t> first = parse_state.first;
+				daw::not_null<iterator_t> const last = parse_state.last;
+				daw::not_null<iterator_t> const whole_last =
 				  parse_state.first +
 				  (std::min)( { parse_state.last - parse_state.first,
 				                static_cast<std::ptrdiff_t>( max_exponent::value ) } );
 
 				unsigned_t significant_digits = 0;
-				iterator discarded_whole_first = nullptr;
-				iterator discarded_whole_last = nullptr;
-				iterator discarded_fract_first = nullptr;
-				iterator discarded_fract_last = nullptr;
-				daw::not_null<iterator> last_char = parse_digits_while_number<iterator>(
+				iterator_t discarded_whole_first = nullptr;
+				iterator_t discarded_whole_last = nullptr;
+				iterator_t discarded_fract_first = nullptr;
+				iterator_t discarded_fract_last = nullptr;
+				daw::not_null<iterator_t> last_char =
+				  parse_digits_while_number<iterator_t>(
 				  first.get( ), whole_last.get( ), significant_digits, 0 );
 				auto const parsed_whole_digit_count = last_char - parse_state.first;
 				auto const stored_whole_digit_count = [&] {
@@ -555,7 +556,7 @@ namespace daw::json {
 						}
 						// We have sig digits we cannot parse because there isn't enough
 						// room in a std::uint64_t
-						daw::not_null<iterator> ptr =
+						daw::not_null<iterator_t> ptr =
 						  skip_digits<( ParseState::is_zero_terminated_string or
 						                ParseState::is_unchecked_input )>( last_char,
 						                                                   last );
@@ -588,14 +589,14 @@ namespace daw::json {
 							discarded_fract_last = first.get( );
 						}
 					} else {
-						daw::not_null<iterator> fract_last =
+						daw::not_null<iterator_t> fract_last =
 						  first + (std::min)( parse_state.last - first,
 						                      static_cast<std::ptrdiff_t>(
 						                        max_exponent::value -
 						                        ( first - parse_state.first ) ) );
 
 						last_char =
-						  parse_digits_while_number<iterator>( first.get( ),
+						  parse_digits_while_number<iterator_t>( first.get( ),
 						                                       fract_last.get( ),
 						                                       significant_digits,
 						                                       stored_whole_digit_count );

--- a/include/daw/json/impl/daw_json_parse_real.h
+++ b/include/daw/json/impl/daw_json_parse_real.h
@@ -144,10 +144,10 @@ namespace daw::json {
 				}
 			}
 
-			template<typename Unsigned>
-			[[nodiscard]] DAW_ATTRIB_FLATINLINE constexpr daw::not_null<char const *>
-			parse_digits_while_number( daw::not_null<char const *> first,
-			                           daw::not_null<char const *> const last,
+			template<typename iterator, typename Unsigned>
+			[[nodiscard]] DAW_ATTRIB_FLATINLINE constexpr daw::not_null<iterator>
+			parse_digits_while_number( daw::not_null<iterator> first,
+			                           daw::not_null<iterator> const last,
 			                           Unsigned &DAW_RESTRICT v,
 			                           std::size_t sig_dig_in_use ) {
 
@@ -163,9 +163,10 @@ namespace daw::json {
 
 				auto value = v;
 				bool parsed_eight_digits = false;
-				if( new_last - first >= 8 and is_made_of_eight_digits_cx( first ) ) {
+				if( new_last - first >= 8 and
+				    is_made_of_eight_digits_cx( first.get( ) ) ) {
 					value *= static_cast<Unsigned>( 100'000'000U );
-					value += static_cast<Unsigned>( parse_8_digits( first ) );
+					value += static_cast<Unsigned>( parse_8_digits( first.get( ) ) );
 					first += 8;
 					parsed_eight_digits = true;
 				}
@@ -375,15 +376,15 @@ namespace daw::json {
 						switch( *exp_first ) {
 						case '-':
 							++exp_first;
-							daw_json_assert_weak(
-							  exp_first < exp_last and parse_digit( *exp_first ) < 10U,
-							  ErrorReason::InvalidNumber );
+							daw_json_assert_weak( exp_first < exp_last and
+							                        parse_digit( *exp_first ) < 10U,
+							                      ErrorReason::InvalidNumber );
 							return -1;
 						case '+':
 							++exp_first;
-							daw_json_assert_weak(
-							  exp_first < exp_last and parse_digit( *exp_first ) < 10U,
-							  ErrorReason::InvalidNumber );
+							daw_json_assert_weak( exp_first < exp_last and
+							                        parse_digit( *exp_first ) < 10U,
+							                      ErrorReason::InvalidNumber );
 							return 1;
 						default:
 							daw_json_assert_weak( parse_digit( *exp_first ) < 10U,
@@ -480,7 +481,8 @@ namespace daw::json {
 				  ErrorReason::InvalidNumberStart,
 				  parse_state );
 
-				[[maybe_unused]] daw::not_null<char const *> const orig_first =
+				using iterator = typename ParseState::iterator;
+				[[maybe_unused]] daw::not_null<iterator> const orig_first =
 				  parse_state.first;
 
 				auto const sign =
@@ -499,19 +501,19 @@ namespace daw::json {
 				                     std::int64_t,
 				                     Result>;
 
-				daw::not_null<char const *> first = parse_state.first;
-				daw::not_null<char const *> const last = parse_state.last;
-				daw::not_null<char const *> const whole_last =
+				daw::not_null<iterator> first = parse_state.first;
+				daw::not_null<iterator> const last = parse_state.last;
+				daw::not_null<iterator> const whole_last =
 				  parse_state.first +
 				  (std::min)( { parse_state.last - parse_state.first,
 				                static_cast<std::ptrdiff_t>( max_exponent::value ) } );
 
 				unsigned_t significant_digits = 0;
-				char const *discarded_whole_first = nullptr;
-				char const *discarded_whole_last = nullptr;
-				char const *discarded_fract_first = nullptr;
-				char const *discarded_fract_last = nullptr;
-				daw::not_null<char const *> last_char = parse_digits_while_number(
+				iterator discarded_whole_first = nullptr;
+				iterator discarded_whole_last = nullptr;
+				iterator discarded_fract_first = nullptr;
+				iterator discarded_fract_last = nullptr;
+				daw::not_null<iterator> last_char = parse_digits_while_number<iterator>(
 				  first.get( ), whole_last.get( ), significant_digits, 0 );
 				auto const parsed_whole_digit_count = last_char - parse_state.first;
 				auto const stored_whole_digit_count = [&] {
@@ -535,7 +537,7 @@ namespace daw::json {
 						}
 						// We have sig digits we cannot parse because there isn't enough
 						// room in a std::uint64_t
-						daw::not_null<char const *> ptr =
+						daw::not_null<iterator> ptr =
 						  skip_digits<( ParseState::is_zero_terminated_string or
 						                ParseState::is_unchecked_input )>( last_char,
 						                                                   last );
@@ -568,15 +570,17 @@ namespace daw::json {
 							discarded_fract_last = first.get( );
 						}
 					} else {
-						daw::not_null<char const *> fract_last =
+						daw::not_null<iterator> fract_last =
 						  first + (std::min)( parse_state.last - first,
 						                      static_cast<std::ptrdiff_t>(
 						                        max_exponent::value -
 						                        ( first - parse_state.first ) ) );
 
-						last_char = parse_digits_while_number(
-						  first.get( ), fract_last.get( ), significant_digits,
-						  stored_whole_digit_count );
+						last_char =
+						  parse_digits_while_number<iterator>( first.get( ),
+						                                       fract_last.get( ),
+						                                       significant_digits,
+						                                       stored_whole_digit_count );
 						exponent_p1 -= static_cast<signed_t>( last_char - first );
 						first = last_char;
 						if( daw::nsc_and( first >= fract_last, first < last ) ) {
@@ -626,8 +630,7 @@ namespace daw::json {
 						                      ErrorReason::UnexpectedEndOfData,
 						                      parse_state );
 						unsigned_t exp_tmp = 0;
-						last_char =
-						  parse_digits_while_number( first.get( ), last.get( ), exp_tmp, 0 );
+						last_char = parse_digits_while_number( first, last, exp_tmp, 0 );
 						first = last_char;
 						return to_signed( exp_tmp, exp_sign );
 					}
@@ -692,12 +695,12 @@ namespace daw::json {
 							                                       exponent,
 							                                       significant_digits,
 							                                       discarded_nonzero,
-							                                       orig_first,
-							                                       first );
+							                                       orig_first.get( ),
+							                                       first.get( ) );
 						} else {
 							static_assert( std::is_same_v<Result, long double> );
-							return json_details::parse_with_strtod<Result>( orig_first,
-							                                                first );
+							return json_details::parse_with_strtod<Result>( orig_first.get( ),
+							                                                first.get( ) );
 						}
 					}
 				}

--- a/include/daw/json/impl/daw_json_parse_real_decimal.h
+++ b/include/daw/json/impl/daw_json_parse_real_decimal.h
@@ -181,8 +181,8 @@ namespace daw::json {
 				[[nodiscard]] constexpr std::int64_t
 				saturating_add( std::int64_t lhs, std::int64_t rhs ) {
 					constexpr auto max_value = std::numeric_limits<std::int64_t>::max( );
-					constexpr auto min_value =
-					  std::numeric_limits<std::int64_t>::lowest( );
+					constexpr auto min_value = daw::lowest_value<std::int64_t>;
+
 					if( rhs > 0 and lhs > max_value - rhs ) {
 						return max_value;
 					}

--- a/include/daw/json/impl/daw_json_parse_real_decimal.h
+++ b/include/daw/json/impl/daw_json_parse_real_decimal.h
@@ -62,7 +62,7 @@ namespace daw::json {
 							return;
 						}
 
-						constexpr std::size_t max_growth = 19;
+						DAW_CPP23_STATIC_LOCAL constexpr std::size_t max_growth = 19;
 						std::uint8_t result[max_digits + max_growth]{ };
 						auto write = max_digits + max_growth;
 						auto read = digit_count;
@@ -180,8 +180,10 @@ namespace daw::json {
 
 				[[nodiscard]] constexpr std::int64_t
 				saturating_add( std::int64_t lhs, std::int64_t rhs ) {
-					constexpr auto max_value = daw::max_value<std::int64_t>;
-					constexpr auto lowest_value = daw::lowest_value<std::int64_t>;
+					DAW_CPP23_STATIC_LOCAL constexpr auto max_value =
+					  daw::max_value<std::int64_t>;
+					DAW_CPP23_STATIC_LOCAL constexpr auto lowest_value =
+					  daw::lowest_value<std::int64_t>;
 
 					if( rhs > 0 and lhs > max_value - rhs ) {
 						return max_value;
@@ -204,9 +206,10 @@ namespace daw::json {
 						++first;
 					}
 
-					constexpr auto positive_limit =
+					DAW_CPP23_STATIC_LOCAL constexpr auto positive_limit =
 					  static_cast<std::uint64_t>( daw::max_value<std::int64_t> );
-					constexpr auto negative_limit = positive_limit + 1U;
+					DAW_CPP23_STATIC_LOCAL constexpr auto negative_limit =
+					  positive_limit + 1U;
 					auto const limit = negative ? negative_limit : positive_limit;
 					std::uint64_t result = 0;
 					bool overflow = false;
@@ -327,9 +330,9 @@ namespace daw::json {
 					return decimal_details::pack_real<Real>( negative, 0, 0 );
 				}
 
-				constexpr std::int32_t smallest_decimal_point =
-				  std::is_same_v<Real, double> ? -324 : -45;
-				constexpr std::int32_t largest_decimal_point =
+				DAW_CPP23_STATIC_LOCAL constexpr std::int32_t
+				  smallest_decimal_point = std::is_same_v<Real, double> ? -324 : -45;
+				DAW_CPP23_STATIC_LOCAL constexpr std::int32_t largest_decimal_point =
 				  std::is_same_v<Real, double> ? 310 : 40;
 				if( decimal.decimal_point < smallest_decimal_point ) {
 					return decimal_details::pack_real<Real>( negative, 0, 0 );
@@ -362,7 +365,8 @@ namespace daw::json {
 
 				// decimal is now in [0.5, 1); IEEE formats use [1, 2).
 				--exponent2;
-				constexpr auto minimum_exponent = 1 - format::exponent_bias;
+				DAW_CPP23_STATIC_LOCAL constexpr auto minimum_exponent =
+				  1 - format::exponent_bias;
 				while( exponent2 < minimum_exponent ) {
 					auto shift = minimum_exponent - exponent2;
 					if( shift > 60 ) {

--- a/include/daw/json/impl/daw_json_parse_real_decimal.h
+++ b/include/daw/json/impl/daw_json_parse_real_decimal.h
@@ -13,12 +13,12 @@
 #include "daw/json/impl/daw_json_parse_real_eisellemire.h"
 #include "daw/json/impl/daw_json_parse_unsigned_int.h"
 
+#include <daw/daw_arith_traits.h>
 #include <daw/daw_bit_cast.h>
 #include <daw/daw_not_null.h>
 
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <type_traits>
 
 namespace daw::json {
@@ -154,7 +154,7 @@ namespace daw::json {
 							return 0;
 						}
 						if( decimal_point >= 19 ) {
-							return std::numeric_limits<std::uint64_t>::max( );
+							return daw::max_value<std::uint64_t>;
 						}
 
 						auto const point = static_cast<std::size_t>( decimal_point );
@@ -180,14 +180,14 @@ namespace daw::json {
 
 				[[nodiscard]] constexpr std::int64_t
 				saturating_add( std::int64_t lhs, std::int64_t rhs ) {
-					constexpr auto max_value = std::numeric_limits<std::int64_t>::max( );
-					constexpr auto min_value = daw::lowest_value<std::int64_t>;
+					constexpr auto max_value = daw::max_value<std::int64_t>;
+					constexpr auto lowest_value = daw::lowest_value<std::int64_t>;
 
 					if( rhs > 0 and lhs > max_value - rhs ) {
 						return max_value;
 					}
-					if( rhs < 0 and lhs < min_value - rhs ) {
-						return min_value;
+					if( rhs < 0 and lhs < lowest_value - rhs ) {
+						return lowest_value;
 					}
 					return lhs + rhs;
 				}
@@ -204,8 +204,8 @@ namespace daw::json {
 						++first;
 					}
 
-					constexpr auto positive_limit = static_cast<std::uint64_t>(
-					  std::numeric_limits<std::int64_t>::max( ) );
+					constexpr auto positive_limit =
+					  static_cast<std::uint64_t>( daw::max_value<std::int64_t> );
 					constexpr auto negative_limit = positive_limit + 1U;
 					auto const limit = negative ? negative_limit : positive_limit;
 					std::uint64_t result = 0;
@@ -225,7 +225,7 @@ namespace daw::json {
 
 					if( negative ) {
 						if( result == negative_limit ) {
-							return std::numeric_limits<std::int64_t>::lowest( );
+							return daw::lowest_value<std::int64_t>;
 						}
 						return -static_cast<std::int64_t>( result );
 					}

--- a/include/daw/json/impl/daw_json_parse_real_eisellemire.h
+++ b/include/daw/json/impl/daw_json_parse_real_eisellemire.h
@@ -38,7 +38,8 @@ namespace daw::json {
 
 				[[nodiscard]] constexpr bool
 				try_append_digit( std::uint64_t &value, unsigned digit ) noexcept {
-					constexpr auto max_value = daw::max_value<std::uint64_t>;
+					DAW_CPP23_STATIC_LOCAL constexpr auto max_value =
+				  daw::max_value<std::uint64_t>;
 					if( digit > 9U or value > ( max_value - digit ) / 10U ) {
 						return false;
 					}
@@ -132,7 +133,7 @@ namespace daw::json {
 
 					// Three extra bits are required: the implicit bit, the rounding bit,
 					// and one bit that may be lost while normalizing the product.
-					constexpr std::uint64_t precision_mask =
+					DAW_CPP23_STATIC_LOCAL constexpr std::uint64_t precision_mask =
 					  daw::max_value<std::uint64_t> >>
 					  ( binary_format<Real>::mantissa_bits + 3 );
 					if( ( product.high & precision_mask ) == precision_mask ) {

--- a/include/daw/json/impl/daw_json_parse_real_eisellemire.h
+++ b/include/daw/json/impl/daw_json_parse_real_eisellemire.h
@@ -151,6 +151,18 @@ namespace daw::json {
 				}
 			} // namespace eisellemire_details
 
+			/// @brief True when `long double` has the same size, precision, and
+			/// exponent range as `double` (e.g. MSVC, and some ARM/AArch64 ABIs),
+			/// meaning it can be computed as `double` with no loss.
+			template<typename Real>
+			inline constexpr bool is_double_sized_long_double_v =
+			  std::is_same_v<Real, long double> and
+			  sizeof( long double ) == sizeof( double ) and
+			  std::numeric_limits<long double>::digits ==
+			    std::numeric_limits<double>::digits and
+			  std::numeric_limits<long double>::max_exponent ==
+			    std::numeric_limits<double>::max_exponent;
+
 			/// Convert the exact decimal value
 			///   (-1 if negative else 1) * significant_digits * 10^exponent
 			/// to the correctly rounded IEEE-754 binary32 or binary64 value.

--- a/include/daw/json/impl/daw_json_parse_real_eisellemire.h
+++ b/include/daw/json/impl/daw_json_parse_real_eisellemire.h
@@ -12,6 +12,7 @@
 
 #include "daw/json/impl/power_of_five_128_table.h"
 
+#include <daw/daw_arith_traits.h>
 #include <daw/daw_attributes.h>
 #include <daw/daw_bit_cast.h>
 #include <daw/daw_cxmath.h>
@@ -37,7 +38,7 @@ namespace daw::json {
 
 				[[nodiscard]] constexpr bool
 				try_append_digit( std::uint64_t &value, unsigned digit ) noexcept {
-					constexpr auto max_value = std::numeric_limits<std::uint64_t>::max( );
+					constexpr auto max_value = daw::max_value<std::uint64_t>;
 					if( digit > 9U or value > ( max_value - digit ) / 10U ) {
 						return false;
 					}
@@ -132,7 +133,7 @@ namespace daw::json {
 					// Three extra bits are required: the implicit bit, the rounding bit,
 					// and one bit that may be lost while normalizing the product.
 					constexpr std::uint64_t precision_mask =
-					  std::numeric_limits<std::uint64_t>::max( ) >>
+					  daw::max_value<std::uint64_t> >>
 					  ( binary_format<Real>::mantissa_bits + 3 );
 					if( ( product.high & precision_mask ) == precision_mask ) {
 						auto const second =
@@ -158,8 +159,8 @@ namespace daw::json {
 			inline constexpr bool is_double_sized_long_double_v =
 			  std::is_same_v<Real, long double> and
 			  sizeof( long double ) == sizeof( double ) and
-			  std::numeric_limits<long double>::digits ==
-			    std::numeric_limits<double>::digits and
+			  daw::digits<long double> ==
+			    daw::digits<double> and
 			  std::numeric_limits<long double>::max_exponent ==
 			    std::numeric_limits<double>::max_exponent;
 

--- a/include/daw/json/impl/daw_json_parse_real_power10.h
+++ b/include/daw/json/impl/daw_json_parse_real_power10.h
@@ -57,16 +57,19 @@ namespace daw::json {
 			  1e290, 1e291, 1e292, 1e293, 1e294, 1e295, 1e296, 1e297, 1e298, 1e299,
 			  1e300, 1e301, 1e302, 1e303, 1e304, 1e305, 1e306, 1e307, 1e308 };
 
-			// 10^0 .. 10^27: exactly representable in 80-bit long double (5^27 < 2^64).
-			// Entries 0-22 are also exact as double; 23-27 require the full 64-bit
-			// mantissa and must not be sourced from dpow10_tbl for extended LD.
+			// 10^0 .. 10^27 are exactly representable in 80-bit long double
+			// (5^27 < 2^64), and 10^0 .. 10^48 in binary128 (5^48 < 2^113).
+			// Entries above 22 must not be sourced from the double table.
 			inline constexpr long double ldpow10_tbl[] = {
 			  1e0L,  1e1L,  1e2L,  1e3L,  1e4L,  1e5L,  1e6L,
 			  1e7L,  1e8L,  1e9L,  1e10L, 1e11L, 1e12L, 1e13L,
 			  1e14L, 1e15L, 1e16L, 1e17L, 1e18L, 1e19L, 1e20L,
 			  1e21L, 1e22L, 1e23L, 1e24L, 1e25L, 1e26L, 1e27L,
+			  1e28L, 1e29L, 1e30L, 1e31L, 1e32L, 1e33L, 1e34L,
+			  1e35L, 1e36L, 1e37L, 1e38L, 1e39L, 1e40L, 1e41L,
+			  1e42L, 1e43L, 1e44L, 1e45L, 1e46L, 1e47L, 1e48L,
 			};
-			inline constexpr int max_ld_exact_exp = 27;
+			inline constexpr int max_ld_table_exp = 48;
 
 			inline constexpr int max_dbl_exp =
 			  std::numeric_limits<double>::max_exponent10;
@@ -89,11 +92,15 @@ namespace daw::json {
 			template<typename Result, typename Unsigned>
 			[[nodiscard]] DAW_ATTRIB_FLATINLINE constexpr Result
 			power10_constexpr( Result result, Unsigned p ) {
-				// For extended long double use the exact LD table for |p| <= 27;
-				// the double table loses precision for p in [23, 27].
+				// For extended long double use the exact LD table where available;
+				// the double table loses precision for p above 22.
 				if constexpr( is_double_sized_long_double_v<Result> == false and
 				              std::is_same_v<Result, long double> ) {
-					if( p >= -max_ld_exact_exp and p <= max_ld_exact_exp ) {
+					DAW_CPP23_STATIC_LOCAL constexpr int max_exact_exp =
+					  std::numeric_limits<long double>::digits == 113
+					    ? max_ld_table_exp
+					    : 27;
+					if( p >= -max_exact_exp and p <= max_exact_exp ) {
 						if( p < 0 ) {
 							return result /
 							       ldpow10_tbl[static_cast<std::size_t>( -p )];
@@ -161,8 +168,8 @@ namespace daw::json {
 					return static_cast<Result>( power10_constexpr(
 					  static_cast<double>( result ), static_cast<std::int32_t>( p ) ) );
 				} else {
-					// Extended long double: power10_constexpr now uses the exact LD
-					// table for |p| <= 27, covering all exponents the parser routes here.
+					// Extended long double: power10_constexpr uses the exact LD table
+					// for all exponents the precise parser routes here.
 					return power10_constexpr( result, static_cast<std::int32_t>( p ) );
 				}
 			}

--- a/include/daw/json/impl/daw_json_parse_real_power10.h
+++ b/include/daw/json/impl/daw_json_parse_real_power10.h
@@ -11,6 +11,7 @@
 #include "daw/json/impl/version.h"
 
 #include "daw/json/impl/daw_json_exec_modes.h"
+#include "daw/json/impl/daw_json_parse_real_eisellemire.h"
 
 #include <daw/daw_arith_traits.h>
 #include <daw/daw_likely.h>
@@ -133,8 +134,15 @@ namespace daw::json {
 				if constexpr( std::is_same_v<Result, double> or
 				              std::is_same_v<Result, float> ) {
 					return power10_constexpr( result, static_cast<std::int32_t>( p ) );
+				} else if constexpr( is_double_sized_long_double_v<Result> ) {
+					// long double here has no more precision than double, so the
+					// double-precision table used by power10_constexpr loses nothing.
+					return static_cast<Result>( power10_constexpr(
+					  static_cast<double>( result ), static_cast<std::int32_t>( p ) ) );
 				} else {
-					// For long double and others fallback to the slower std::pow
+					// For genuine extended/quad precision long double, std::pow keeps
+					// full precision; power10_constexpr's table is double-precision
+					// only and would silently truncate it.
 					using std::pow;
 					return result * pow( static_cast<Result>( 10.0 ), p );
 				}

--- a/include/daw/json/impl/daw_json_parse_real_power10.h
+++ b/include/daw/json/impl/daw_json_parse_real_power10.h
@@ -57,6 +57,17 @@ namespace daw::json {
 			  1e290, 1e291, 1e292, 1e293, 1e294, 1e295, 1e296, 1e297, 1e298, 1e299,
 			  1e300, 1e301, 1e302, 1e303, 1e304, 1e305, 1e306, 1e307, 1e308 };
 
+			// 10^0 .. 10^27: exactly representable in 80-bit long double (5^27 < 2^64).
+			// Entries 0-22 are also exact as double; 23-27 require the full 64-bit
+			// mantissa and must not be sourced from dpow10_tbl for extended LD.
+			inline constexpr long double ldpow10_tbl[] = {
+			  1e0L,  1e1L,  1e2L,  1e3L,  1e4L,  1e5L,  1e6L,
+			  1e7L,  1e8L,  1e9L,  1e10L, 1e11L, 1e12L, 1e13L,
+			  1e14L, 1e15L, 1e16L, 1e17L, 1e18L, 1e19L, 1e20L,
+			  1e21L, 1e22L, 1e23L, 1e24L, 1e25L, 1e26L, 1e27L,
+			};
+			inline constexpr int max_ld_exact_exp = 27;
+
 			inline constexpr int max_dbl_exp =
 			  std::numeric_limits<double>::max_exponent10;
 
@@ -78,8 +89,18 @@ namespace daw::json {
 			template<typename Result, typename Unsigned>
 			[[nodiscard]] DAW_ATTRIB_FLATINLINE constexpr Result
 			power10_constexpr( Result result, Unsigned p ) {
-				// We only have a double table, of which float is a subset.  Long double
-				// will be calculated in terms of that
+				// For extended long double use the exact LD table for |p| <= 27;
+				// the double table loses precision for p in [23, 27].
+				if constexpr( is_double_sized_long_double_v<Result> == false and
+				              std::is_same_v<Result, long double> ) {
+					if( p >= -max_ld_exact_exp and p <= max_ld_exact_exp ) {
+						if( p < 0 ) {
+							return result /
+							       ldpow10_tbl[static_cast<std::size_t>( -p )];
+						}
+						return result * ldpow10_tbl[static_cast<std::size_t>( p )];
+					}
+				}
 
 				DAW_CPP23_STATIC_LOCAL constexpr auto max_v =
 				  static_cast<Result>( dpow10_tbl[max_exp<Result>] );
@@ -140,11 +161,9 @@ namespace daw::json {
 					return static_cast<Result>( power10_constexpr(
 					  static_cast<double>( result ), static_cast<std::int32_t>( p ) ) );
 				} else {
-					// For genuine extended/quad precision long double, std::pow keeps
-					// full precision; power10_constexpr's table is double-precision
-					// only and would silently truncate it.
-					using std::pow;
-					return result * pow( static_cast<Result>( 10.0 ), p );
+					// Extended long double: power10_constexpr now uses the exact LD
+					// table for |p| <= 27, covering all exponents the parser routes here.
+					return power10_constexpr( result, static_cast<std::int32_t>( p ) );
 				}
 			}
 

--- a/include/daw/json/impl/daw_json_parse_std_string.h
+++ b/include/daw/json/impl/daw_json_parse_std_string.h
@@ -20,6 +20,7 @@
 #include <daw/daw_data_end.h>
 #include <daw/daw_likely.h>
 #include <daw/daw_not_null.h>
+#include <daw/daw_span.h>
 
 #include <cstddef>
 #include <daw/stdinc/data_access.h>
@@ -44,7 +45,7 @@ namespace daw::json {
 			byte_from_nibbles( daw::not_null<char const *> &first ) {
 				auto const n0 = to_nibble( static_cast<unsigned char>( *first++ ) );
 				auto const n1 = to_nibble( static_cast<unsigned char>( *first++ ) );
-				if constexpr( is_unchecked_input ) {
+				if constexpr( not is_unchecked_input ) {
 					daw_json_ensure( n0 < 16 and n1 < 16, ErrorReason::InvalidUTFEscape );
 				}
 				return to_uint16( ( n0 << 4U ) | n1 );
@@ -69,13 +70,19 @@ namespace daw::json {
 				cp |= byte_from_nibbles<ParseState::is_unchecked_input>( first );
 				if( cp <= 0x7FU ) {
 					*it++ = static_cast<char>( static_cast<unsigned char>( cp ) );
-					parse_state.first = first;
+					parse_state.first = input_pointer( parse_state.first, first.get( ) );
 					return it;
 				}
 
 				//******************************
+				daw_json_assert_weak(
+				  cp < 0xDC00U or cp > 0xDFFFU, ErrorReason::InvalidUTFEscape,
+				  parse_state ); // Lone/unpaired low surrogate
 				if( 0xD800U <= cp and cp <= 0xDBFFU ) {
 					cp = ( cp - 0xD800U ) * 0x400U;
+					daw_json_assert_weak(
+					  *first == '\\', ErrorReason::InvalidUTFEscape,
+					  parse_state ); // High surrogate must be followed by \\u
 					++first;
 					daw_json_assert_weak(
 					  ( parse_state.last - first >= 5 ) and *first == 'u',
@@ -88,6 +95,10 @@ namespace daw::json {
 					  << 8U;
 					trailing |=
 					  byte_from_nibbles<ParseState::is_unchecked_input>( first );
+					daw_json_assert_weak(
+					  0xDC00U <= trailing and trailing <= 0xDFFFU,
+					  ErrorReason::InvalidUTFEscape,
+					  parse_state ); // Expected a low surrogate to complete the pair
 					trailing -= 0xDC00U;
 					cp += trailing;
 					cp += 0x10000;
@@ -105,7 +116,7 @@ namespace daw::json {
 					*it++ = enc1;
 					*it++ = enc2;
 					*it++ = enc3;
-					parse_state.first = first;
+					parse_state.first = input_pointer( parse_state.first, first.get( ) );
 					return it;
 				}
 				//******************************
@@ -118,7 +129,7 @@ namespace daw::json {
 					*it++ = enc0;
 					*it++ = enc1;
 					*it++ = enc2;
-					parse_state.first = first;
+					parse_state.first = input_pointer( parse_state.first, first.get( ) );
 					return it;
 				}
 				//******************************
@@ -128,7 +139,7 @@ namespace daw::json {
 				char const enc0 = u32toC( ( cp >> 6U ) | 0b1100'0000U );
 				*it++ = enc0;
 				*it++ = enc1;
-				parse_state.first = first;
+				parse_state.first = input_pointer( parse_state.first, first.get( ) );
 				return it;
 			}
 
@@ -144,11 +155,17 @@ namespace daw::json {
 				cp |= byte_from_nibbles<ParseState::is_unchecked_input>( first );
 				if( cp <= 0x7FU ) {
 					app( u32toC( cp ) );
-					parse_state.first = first;
+					parse_state.first = input_pointer( parse_state.first, first.get( ) );
 					return;
 				}
+				daw_json_assert_weak(
+				  cp < 0xDC00U or cp > 0xDFFFU, ErrorReason::InvalidUTFEscape,
+				  parse_state ); // Lone/unpaired low surrogate
 				if( 0xD800U <= cp and cp <= 0xDBFFU ) {
 					cp = ( cp - 0xD800U ) * 0x400U;
+					daw_json_assert_weak(
+					  *first == '\\', ErrorReason::InvalidUTFEscape,
+					  parse_state ); // High surrogate must be followed by \\u
 					++first;
 					daw_json_assert_weak(
 					  *first == 'u', ErrorReason::InvalidUTFEscape, parse_state );
@@ -159,6 +176,10 @@ namespace daw::json {
 					  << 8U;
 					trailing |=
 					  byte_from_nibbles<ParseState::is_unchecked_input>( first );
+					daw_json_assert_weak(
+					  0xDC00U <= trailing and trailing <= 0xDFFFU,
+					  ErrorReason::InvalidUTFEscape,
+					  parse_state ); // Expected a low surrogate to complete the pair
 					trailing -= 0xDC00U;
 					cp += trailing;
 					cp += 0x10000;
@@ -176,7 +197,7 @@ namespace daw::json {
 					app( enc1 );
 					app( enc2 );
 					app( enc3 );
-					parse_state.first = first;
+					parse_state.first = input_pointer( parse_state.first, first.get( ) );
 					return;
 				}
 				if( cp >= 0x800U ) {
@@ -188,7 +209,7 @@ namespace daw::json {
 					app( enc0 );
 					app( enc1 );
 					app( enc2 );
-					parse_state.first = first;
+					parse_state.first = input_pointer( parse_state.first, first.get( ) );
 					return;
 				}
 				// cp >= 0x80U
@@ -197,7 +218,7 @@ namespace daw::json {
 				char const enc0 = u32toC( ( cp >> 6U ) | 0b1100'0000U );
 				app( enc0 );
 				app( enc1 );
-				parse_state.first = first;
+				parse_state.first = input_pointer( parse_state.first, first.get( ) );
 			}
 
 			namespace parse_tokens {
@@ -208,32 +229,58 @@ namespace daw::json {
 			// appender
 			template<bool AllowHighEight, typename JsonMember, bool KnownBounds,
 			         typename ParseState>
-			[[nodiscard]] constexpr auto
+			[[nodiscard]] constexpr json_result_t<JsonMember>
 			parse_string_known_stdstring( ParseState &parse_state ) {
-				using string_type = json_base_type_t<JsonMember>;
-				string_type result =
-				  string_type( std::size( parse_state ) + 1,
-				               '\0',
-				               parse_state.template get_allocator_for<char>( ) );
-				daw::not_null<char *> it = std::data( result );
+				DAW_CPP23_STATIC_LOCAL constexpr bool is_insitu =
+				  JsonMember::expected_type == JsonParseTypes::StringInsitu;
+
+				static_assert(
+				  not is_insitu or ParseState::allow_string_mutation,
+				  "In-situ strings can only be parsed from writable input documents" );
+				static_assert( not is_insitu or
+				                 std::is_same_v<typename ParseState::iterator, char *>,
+				               "In-situ strings require a mutable character buffer" );
 
 				bool const has_quote = parse_state.front( ) == '"';
 				if( has_quote ) {
 					parse_state.remove_prefix( );
 				}
 
+				using string_type = json_base_type_t<JsonMember>;
+				using result_t =
+				  std::conditional_t<is_insitu, daw::span<char>, string_type>;
+				result_t result = [&] {
+					if constexpr( is_insitu ) {
+						return daw::span( std::data( parse_state ),
+						                  std::size( parse_state ) );
+					} else {
+						return string_type(
+						  std::size( parse_state ) + 1U +
+						    static_cast<unsigned>( has_quote ),
+						  '\0',
+						  parse_state.template get_allocator_for<char>( ) );
+					}
+				}( );
+				daw::not_null<char *> it = std::data( result );
+
 				if( auto const first_slash =
 				      static_cast<std::ptrdiff_t>( parse_state.counter ) - 1;
 				    first_slash > 1 ) {
-					it = daw::algorithm::copy_n( parse_state.first,
-					                             it.get( ),
-					                             static_cast<std::size_t>( first_slash ) )
-					       .output;
+					if constexpr( is_insitu ) {
+						it += first_slash;
+					} else {
+						it =
+						  daw::algorithm::copy_n( parse_state.first,
+						                          it.get( ),
+						                          static_cast<std::size_t>( first_slash ) )
+						    .output;
+					}
 					parse_state.first += first_slash;
 				}
+
 				DAW_CPP23_STATIC_LOCAL constexpr auto in_json_string =
 				  []( auto const &r ) DAW_JSON_CPP23_STATIC_CALL_OP -> bool {
-					if constexpr( not ParseState::is_unchecked_input ) {
+					if constexpr( KnownBounds or not ParseState::is_unchecked_input ) {
 						if( not DAW_LIKELY( r.has_more( ) ) ) {
 							return false;
 						}
@@ -248,31 +295,37 @@ namespace daw::json {
 
 						if( not json_details::use_constexpr_exec_mode<
 						      typename ParseState::exec_tag_t>( ) ) {
-							first =
-							  mem_move_to_next_of<( ParseState::is_unchecked_input or
-							                        ParseState::is_zero_terminated_string ),
-							                      typename ParseState::exec_tag_t,
-							                      '"',
-							                      '\\'>( first, last );
+							first = mem_move_to_next_of<
+							  ( not KnownBounds and
+							    ( ParseState::is_unchecked_input or
+							      ParseState::is_zero_terminated_string ) ),
+							  typename ParseState::exec_tag_t,
+							  '"',
+							  '\\'>( first, last );
 						} else {
+							while( first < last and *first != '"' and *first != '\\' ) {
+								++first;
+							}
 							daw_json_assert_weak( KnownBounds or first < last,
 							                      ErrorReason::UnexpectedEndOfData,
 							                      parse_state );
-							while( *first != '"' and *first != '\\' ) {
-								++first;
-								daw_json_assert_weak( KnownBounds or first < last,
-								                      ErrorReason::UnexpectedEndOfData,
-								                      parse_state );
-							}
 						}
+
+						auto const run_size = first.get( ) - parse_state.first;
 						daw_json_assert_weak(
 						  static_cast<std::ptrdiff_t>( result.size( ) ) -
-						      std::distance( result.data( ), it.get( ) ) >=
-						    std::distance( parse_state.first, first.get( ) ),
+						      ( it.get( ) - result.data( ) ) >=
+						    run_size,
 						  ErrorReason::UnexpectedEndOfData );
-						it = daw::algorithm::copy(
-						  parse_state.first, first.get( ), it.get( ) );
-						parse_state.first = first;
+
+						if( it.get( ) == parse_state.first ) {
+							it += run_size;
+						} else {
+							it = daw::algorithm::copy(
+							  parse_state.first, first.get( ), it.get( ) );
+						}
+						parse_state.first =
+						  input_pointer( parse_state.first, first.get( ) );
 					}
 					if( parse_state.front( ) == '\\' ) {
 						parse_state.remove_prefix( );
@@ -310,14 +363,11 @@ namespace daw::json {
 							parse_state.remove_prefix( );
 							break;
 						default:
-							if constexpr( not AllowHighEight ) {
-								daw_json_assert_weak(
-								  ( not parse_state.is_space_unchecked( ) ) &
-								    ( static_cast<unsigned char>( parse_state.front( ) ) <=
-								      0x7FU ),
-								  ErrorReason::InvalidStringHighASCII,
-								  parse_state );
-							}
+							// Every legal escape character (", \, /, b, f, n, r, t, u) is
+							// handled by an explicit case above; anything else following a
+							// backslash is not a valid JSON escape.
+							daw_json_assert_weak( false, ErrorReason::InvalidString,
+							                      parse_state );
 							*it++ = parse_state.front( );
 							parse_state.remove_prefix( );
 						}
@@ -335,14 +385,27 @@ namespace daw::json {
 				  std::distance( std::data( result ), it.get( ) ) );
 				daw_json_assert_weak(
 				  std::size( result ) >= sz, ErrorReason::InvalidString, parse_state );
-				result.resize( sz );
-				if constexpr( std::is_convertible_v<string_type,
+
+				if constexpr( is_insitu ) {
+					*it = '"';
+					++it;
+					while( it != ( parse_state.last + 1 ) ) {
+						*it = ' ';
+						++it;
+					}
+					result = result.subspan( 0, sz );
+				} else {
+					result.resize( sz );
+				}
+
+				if constexpr( not is_insitu and
+				              std::is_convertible_v<result_t,
 				                                    json_result_t<JsonMember>> ) {
 					return result;
 				} else {
 					using constructor_t = json_constructor_t<JsonMember>;
-					construct_value<json_result_t<JsonMember>, constructor_t>(
-					  parse_state, std::data( result ), daw::data_end( result ) );
+					return construct_value<json_result_t<JsonMember>, constructor_t>(
+					  parse_state, std::data( result ), std::size( result ) );
 				}
 			}
 		} // namespace json_details

--- a/include/daw/json/impl/daw_json_parse_string_quote.h
+++ b/include/daw/json/impl/daw_json_parse_string_quote.h
@@ -132,7 +132,11 @@ namespace daw::json {
 							}
 						}
 					}
-					parse_state.first = first;
+					if constexpr( std::is_same_v<char const *, typename ParseState::iterator> ) {
+						parse_state.first = first;
+					} else {
+						parse_state.first += first.get( ) - parse_state.first;
+					}
 					return static_cast<std::size_t>( need_slow_path );
 				}
 
@@ -275,7 +279,11 @@ namespace daw::json {
 						                      ErrorReason::InvalidString,
 						                      parse_state );
 					}
-					parse_state.first = first;
+					if constexpr( std::is_same_v<char const *, typename ParseState::iterator> ) {
+						parse_state.first = first;
+					} else {
+						parse_state.first += first.get( ) - parse_state.first;
+					}
 					return static_cast<std::size_t>( need_slow_path );
 				}
 

--- a/include/daw/json/impl/daw_json_parse_unsigned_int.h
+++ b/include/daw/json/impl/daw_json_parse_unsigned_int.h
@@ -204,11 +204,10 @@ namespace daw::json {
 					}
 				}
 				if constexpr( RangeChecked != options::JsonRangeCheck::Never ) {
-					auto const count = ( daw::numeric_limits<result_t>::digits10 + 1U ) -
-					                   std::size( parse_state );
+					auto const count =
+					  ( daw::digits10<result_t> + 1U ) - std::size( parse_state );
 					daw_json_ensure(
-					  ( ( result <= static_cast<uresult_t>(
-					                  ( daw::numeric_limits<result_t>::max )( ) ) ) &
+					  ( ( result <= static_cast<uresult_t>( daw::max_value<result_t> ) ) &
 					    ( count >= 0 ) ),
 					  ErrorReason::NumberOutOfRange,
 					  parse_state );
@@ -291,9 +290,9 @@ namespace daw::json {
 				}
 
 				if constexpr( RangeChecked != options::JsonRangeCheck::Never ) {
-					auto const count = static_cast<std::ptrdiff_t>(
-					                     daw::numeric_limits<result_t>::digits10 + 1 ) -
-					                   ( first - orig_first );
+					auto const count =
+					  static_cast<std::ptrdiff_t>( daw::digits10<result_t> + 1 ) -
+					  ( first - orig_first );
 					daw_json_ensure(
 					  count >= 0, ErrorReason::NumberOutOfRange, parse_state );
 				}

--- a/include/daw/json/impl/daw_json_parse_unsigned_int.h
+++ b/include/daw/json/impl/daw_json_parse_unsigned_int.h
@@ -28,16 +28,6 @@
 #include <daw/stdinc/data_access.h>
 #include <limits>
 
-#if defined( DAW_ALLOW_SSE42 )
-#include <emmintrin.h>
-#include <smmintrin.h>
-#include <tmmintrin.h>
-#include <xmmintrin.h>
-#if defined( DAW_HAS_MSVC_LIKE )
-#include <intrin.h>
-#endif
-#endif
-
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
 		namespace json_details {
@@ -56,19 +46,7 @@ namespace daw::json {
 				// The copy to local buffer is to get the compiler to treat it like a
 				// reinterpret_cast
 
-				std::byte const buff[8]{ static_cast<std::byte>( ptr[0] ),
-				                         static_cast<std::byte>( ptr[1] ),
-				                         static_cast<std::byte>( ptr[2] ),
-				                         static_cast<std::byte>( ptr[3] ),
-				                         static_cast<std::byte>( ptr[4] ),
-				                         static_cast<std::byte>( ptr[5] ),
-				                         static_cast<std::byte>( ptr[6] ),
-				                         static_cast<std::byte>( ptr[7] ) };
-
-				auto val = UInt64( );
-				for( std::size_t n = 0; n < 8; ++n ) {
-					val |= to_uint64( buff[n] ) << ( 8 * n );
-				}
+				auto const val = daw::to_uint64_buffer( ptr.get( ) );
 				return ( ( ( val & 0xF0F0'F0F0'F0F0'F0F0_u64 ) |
 				           ( ( ( val + 0x0606'0606'0606'0606_u64 ) &
 				               0xF0F0'F0F0'F0F0'F0F0_u64 ) >>

--- a/include/daw/json/impl/daw_json_parse_unsigned_int.h
+++ b/include/daw/json/impl/daw_json_parse_unsigned_int.h
@@ -235,7 +235,12 @@ namespace daw::json {
 					  ErrorReason::NumberOutOfRange,
 					  parse_state );
 				}
-				parse_state.first = first;
+				if constexpr( std::is_same_v<char const *,
+				                             typename ParseState::iterator> ) {
+					parse_state.first = first;
+				} else {
+					parse_state.first += first.get( ) - parse_state.first;
+				}
 				if constexpr( RangeChecked == options::JsonRangeCheck::Never ) {
 					return daw::construct_a<Unsigned>( static_cast<Unsigned>( result ) );
 				} else {
@@ -315,7 +320,12 @@ namespace daw::json {
 					  count >= 0, ErrorReason::NumberOutOfRange, parse_state );
 				}
 
-				parse_state.first = first;
+				if constexpr( std::is_same_v<char const *,
+				                             typename ParseState::iterator> ) {
+					parse_state.first = first;
+				} else {
+					parse_state.first += first.get( ) - parse_state.first;
+				}
 				if constexpr( RangeChecked == options::JsonRangeCheck::Never ) {
 					return daw::construct_a<Unsigned>(
 					  static_cast<Unsigned>( static_cast<result_t>( result ) ) );

--- a/include/daw/json/impl/daw_json_parse_value.h
+++ b/include/daw/json/impl/daw_json_parse_value.h
@@ -333,7 +333,6 @@ namespace daw::json {
 					if( parse_state.front( ) == 'n' ) {
 						parse_state.remove_prefix( 4 );
 						parse_state.trim_left_unchecked( );
-						parse_state.remove_prefix( );
 						return construct_empty( );
 					}
 					return construct_value<base_member_type, constructor_t>(
@@ -532,9 +531,7 @@ namespace daw::json {
 					// There are no escapes in the string, we can just use the ptr/size
 					// ctor
 					return construct_value<json_result_t<JsonMember>, constructor_t>(
-					  parse_state,
-					  std::data( parse_state2 ),
-					  daw::data_end( parse_state2 ) );
+					  parse_state, std::data( parse_state2 ), std::size( parse_state2 ) );
 				}
 			}
 
@@ -589,11 +586,10 @@ namespace daw::json {
 				}( );
 				if constexpr( JsonMember::custom_json_type !=
 				              options::JsonCustomTypes::Any ) {
-					daw_json_assert_weak(
-					  str.has_more( ) and
-					    not( str.front( ) == '[' or str.front( ) == '{' ),
-					  ErrorReason::InvalidStartOfValue,
-					  str );
+					daw_json_assert_weak( str.has_more( ) and not( str.front( ) == '[' or
+					                                               str.front( ) == '{' ),
+					                      ErrorReason::InvalidStartOfValue,
+					                      str );
 				}
 				using constructor_t = typename JsonMember::from_converter_t;
 				return construct_value<json_result_t<JsonMember>, constructor_t>(
@@ -1265,8 +1261,8 @@ namespace daw::json {
 
 				auto const found =
 				  find_range2( submember_state, JsonMember::json_path );
-				daw_json_ensure( found, ErrorReason::JSONPathNotFound,
-				                 submember_state );
+				daw_json_ensure(
+				  found, ErrorReason::JSONPathNotFound, submember_state );
 
 				using member_type = typename JsonMember::member_type;
 				return parse_value<member_type, false, member_type::expected_type>(
@@ -1289,6 +1285,9 @@ namespace daw::json {
 					return parse_value_bool<JsonMember, KnownBounds>( parse_state );
 				} else if constexpr( PTag == JsonParseTypes::StringRaw ) {
 					return parse_value_string_raw<JsonMember, KnownBounds>( parse_state );
+				} else if constexpr( PTag == JsonParseTypes::StringInsitu ) {
+					return parse_value_string_escaped<JsonMember, KnownBounds>(
+					  parse_state );
 				} else if constexpr( PTag == JsonParseTypes::StringEscaped ) {
 					return parse_value_string_escaped<JsonMember, KnownBounds>(
 					  parse_state );

--- a/include/daw/json/impl/daw_json_simd_iterator_class.h
+++ b/include/daw/json/impl/daw_json_simd_iterator_class.h
@@ -74,7 +74,8 @@ namespace daw::json {
 					  ( input == simd_details::splat<simd_type>( '\\' ) ).to_ullong( ) &
 					  valid_bits;
 
-					constexpr std::uint64_t odd_bits = 0xAAAAAAAAAAAAAAAAULL;
+					DAW_CPP23_STATIC_LOCAL constexpr std::uint64_t odd_bits =
+					  0xAAAAAAAAAAAAAAAAULL;
 					auto const previous_escaped = escaped ? std::uint64_t{ 1 } : 0U;
 					auto const potential_escape = backslash_bits & ~previous_escaped;
 					auto const maybe_escaped = potential_escape << 1U;

--- a/include/daw/json/impl/daw_json_simd_iterator_common.h
+++ b/include/daw/json/impl/daw_json_simd_iterator_common.h
@@ -506,7 +506,8 @@ namespace daw::json {
 					auto const valid_bits = low_bits( count );
 					auto const backslash_bits = backslash.to_ullong( ) & valid_bits;
 
-					constexpr std::uint64_t odd_bits = 0xAAAAAAAAAAAAAAAAULL;
+					DAW_CPP23_STATIC_LOCAL constexpr std::uint64_t odd_bits =
+					  0xAAAAAAAAAAAAAAAAULL;
 					auto const previous_escaped = state.escaped ? std::uint64_t{ 1 } : 0;
 					auto const potential_escape = backslash_bits & ~previous_escaped;
 					auto const maybe_escaped = potential_escape << 1U;

--- a/include/daw/json/impl/daw_json_skip.h
+++ b/include/daw/json/impl/daw_json_skip.h
@@ -151,10 +151,10 @@ namespace daw::json {
 				return result;
 			}
 
-			template<bool skip_end_check>
-			DAW_ATTRIB_FLATINLINE [[nodiscard]] constexpr daw::not_null<char const *>
-			skip_digits( daw::not_null<char const *> first,
-			             daw::not_null<char const *> const last ) {
+			template<bool skip_end_check, typename iterator>
+			DAW_ATTRIB_FLATINLINE [[nodiscard]] constexpr daw::not_null<iterator>
+			skip_digits( daw::not_null<iterator> first,
+			             daw::not_null<iterator> const last ) {
 				(void)last; // only used inside if constexpr and gcc9 warns
 				unsigned dig = parse_digit( *first );
 				while( dig < 10 ) {
@@ -242,7 +242,7 @@ namespace daw::json {
 					daw_json_assert_weak(
 					  first < last, ErrorReason::UnexpectedEndOfData, [&] {
 						  auto r = parse_state;
-						  r.first = first;
+						  r.first = input_pointer( r.first, first.get( ) );
 						  return r;
 					  }( ) );
 					dig = parse_digit( *first );
@@ -261,10 +261,10 @@ namespace daw::json {
 					}
 				}
 
-				parse_state.first = first;
-				result.last = first;
-				result.class_first = decimal;
-				result.class_last = exp;
+				parse_state.first = input_pointer( parse_state.first, first.get( ) );
+				result.last = input_pointer( result.first, first.get( ) );
+				result.class_first = input_pointer( result.first, decimal );
+				result.class_last = input_pointer( result.first, exp );
 				return result;
 			}
 
@@ -335,6 +335,8 @@ namespace daw::json {
 				              JsonMember::expected_type == JsonParseTypes::StringRaw or
 				              JsonMember::expected_type ==
 				                JsonParseTypes::StringEscaped or
+				              JsonMember::expected_type ==
+				                JsonParseTypes::StringInsitu or
 				              JsonMember::expected_type == JsonParseTypes::Custom ) {
 					// json string encodings
 					daw_json_assert_weak( parse_state.front( ) == '"',

--- a/include/daw/json/impl/daw_json_skip_class_simd.h
+++ b/include/daw/json/impl/daw_json_skip_class_simd.h
@@ -87,13 +87,13 @@ namespace daw::json {
 			template<SkipBracketedType BracketedType, typename ParseState>
 			[[nodiscard]] DAW_ATTRIB_FLATTEN DAW_JSON_SIMD_CONSTEXPR ParseState
 			skip_bracketed_item_simd( ParseState &parse_state ) {
-				constexpr char primary_left =
+				DAW_CPP23_STATIC_LOCAL constexpr char primary_left =
 				  BracketedType == SkipBracketedType::Class ? '{' : '[';
-				constexpr char primary_right =
+				DAW_CPP23_STATIC_LOCAL constexpr char primary_right =
 				  BracketedType == SkipBracketedType::Class ? '}' : ']';
-				constexpr char secondary_left =
+				DAW_CPP23_STATIC_LOCAL constexpr char secondary_left =
 				  BracketedType == SkipBracketedType::Class ? '[' : '{';
-				constexpr char secondary_right =
+				DAW_CPP23_STATIC_LOCAL constexpr char secondary_right =
 				  BracketedType == SkipBracketedType::Class ? ']' : '}';
 
 				using namespace skip_bracketed_item_simd_details;
@@ -124,7 +124,8 @@ namespace daw::json {
 					auto const backslash_bits =
 					  ( input == splat( '\\' ) ).to_ullong( ) & valid_bits;
 
-					constexpr std::uint64_t odd_bits = 0xAAAAAAAAAAAAAAAAULL;
+					DAW_CPP23_STATIC_LOCAL constexpr std::uint64_t odd_bits =
+					  0xAAAAAAAAAAAAAAAAULL;
 					auto const previous_escaped = escaped ? std::uint64_t{ 1 } : 0;
 					auto const potential_escape = backslash_bits & ~previous_escaped;
 					auto const maybe_escaped = potential_escape << 1U;

--- a/include/daw/json/impl/daw_json_types_base.h
+++ b/include/daw/json/impl/daw_json_types_base.h
@@ -130,6 +130,17 @@ namespace daw::json {
 			  json_nullable<T, json_string<json_details::unwrapped_t<T>, Options>,
 			                NullableType, Constructor>;
 
+			template<typename T, json_options_t Options = string_opts_def,
+			         typename Constructor = use_default>
+			struct json_string_insitu;
+
+			template<typename T, json_options_t Options = string_opts_def,
+			         JsonNullable NullableType = JsonNullable::Nullable,
+			         typename Constructor = use_default>
+			using json_string_insitu_null =
+			  json_nullable<T, json_string_insitu<json_details::unwrapped_t<T>, Options>,
+			                NullableType, Constructor>;
+
 			template<typename T, json_options_t Options = bool_opts_def,
 			         typename Constructor = use_default>
 			struct json_bool;

--- a/include/daw/json/impl/daw_not_const_ex_functions.h
+++ b/include/daw/json/impl/daw_not_const_ex_functions.h
@@ -161,8 +161,9 @@ namespace daw::json {
 			DAW_ATTRIB_INLINE constexpr std::uint64_t
 			find_escaped_branchless( std::uint64_t &prev_escaped,
 			                         std::uint64_t backslashes ) {
-				constexpr std::uint64_t odd_bits = 0xAAAA'AAAA'AAAA'AAAAULL;
-				constexpr auto valid_bits = [] {
+				DAW_CPP23_STATIC_LOCAL constexpr std::uint64_t odd_bits =
+				  0xAAAA'AAAA'AAAA'AAAAULL;
+				DAW_CPP23_STATIC_LOCAL constexpr auto valid_bits = [] {
 					if constexpr( char_simd_size == 64 ) {
 						return ~std::uint64_t{ 0 };
 					} else {

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -277,6 +277,57 @@ namespace daw::json {
 		} // namespace json_details
 
 		namespace utils {
+			template<bool RestrictHigh, typename WriteableType>
+			[[nodiscard]] static constexpr WriteableType
+			escape_codepoint_to_iterator( WriteableType it, std::uint32_t cp ) {
+				switch( cp ) {
+				case '"':
+					it.write( "\\\"" );
+					break;
+				case '\\':
+					it.write( "\\\\" );
+					break;
+				case '\b':
+					it.write( "\\b" );
+					break;
+				case '\f':
+					it.write( "\\f" );
+					break;
+				case '\n':
+					it.write( "\\n" );
+					break;
+				case '\r':
+					it.write( "\\r" );
+					break;
+				case '\t':
+					it.write( "\\t" );
+					break;
+				default:
+					if( cp < 0x20U ) {
+						it = json_details::output_hex( static_cast<std::uint16_t>( cp ),
+						                               it );
+						break;
+					}
+					if constexpr( RestrictHigh ) {
+						if( cp >= 0x80U and cp <= 0xFFFFU ) {
+							it = json_details::output_hex(
+							  static_cast<std::uint16_t>( cp ), it );
+							break;
+						}
+						if( cp > 0xFFFFU ) {
+							it = json_details::output_hex(
+							  static_cast<std::uint16_t>( 0xD7C0U + ( cp >> 10U ) ), it );
+							it = json_details::output_hex(
+							  static_cast<std::uint16_t>( 0xDC00U + ( cp & 0x3FFU ) ), it );
+							break;
+						}
+					}
+					json_details::utf32_to_utf8( cp, it );
+					break;
+				}
+				return it;
+			}
+
 			template<
 			  bool do_escape = false,
 			  options::EightBitModes EightBitMode = options::EightBitModes::AllowFull,
@@ -372,52 +423,7 @@ namespace daw::json {
 								first = it_t( std::next( first.base( ) ) );
 							}
 						}
-						switch( cp ) {
-						case '"':
-							it.write( "\\\"" );
-							break;
-						case '\\':
-							it.write( "\\\\" );
-							break;
-						case '\b':
-							it.write( "\\b" );
-							break;
-						case '\f':
-							it.write( "\\f" );
-							break;
-						case '\n':
-							it.write( "\\n" );
-							break;
-						case '\r':
-							it.write( "\\r" );
-							break;
-						case '\t':
-							it.write( "\\t" );
-							break;
-						default:
-							if( cp < 0x20U ) {
-								it = json_details::output_hex( static_cast<std::uint16_t>( cp ),
-								                               it );
-								break;
-							}
-							if constexpr( restrict_high::value ) {
-								if( cp >= 0x7FU and cp <= 0xFFFFU ) {
-									it = json_details::output_hex(
-									  static_cast<std::uint16_t>( cp ), it );
-									break;
-								}
-								if( cp > 0xFFFFU ) {
-									it = json_details::output_hex(
-									  static_cast<std::uint16_t>( 0xD7C0U + ( cp >> 10U ) ), it );
-									it = json_details::output_hex(
-									  static_cast<std::uint16_t>( 0xDC00U + ( cp & 0x3FFU ) ),
-									  it );
-									break;
-								}
-							}
-							json_details::utf32_to_utf8( cp, it );
-							break;
-						}
+						it = escape_codepoint_to_iterator<restrict_high::value>( it, cp );
 					}
 				} else {
 					if constexpr( json_details::is_string_view_like_v<Container> ) {
@@ -462,52 +468,7 @@ namespace daw::json {
 					auto chr_it = utf8::unchecked::iterator<char const *>( ptr );
 					while( *chr_it.base( ) != '\0' ) {
 						auto const cp = *chr_it++;
-						switch( cp ) {
-						case '"':
-							it.write( "\\\"" );
-							break;
-						case '\\':
-							it.write( "\\\\" );
-							break;
-						case '\b':
-							it.write( "\\b" );
-							break;
-						case '\f':
-							it.write( "\\f" );
-							break;
-						case '\n':
-							it.write( "\\n" );
-							break;
-						case '\r':
-							it.write( "\\r" );
-							break;
-						case '\t':
-							it.write( "\\t" );
-							break;
-						default:
-							if( cp < 0x20U ) {
-								it = json_details::output_hex( static_cast<std::uint16_t>( cp ),
-								                               it );
-								break;
-							}
-							if constexpr( restrict_high::value ) {
-								if( cp >= 0x7FU and cp <= 0xFFFFU ) {
-									it = json_details::output_hex(
-									  static_cast<std::uint16_t>( cp ), it );
-									break;
-								}
-								if( cp > 0xFFFFU ) {
-									it = json_details::output_hex(
-									  static_cast<std::uint16_t>( 0xD7C0U + ( cp >> 10U ) ), it );
-									it = output_hex(
-									  static_cast<std::uint16_t>( 0xDC00U + ( cp & 0x3FFU ) ),
-									  it );
-									break;
-								}
-							}
-							json_details::utf32_to_utf8( cp, it );
-							break;
-						}
+						it = escape_codepoint_to_iterator<restrict_high::value>( it, cp );
 					}
 				} else if constexpr( restrict_high::value ) {
 					auto const *const first = ptr;
@@ -957,7 +918,7 @@ namespace daw::json {
 				it.put( '"' );
 				it = utils::copy_to_iterator<escape_output_v<JsonMember> !=
 				                               options::EscapeValidUTF8::AssumeValid,
-				                             JsonMember::eight_bit_mode>( it, value );
+				                             JsonMember::eight_bit_mode, true>( it, value );
 				it.put( '"' );
 				return it;
 			}

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -290,7 +290,7 @@ namespace daw::json {
 				using restrict_high = std::bool_constant<
 				  EightBitMode != options::EightBitModes::AllowFull or
 				  ( WritableType::restricted_string_output ==
-				    options::RestrictedStringOutput::OnlyAllow7bitsStrings )>;
+				    options::RestrictedStringOutput::OnlyAllow7bitStrings )>;
 				if constexpr( do_escape ) {
 					if constexpr( use_scanned_write and
 					              json_details::is_string_view_like_v<Container> ) {
@@ -456,7 +456,7 @@ namespace daw::json {
 				using restrict_high = std::bool_constant<
 				  EightBitMode != options::EightBitModes::AllowFull or
 				  ( WriteableType::restricted_string_output ==
-				    options::RestrictedStringOutput::OnlyAllow7bitsStrings )>;
+				    options::RestrictedStringOutput::OnlyAllow7bitStrings )>;
 
 				if constexpr( do_escape ) {
 					auto chr_it = utf8::unchecked::iterator<char const *>( ptr );

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -1942,12 +1942,11 @@ namespace daw::json {
 					out_it.put( '.' );
 					auto const p2val = dec.significand - ( p1val * p1pow );
 					// ensure we account for leading zeros
-					//					auto const sig_sigits =
 					{
-						auto const l10_sig = daw::cxmath::count_digits( dec.significand );
 						auto const l10_p1val = daw::cxmath::count_digits( p1val );
 						auto const l10_p2val = daw::cxmath::count_digits( p2val );
-						auto const extra_zeros = l10_sig - ( l10_p2val + l10_p1val );
+						auto const extra_zeros =
+						  static_cast<int>( digit_values ) - ( l10_p2val + l10_p1val );
 						for( int n = 0; n < extra_zeros; ++n ) {
 							out_it.put( '0' );
 						}

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -48,7 +48,7 @@
 
 namespace daw::json {
 	inline namespace DAW_JSON_VER {
-			namespace json_details {
+		namespace json_details {
 			template<options::FPOutputFormat fp_output_format,
 			         unsigned Precision = daw::max_value<unsigned>, typename Real,
 			         typename WriteableType>
@@ -280,8 +280,7 @@ namespace daw::json {
 			template<
 			  bool do_escape = false,
 			  options::EightBitModes EightBitMode = options::EightBitModes::AllowFull,
-			  bool use_scanned_write = false,
-			  typename WritableType,
+			  bool use_scanned_write = false, typename WritableType,
 			  typename Container DAW_ENABLEIF(
 			    daw::traits::is_container_like_v<daw::remove_cvref_t<Container>> )>
 			DAW_REQUIRES(
@@ -778,7 +777,7 @@ namespace daw::json {
 				              daw::is_integral_v<parse_to_t> ) {
 					auto v = static_cast<under_type>( value );
 
-					char buff[daw::numeric_limits<under_type>::digits10 + 10]{ };
+					char buff[daw::digits10<under_type> + 10]{ };
 					char *num_start = buff;
 					char *ptr = buff;
 					if constexpr( JsonMember::literal_as_string ==
@@ -790,7 +789,7 @@ namespace daw::json {
 						*ptr++ = '-';
 						++num_start;
 						// Do 1 round here just in case we are
-						// daw::numeric_limits<intmax_t>::min( ) and cannot negate
+						// daw::min_value<intmax_t> and cannot negate
 						// This is a subtraction because when v < 0, v % 100 is negative
 						auto const tmp = -static_cast<std::size_t>( v % 10 );
 						v /= -10;
@@ -870,7 +869,7 @@ namespace daw::json {
 						it.put( '0' );
 					} else {
 						daw_json_ensure( v > 0, ErrorReason::NumberOutOfRange );
-						char buff[daw::numeric_limits<under_type>::digits10 + 10]{ };
+						char buff[daw::digits10<under_type> + 10U]{ };
 						char *ptr = buff;
 						while( v >= 10 ) {
 							auto const tmp = static_cast<std::size_t>( v % 100U );
@@ -1098,8 +1097,7 @@ namespace daw::json {
 					it.put( '"' );
 				}
 
-				if constexpr( daw::is_callable_r_v<
-				                WriteableType,
+				if constexpr( daw::is_callable_r_v<WriteableType,
 				                                   typename JsonMember::to_converter_t,
 				                                   WriteableType,
 				                                   parse_to_t> ) {
@@ -1428,8 +1426,7 @@ namespace daw::json {
 				if( path_item.current.empty( ) ) {
 					daw_json_ensure( path_item.found_char == '[',
 					                 ErrorReason::OutputError );
-					return to_json_string_submember_array<JsonMember>( it, path,
-					                                                   value );
+					return to_json_string_submember_array<JsonMember>( it, path, value );
 				}
 
 				it.put( '{' );

--- a/include/daw/json/impl/to_daw_json_string.h
+++ b/include/daw/json/impl/to_daw_json_string.h
@@ -1482,7 +1482,8 @@ namespace daw::json {
 					return to_json_string_bool<JsonMember>( it, value );
 				} else if constexpr( Tag == JsonParseTypes::StringRaw ) {
 					return to_json_string_string_raw<JsonMember>( it, value );
-				} else if constexpr( Tag == JsonParseTypes::StringEscaped ) {
+				} else if constexpr( Tag == JsonParseTypes::StringEscaped or
+				                     Tag == JsonParseTypes::StringInsitu ) {
 					return to_json_string_string_escaped<JsonMember>( it, value );
 				} else if constexpr( Tag == JsonParseTypes::Date ) {
 					return to_json_string_date<JsonMember>( it, value );

--- a/include/daw/json/impl/version.h
+++ b/include/daw/json/impl/version.h
@@ -17,9 +17,9 @@
 #if not defined( DAW_JSON_VER_OVERRIDE )
 // Should be updated when a potential ABI break is anticipated
 #if defined( DEBUG ) or not defined( NDEBUG )
-#define DAW_JSON_VER v3_38_1d
+#define DAW_JSON_VER v3_39_0d
 #else
-#define DAW_JSON_VER v3_38_1
+#define DAW_JSON_VER v3_39_0
 #endif
 #else
 #define DAW_JSON_VER DAW_JSON_VER_OVERRIDE

--- a/include/daw/third_party/dragonbox/dragonbox_to_decimal.h
+++ b/include/daw/third_party/dragonbox/dragonbox_to_decimal.h
@@ -708,7 +708,8 @@ namespace daw::jkj::dragonbox {
 				struct table_holder {
 					static constexpr table_t<UInt, a, N> table =
 					  [] DAW_CPP23_STATIC_CALL_OP {
-						  constexpr auto mod_inverse = modular_inverse<UInt, a>( );
+						  DAW_CPP23_STATIC_LOCAL constexpr auto mod_inverse =
+						    modular_inverse<UInt, a>( );
 						  table_t<UInt, a, N> tbl{ };
 						  std::common_type_t<UInt, unsigned int> pow_of_mod_inverse = 1;
 						  UInt pow_of_a = 1;

--- a/readme.md
+++ b/readme.md
@@ -375,7 +375,7 @@ Parsing errors default to throwing a `daw::json::json_exception` that includes i
 If exceptions are disabled the library will call `std::terminate` upon a parse error by default.
 
 ## Custom Error Handling
-While, the error handling defaults to throwing a `daw::json::json_exception` on errors, or calling `std::terminate` if exceptions are disabled.  One can change this behaviour by setting the function pointer `daw::json::daw_json_error_handler`.  The only requirement is that the function does not return.  An example that utilizes this is in [error_handling_bench_test.cpp](tests/src/error_handling_bench_test.cpp) 
+While, the error handling defaults to throwing a `daw::json::json_exception` on errors, or calling `std::terminate` if exceptions are disabled.  One can change this behaviour by setting the function pointer `daw::json::daw_json_error_handler` (and its companion user-data pointer `daw::json::daw_json_error_handler_data`).  The only requirement is that the function does not return.  **Both are `thread_local`**: setting them affects parsing on the thread that set them only, so a handler installed on a "setup" thread will not apply to parsing done on other threads, each of which sees the default handler until it sets its own.  An example that utilizes this is in [error_handling_bench_test.cpp](tests/src/error_handling_bench_test.cpp) 
 
 ## Parsing call
 ###### [Top](#content)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1251,6 +1251,24 @@ add_test( NAME custom_optional_number_test COMMAND custom_optional_number_test W
 add_dependencies( ci_tests custom_optional_number_test )
 add_dependencies( full custom_optional_number_test )
 
+add_executable( custom_types_string_literal_test src/custom_types_string_literal_test.cpp )
+target_link_libraries( custom_types_string_literal_test PRIVATE json_test )
+add_test( NAME custom_types_string_literal_test COMMAND custom_types_string_literal_test )
+add_dependencies( ci_tests custom_types_string_literal_test )
+add_dependencies( full custom_types_string_literal_test )
+
+add_executable( parse_policy_options_test src/parse_policy_options_test.cpp )
+target_link_libraries( parse_policy_options_test PRIVATE json_test )
+add_test( NAME parse_policy_options_test COMMAND parse_policy_options_test )
+add_dependencies( ci_tests parse_policy_options_test )
+add_dependencies( full parse_policy_options_test )
+
+add_executable( serialize_policy_options_test src/serialize_policy_options_test.cpp )
+target_link_libraries( serialize_policy_options_test PRIVATE json_test )
+add_test( NAME serialize_policy_options_test COMMAND serialize_policy_options_test )
+add_dependencies( ci_tests serialize_policy_options_test )
+add_dependencies( full serialize_policy_options_test )
+
 add_executable( multi_tu_test src/multi_tu_p0_test.cpp src/multi_tu_p1_test.cpp )
 target_link_libraries( multi_tu_test json_test )
 add_test( NAME multi_tu_test_test COMMAND multi_tu_test )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -776,6 +776,22 @@ add_test( NAME long_double_test COMMAND long_double_test )
 add_dependencies( ci_tests long_double_test )
 add_dependencies( full long_double_test )
 
+add_executable( json_event_parser_max_depth_test
+                 src/json_event_parser_max_depth_test.cpp )
+target_link_libraries( json_event_parser_max_depth_test PRIVATE json_test )
+add_test( NAME json_event_parser_max_depth_test
+          COMMAND json_event_parser_max_depth_test )
+add_dependencies( ci_tests json_event_parser_max_depth_test )
+add_dependencies( full json_event_parser_max_depth_test )
+
+add_executable( json_event_parser_handler_result_test
+                 src/json_event_parser_handler_result_test.cpp )
+target_link_libraries( json_event_parser_handler_result_test PRIVATE json_test )
+add_test( NAME json_event_parser_handler_result_test
+          COMMAND json_event_parser_handler_result_test )
+add_dependencies( ci_tests json_event_parser_handler_result_test )
+add_dependencies( full json_event_parser_handler_result_test )
+
 if( DAW_USE_EXCEPTIONS )
 	add_executable( test_details_skip_string src/test_details_skip_string.cpp )
 	target_link_libraries( test_details_skip_string PRIVATE json_test )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -770,6 +770,12 @@ add_test( test_parse_real_lemire_test test_parse_real_lemire )
 add_dependencies( ci_tests test_parse_real_lemire )
 add_dependencies( full test_parse_real_lemire )
 
+add_executable( long_double_test src/long_double_test.cpp )
+target_link_libraries( long_double_test PRIVATE json_test )
+add_test( NAME long_double_test COMMAND long_double_test )
+add_dependencies( ci_tests long_double_test )
+add_dependencies( full long_double_test )
+
 if( DAW_USE_EXCEPTIONS )
 	add_executable( test_details_skip_string src/test_details_skip_string.cpp )
 	target_link_libraries( test_details_skip_string PRIVATE json_test )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -249,6 +249,14 @@ endif()
 target_link_libraries( twitter_test PRIVATE json_test )
 add_dependencies( full twitter_test )
 
+if( DAW_JSON_FULL_TESTS )
+	add_executable( twitter_insitu_test src/twitter_insitu_test.cpp )
+	add_test( NAME twitter_insitu_test COMMAND twitter_insitu_test ./twitter.json WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test_data/" )
+else()
+	add_executable( twitter_insitu_test EXCLUDE_FROM_ALL src/twitter_insitu_test.cpp )
+endif()
+target_link_libraries( twitter_insitu_test PRIVATE json_test )
+add_dependencies( full twitter_insitu_test )
 
 if( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND CLANG_VERSION_MAJOR VERSION_GREATER_EQUAL 9 )
 	if( DAW_JSON_FULL_TESTS )
@@ -1266,6 +1274,12 @@ target_link_libraries( daw_json_writer_test json_test )
 add_test( NAME daw_json_writer_test_test COMMAND daw_json_writer_test )
 add_dependencies( ci_tests daw_json_writer_test )
 add_dependencies( full daw_json_writer_test )
+
+add_executable( json_string_insitu_test src/json_string_insitu_test.cpp )
+target_link_libraries( json_string_insitu_test PRIVATE json_test )
+add_test( NAME json_string_insitu_test COMMAND json_string_insitu_test )
+add_dependencies( ci_tests json_string_insitu_test )
+add_dependencies( full json_string_insitu_test )
 
 add_executable( daw_json_writer_mapping_test
 								src/daw_json_writer_mapping_test.cpp )

--- a/tests/include/twitter_insitu_test.h
+++ b/tests/include/twitter_insitu_test.h
@@ -1,0 +1,186 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+
+#pragma once
+
+#include <daw/json/daw_from_json_fwd.h>
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace daw::twitter_insitu {
+	using twitter_tp = std::chrono::time_point<std::chrono::system_clock,
+	                                           std::chrono::milliseconds>;
+
+	struct metadata_t {
+		std::string_view result_type;
+		std::string_view iso_language_code;
+	}; // metadata_t
+
+	struct urls_element_t {
+		std::string_view url;
+		std::string_view expanded_url;
+		std::string_view display_url;
+		std::vector<int32_t> indices;
+	}; // urls_element_t
+
+	struct url_t {
+		std::vector<urls_element_t> urls;
+	}; // url_t
+
+	struct entities_t {
+		std::optional<url_t> url;
+		std::optional<url_t> description;
+	}; // entities_t
+
+	struct user_t {
+		int64_t id;
+		std::string_view id_str;
+		std::string_view name;
+		std::string_view screen_name;
+		std::string_view location;
+		std::string_view description;
+		std::optional<std::string_view> url;
+		entities_t entities;
+		bool _jsonprotected;
+		int32_t followers_count;
+		int32_t friends_count;
+		int32_t listed_count;
+		twitter_tp created_at;
+		int32_t favourites_count;
+		bool geo_enabled;
+		bool verified;
+		int32_t statuses_count;
+		std::string_view lang;
+		bool contributors_enabled;
+		bool is_translator;
+		bool is_translation_enabled;
+		std::string_view profile_background_color;
+		std::string_view profile_background_image_url;
+		std::string_view profile_background_image_url_https;
+		bool profile_background_tile;
+		std::string_view profile_image_url;
+		std::string_view profile_image_url_https;
+		std::optional<std::string_view> profile_banner_url;
+		std::string_view profile_link_color;
+		std::string_view profile_sidebar_border_color;
+		std::string_view profile_sidebar_fill_color;
+		std::string_view profile_text_color;
+		bool profile_use_background_image;
+		bool default_profile;
+		bool default_profile_image;
+		bool following;
+		bool follow_request_sent;
+		bool notifications;
+	}; // user_t
+
+	struct hashtags_element_t {
+		std::string_view text;
+		std::vector<int32_t> indices;
+	}; // hashtags_element_t
+
+	struct tweet_object_t {
+		metadata_t metadata;
+		twitter_tp created_at;
+		int64_t id;
+		std::string_view id_str;
+		std::string_view text;
+		std::string_view source;
+		bool truncated;
+		std::optional<int64_t> in_reply_to_status_id;
+		std::optional<std::string_view> in_reply_to_status_id_str;
+		std::optional<int64_t> in_reply_to_user_id;
+		std::optional<std::string_view> in_reply_to_user_id_str;
+		std::optional<std::string_view> in_reply_to_screen_name;
+		user_t user;
+		int32_t retweet_count;
+		std::optional<int32_t> favorite_count;
+		entities_t entities;
+		bool favorited;
+		bool retweeted;
+		std::optional<bool> possibly_sensitive;
+		std::string_view lang;
+	}; // statuses_element_t
+
+	struct user_mentions_element_t {
+		std::string_view screen_name;
+		std::string_view name;
+		int64_t id;
+		std::string_view id_str;
+		std::vector<int32_t> indices;
+	}; // user_mentions_element_t
+
+	struct size_item_t {
+		int64_t w;
+		int64_t h;
+		std::string_view resize;
+	}; // size_item_t
+
+	struct sizes_t {
+		size_item_t medium;
+		size_item_t small_;
+		size_item_t thumb;
+		size_item_t large;
+	}; // sizes_t
+
+	struct media_element_t {
+		int64_t id;
+		std::string_view id_str;
+		std::vector<int32_t> indices;
+		std::string_view media_url;
+		std::string_view media_url_https;
+		std::string_view url;
+		std::string_view display_url;
+		std::string_view expanded_url;
+		std::string_view type;
+		sizes_t sizes;
+	}; // media_element_t
+
+	struct retweeted_status_t {
+		metadata_t metadata;
+		twitter_tp created_at;
+		int64_t id;
+		std::string_view id_str;
+		std::string_view text;
+		std::string_view source;
+		bool truncated;
+		std::optional<int64_t> in_reply_to_status_id;
+		std::optional<std::string_view> in_reply_to_status_id_str;
+		std::optional<int64_t> in_reply_to_user_id;
+		std::optional<std::string_view> in_reply_to_user_id_str;
+		std::optional<std::string_view> in_reply_to_screen_name;
+		user_t user;
+		int32_t retweet_count;
+		std::optional<int32_t> favorite_count;
+		entities_t entities;
+		bool favorited;
+		bool retweeted;
+		std::optional<bool> possibly_sensitive;
+		std::string_view lang;
+	}; // retweeted_status_t
+
+	struct search_metadata_t {
+		double completed_in;
+		int64_t max_id;
+		std::string_view max_id_str;
+		std::string_view next_results;
+		std::string_view query;
+		std::string_view refresh_url;
+		int64_t count;
+		int64_t since_id;
+		std::string_view since_id_str;
+	}; // search_metadata_t
+
+	struct twitter_object_t {
+		std::vector<tweet_object_t> statuses;
+		search_metadata_t search_metadata;
+	}; // twitter_object_t
+} // namespace daw::twitter_insitu

--- a/tests/include/twitter_insitu_test_json.h
+++ b/tests/include/twitter_insitu_test_json.h
@@ -1,0 +1,604 @@
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+
+#pragma once
+
+#include "twitter_insitu_test.h"
+
+#include <daw/daw_attributes.h>
+#include <daw/json/daw_json_link_types.h>
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+namespace daw::twitter_insitu {
+	struct TimestampConverter {
+		constexpr twitter_tp operator( )( std::string_view sv ) const {
+			daw_json_ensure(
+			  sv.size( ) >= 26,
+			  daw::json::ErrorReason::InvalidTimestamp ); // Date format is always 26
+
+			// Skip Day of Week
+			sv.remove_prefix( 4 );
+			auto const mo = daw::json::datetime::parse_short_month( sv );
+			sv.remove_prefix( 4 );
+			auto const dy =
+			  daw::json::parse_utils::parse_unsigned<uint_least32_t, 2>( sv.data( ) );
+			sv.remove_prefix( 2U + static_cast<unsigned>( dy > 9 ) );
+			auto const hr =
+			  daw::json::parse_utils::parse_unsigned<uint_least32_t, 2>( sv.data( ) );
+			sv.remove_prefix( 3 );
+			auto const mn =
+			  daw::json::parse_utils::parse_unsigned<uint_least32_t, 2>( sv.data( ) );
+			sv.remove_prefix( 3 );
+			auto const se =
+			  daw::json::parse_utils::parse_unsigned<uint_least32_t, 2>( sv.data( ) );
+			sv.remove_prefix( 3 );
+			auto const sign = sv.front( ) == '+' ? 1 : -1;
+			sv.remove_prefix( 1 );
+			auto const off_hr =
+			  daw::json::parse_utils::parse_unsigned<int_least32_t, 2>( sv.data( ) ) *
+			  sign;
+			sv.remove_prefix( 2 );
+			auto const off_mn =
+			  daw::json::parse_utils::parse_unsigned<int_least32_t, 2>( sv.data( ) ) *
+			  sign;
+			sv.remove_prefix( 3 );
+			daw_json_ensure( not sv.empty( ),
+			                 daw::json::ErrorReason::InvalidTimestamp );
+			int const yr_sign = [&] {
+				if( sv.front( ) == '-' ) {
+					sv.remove_prefix( 1 );
+					return -1;
+				} else if( sv.front( ) == '+' ) {
+					sv.remove_prefix( 1 );
+				}
+				return 1;
+			}( );
+			auto const yr =
+			  yr_sign *
+			  daw::json::parse_utils::parse_unsigned2<int_least32_t>( sv.data( ) );
+
+			daw_json_ensure( mo <= 12 and dy <= 31 and hr <= 24 and mn <= 61 and
+			                   se <= 61,
+			                 daw::json::ErrorReason::InvalidTimestamp );
+			return daw::json::datetime::civil_to_time_point(
+			         yr, mo, dy, hr, mn, se, 0 ) +
+			       std::chrono::hours( off_hr ) + std::chrono::minutes( off_mn );
+		}
+
+		template<typename OutputIterator>
+		constexpr OutputIterator operator( )( OutputIterator it,
+		                                      twitter_tp tp ) const {
+
+			auto const &[yr, mo, dy, hr, mn, se, ms] =
+			  daw::json::datetime::time_point_to_civil( tp );
+			// Day of Week
+			it = daw::json::utils::copy_to_iterator(
+			  it, daw::json::datetime::short_day_of_week( tp ) );
+			*it++ = ' ';
+			// Month
+			it = daw::json::utils::copy_to_iterator(
+			  it, daw::json::datetime::month_short_name( mo ) );
+			*it++ = ' ';
+			it = daw::json::utils::integer_to_string( it, dy );
+			*it++ = ' ';
+			if( hr < 10 ) {
+				*it++ = '0';
+			}
+			it = daw::json::utils::integer_to_string( it, hr );
+			*it++ = ':';
+			if( mn < 10 ) {
+				*it++ = '0';
+			}
+			it = daw::json::utils::integer_to_string( it, mn );
+			*it++ = ':';
+			if( se < 10 ) {
+				*it++ = '0';
+			}
+			it = daw::json::utils::integer_to_string( it, se );
+			it = daw::json::utils::copy_to_iterator( it, " +0000 " );
+			it = daw::json::utils::integer_to_string( it, yr );
+			return it;
+		}
+	};
+} // namespace daw::twitter_insitu
+
+namespace daw::json {
+	template<>
+	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter_insitu::metadata_t> {
+
+		static inline constexpr char result_type[] = "result_type";
+		static inline constexpr char iso_language_code[] = "iso_language_code";
+		using type = json_member_list<json_string_insitu<result_type>,
+		                              json_string_insitu<iso_language_code>>;
+
+		[[nodiscard]] static DAW_JSON_CX_STRING auto
+		to_json_data( daw::twitter_insitu::metadata_t const &value ) {
+			return std::forward_as_tuple( value.result_type,
+			                              value.iso_language_code );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN
+	  json_data_contract<daw::twitter_insitu::urls_element_t> {
+
+		static inline constexpr char url[] = "url";
+		static inline constexpr char expanded_url[] = "expanded_url";
+		static inline constexpr char display_url[] = "display_url";
+		static inline constexpr char indices[] = "indices";
+		using type = json_member_list<
+		  json_string_insitu<url>, json_string_insitu<expanded_url>,
+		  json_string_insitu<display_url>, json_array<indices, int32_t>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::urls_element_t const &value ) {
+			return std::forward_as_tuple(
+			  value.url, value.expanded_url, value.display_url, value.indices );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter_insitu::url_t> {
+
+		static inline constexpr char urls[] = "urls";
+		using type =
+		  json_member_list<json_array<urls, daw::twitter_insitu::urls_element_t>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::url_t const &value ) {
+			return std::forward_as_tuple( value.urls );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter_insitu::entities_t> {
+		using ignore_unknown_members = void;
+
+		static inline constexpr char url[] = "url";
+		static inline constexpr char description[] = "description";
+		using type = json_member_list<
+		  json_class_null<url, std::optional<daw::twitter_insitu::url_t>>,
+		  json_class_null<description, std::optional<daw::twitter_insitu::url_t>>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::entities_t const &value ) {
+			return std::forward_as_tuple( value.url, value.description );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter_insitu::user_t> {
+		using ignore_unknown_members = void;
+
+		static inline constexpr char id[] = "id";
+		static inline constexpr char id_str[] = "id_str";
+		static inline constexpr char name[] = "name";
+		static inline constexpr char screen_name[] = "screen_name";
+		static inline constexpr char location[] = "location";
+		static inline constexpr char description[] = "description";
+		static inline constexpr char url[] = "url";
+		static inline constexpr char entities[] = "entities";
+		static inline constexpr char _jsonprotected[] = "protected";
+		static inline constexpr char followers_count[] = "followers_count";
+		static inline constexpr char friends_count[] = "friends_count";
+		static inline constexpr char listed_count[] = "listed_count";
+		static inline constexpr char created_at[] = "created_at";
+		static inline constexpr char favourites_count[] = "favourites_count";
+		static inline constexpr char geo_enabled[] = "geo_enabled";
+		static inline constexpr char verified[] = "verified";
+		static inline constexpr char statuses_count[] = "statuses_count";
+		static inline constexpr char lang[] = "lang";
+		static inline constexpr char contributors_enabled[] =
+		  "contributors_enabled";
+		static inline constexpr char is_translator[] = "is_translator";
+		static inline constexpr char is_translation_enabled[] =
+		  "is_translation_enabled";
+		static inline constexpr char profile_background_color[] =
+		  "profile_background_color";
+		static inline constexpr char profile_background_image_url[] =
+		  "profile_background_image_url";
+		static inline constexpr char profile_background_image_url_https[] =
+		  "profile_background_image_url_https";
+		static inline constexpr char profile_background_tile[] =
+		  "profile_background_tile";
+		static inline constexpr char profile_image_url[] = "profile_image_url";
+		static inline constexpr char profile_image_url_https[] =
+		  "profile_image_url_https";
+		static inline constexpr char profile_banner_url[] = "profile_banner_url";
+		static inline constexpr char profile_link_color[] = "profile_link_color";
+		static inline constexpr char profile_sidebar_border_color[] =
+		  "profile_sidebar_border_color";
+		static inline constexpr char profile_sidebar_fill_color[] =
+		  "profile_sidebar_fill_color";
+		static inline constexpr char profile_text_color[] = "profile_text_color";
+		static inline constexpr char profile_use_background_image[] =
+		  "profile_use_background_image";
+		static inline constexpr char default_profile[] = "default_profile";
+		static inline constexpr char default_profile_image[] =
+		  "default_profile_image";
+		static inline constexpr char following[] = "following";
+		static inline constexpr char follow_request_sent[] = "follow_request_sent";
+		static inline constexpr char notifications[] = "notifications";
+		using type = json_member_list<
+		  json_number<id, int64_t>, json_string_insitu<id_str>,
+		  json_string_insitu<name>, json_string_insitu<screen_name>,
+		  json_string_insitu<location>, json_string_insitu<description>,
+		  json_string_insitu_null<url>,
+		  json_class<entities, daw::twitter_insitu::entities_t>,
+		  json_bool<_jsonprotected>, json_number<followers_count, int32_t>,
+		  json_number<friends_count, int32_t>, json_number<listed_count, int32_t>,
+		  json_custom<created_at, daw::twitter_insitu::twitter_tp,
+		              daw::twitter_insitu::TimestampConverter,
+		              daw::twitter_insitu::TimestampConverter>,
+		  json_number<favourites_count, int32_t>, json_bool<geo_enabled>,
+		  json_bool<verified>, json_number<statuses_count, int32_t>,
+		  json_string_insitu<lang>, json_bool<contributors_enabled>,
+		  json_bool<is_translator>, json_bool<is_translation_enabled>,
+		  json_string_insitu<profile_background_color>,
+		  json_string_insitu<profile_background_image_url>,
+		  json_string_insitu<profile_background_image_url_https>,
+		  json_bool<profile_background_tile>, json_string_insitu<profile_image_url>,
+		  json_string_insitu<profile_image_url_https>,
+		  json_string_insitu_null<profile_banner_url>,
+		  json_string_insitu<profile_link_color>,
+		  json_string_insitu<profile_sidebar_border_color>,
+		  json_string_insitu<profile_sidebar_fill_color>,
+		  json_string_insitu<profile_text_color>,
+		  json_bool<profile_use_background_image>, json_bool<default_profile>,
+		  json_bool<default_profile_image>, json_bool<following>,
+		  json_bool<follow_request_sent>, json_bool<notifications>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::user_t const &value ) {
+			return std::forward_as_tuple( value.id,
+			                              value.id_str,
+			                              value.name,
+			                              value.screen_name,
+			                              value.location,
+			                              value.description,
+			                              value.url,
+			                              value.entities,
+			                              value._jsonprotected,
+			                              value.followers_count,
+			                              value.friends_count,
+			                              value.listed_count,
+			                              value.created_at,
+			                              value.favourites_count,
+			                              value.geo_enabled,
+			                              value.verified,
+			                              value.statuses_count,
+			                              value.lang,
+			                              value.contributors_enabled,
+			                              value.is_translator,
+			                              value.is_translation_enabled,
+			                              value.profile_background_color,
+			                              value.profile_background_image_url,
+			                              value.profile_background_image_url_https,
+			                              value.profile_background_tile,
+			                              value.profile_image_url,
+			                              value.profile_image_url_https,
+			                              value.profile_banner_url,
+			                              value.profile_link_color,
+			                              value.profile_sidebar_border_color,
+			                              value.profile_sidebar_fill_color,
+			                              value.profile_text_color,
+			                              value.profile_use_background_image,
+			                              value.default_profile,
+			                              value.default_profile_image,
+			                              value.following,
+			                              value.follow_request_sent,
+			                              value.notifications );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN
+	  json_data_contract<daw::twitter_insitu::hashtags_element_t> {
+
+		static inline constexpr char text[] = "text";
+		static inline constexpr char indices[] = "indices";
+		using type =
+		  json_member_list<json_string_insitu<text>, json_array<indices, int32_t>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::hashtags_element_t const &value ) {
+			return std::forward_as_tuple( value.text, value.indices );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN
+	  json_data_contract<daw::twitter_insitu::tweet_object_t> {
+		using ignore_unknown_members = void;
+
+		static inline constexpr char metadata[] = "metadata";
+		static inline constexpr char created_at[] = "created_at";
+		static inline constexpr char id[] = "id";
+		static inline constexpr char id_str[] = "id_str";
+		static inline constexpr char text[] = "text";
+		static inline constexpr char source[] = "source";
+		static inline constexpr char truncated[] = "truncated";
+		static inline constexpr char in_reply_to_status_id[] =
+		  "in_reply_to_status_id";
+		static inline constexpr char in_reply_to_status_id_str[] =
+		  "in_reply_to_status_id_str";
+		static inline constexpr char in_reply_to_user_id[] = "in_reply_to_user_id";
+		static inline constexpr char in_reply_to_user_id_str[] =
+		  "in_reply_to_user_id_str";
+		static inline constexpr char in_reply_to_screen_name[] =
+		  "in_reply_to_screen_name";
+		static inline constexpr char user[] = "user";
+		static inline constexpr char retweet_count[] = "retweet_count";
+		static inline constexpr char favorite_count[] = "favorite_count";
+		static inline constexpr char entities[] = "entities";
+		static inline constexpr char favorited[] = "favorited";
+		static inline constexpr char retweeted[] = "retweeted";
+		static inline constexpr char possibly_sensitive[] = "possibly_sensitive";
+		static inline constexpr char lang[] = "lang";
+		using type = json_member_list<
+		  json_class<metadata, daw::twitter_insitu::metadata_t>,
+		  json_custom<created_at, daw::twitter_insitu::twitter_tp,
+		              daw::twitter_insitu::TimestampConverter,
+		              daw::twitter_insitu::TimestampConverter>,
+		  json_number<id, int64_t>, json_string_insitu<id_str>,
+		  json_string_insitu<text>, json_string_insitu<source>,
+		  json_bool<truncated>,
+		  json_number_null<in_reply_to_status_id, std::optional<int64_t>>,
+		  json_string_insitu_null<in_reply_to_status_id_str>,
+		  json_number_null<in_reply_to_user_id, std::optional<int64_t>>,
+		  json_string_insitu_null<in_reply_to_user_id_str>,
+		  json_string_insitu_null<in_reply_to_screen_name>,
+		  json_class<user, daw::twitter_insitu::user_t>,
+		  json_number<retweet_count, int32_t>,
+		  json_number_null<favorite_count, std::optional<int32_t>>,
+		  json_class<entities, daw::twitter_insitu::entities_t>,
+		  json_bool<favorited>, json_bool<retweeted>,
+		  json_bool_null<possibly_sensitive>, json_string_insitu<lang>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::tweet_object_t const &value ) {
+			return std::forward_as_tuple( value.metadata,
+			                              value.created_at,
+			                              value.id,
+			                              value.id_str,
+			                              value.text,
+			                              value.source,
+			                              value.truncated,
+			                              value.in_reply_to_status_id,
+			                              value.in_reply_to_status_id_str,
+			                              value.in_reply_to_user_id,
+			                              value.in_reply_to_user_id_str,
+			                              value.in_reply_to_screen_name,
+			                              value.user,
+			                              value.retweet_count,
+			                              value.favorite_count,
+			                              value.entities,
+			                              value.favorited,
+			                              value.retweeted,
+			                              value.possibly_sensitive,
+			                              value.lang );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN
+	  json_data_contract<daw::twitter_insitu::user_mentions_element_t> {
+		static inline constexpr char screen_name[] = "screen_name";
+		static inline constexpr char name[] = "name";
+		static inline constexpr char id[] = "id";
+		static inline constexpr char id_str[] = "id_str";
+		static inline constexpr char indices[] = "indices";
+		using type =
+		  json_member_list<json_string_insitu<screen_name>,
+		                   json_string_insitu<name>, json_number<id, int64_t>,
+		                   json_string_insitu<id_str>,
+		                   json_array<indices, int64_t>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::user_mentions_element_t const &value ) {
+			return std::forward_as_tuple(
+			  value.screen_name, value.name, value.id, value.id_str, value.indices );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN
+	  json_data_contract<daw::twitter_insitu::size_item_t> {
+		static inline constexpr char w[] = "w";
+		static inline constexpr char h[] = "h";
+		static inline constexpr char resize[] = "resize";
+		using type =
+		  json_member_list<json_number<w, int64_t>, json_number<h, int64_t>,
+		                   json_string_insitu<resize>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::size_item_t const &value ) {
+			return std::forward_as_tuple( value.w, value.h, value.resize );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN json_data_contract<daw::twitter_insitu::sizes_t> {
+		static inline constexpr char medium[] = "medium";
+		static inline constexpr char small_[] = "small";
+		static inline constexpr char thumb[] = "thumb";
+		static inline constexpr char large[] = "large";
+		using type =
+		  json_member_list<json_class<medium, daw::twitter_insitu::size_item_t>,
+		                   json_class<small_, daw::twitter_insitu::size_item_t>,
+		                   json_class<thumb, daw::twitter_insitu::size_item_t>,
+		                   json_class<large, daw::twitter_insitu::size_item_t>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::sizes_t const &value ) {
+			return std::forward_as_tuple(
+			  value.medium, value.small_, value.thumb, value.large );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN
+	  json_data_contract<daw::twitter_insitu::media_element_t> {
+
+		static inline constexpr char id[] = "id";
+		static inline constexpr char id_str[] = "id_str";
+		static inline constexpr char indices[] = "indices";
+		static inline constexpr char media_url[] = "media_url";
+		static inline constexpr char media_url_https[] = "media_url_https";
+		static inline constexpr char url[] = "url";
+		static inline constexpr char display_url[] = "display_url";
+		static inline constexpr char expanded_url[] = "expanded_url";
+		static inline constexpr char _jsontype[] = "type";
+		static inline constexpr char sizes[] = "sizes";
+		using type = json_member_list<
+		  json_number<id, int64_t>, json_string_insitu<id_str>,
+		  json_array<indices, int64_t>, json_string_insitu<media_url>,
+		  json_string_insitu<media_url_https>, json_string_insitu<url>,
+		  json_string_insitu<display_url>, json_string_insitu<expanded_url>,
+		  json_string_insitu<_jsontype>,
+		  json_class<sizes, daw::twitter_insitu::sizes_t>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::media_element_t const &value ) {
+			return std::forward_as_tuple( value.id,
+			                              value.id_str,
+			                              value.indices,
+			                              value.media_url,
+			                              value.media_url_https,
+			                              value.url,
+			                              value.display_url,
+			                              value.expanded_url,
+			                              value.type,
+			                              value.sizes );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN
+	  json_data_contract<daw::twitter_insitu::retweeted_status_t> {
+		static inline constexpr char metadata[] = "metadata";
+		static inline constexpr char created_at[] = "created_at";
+		static inline constexpr char id[] = "id";
+		static inline constexpr char id_str[] = "id_str";
+		static inline constexpr char text[] = "text";
+		static inline constexpr char source[] = "source";
+		static inline constexpr char truncated[] = "truncated";
+		static inline constexpr char in_reply_to_status_id[] =
+		  "in_reply_to_status_id";
+		static inline constexpr char in_reply_to_status_id_str[] =
+		  "in_reply_to_status_id_str";
+		static inline constexpr char in_reply_to_user_id[] = "in_reply_to_user_id";
+		static inline constexpr char in_reply_to_user_id_str[] =
+		  "in_reply_to_user_id_str";
+		static inline constexpr char in_reply_to_screen_name[] =
+		  "in_reply_to_screen_name";
+		static inline constexpr char user[] = "user";
+		static inline constexpr char retweet_count[] = "retweet_count";
+		static inline constexpr char favorite_count[] = "favorite_count";
+		static inline constexpr char entities[] = "entities";
+		static inline constexpr char favorited[] = "favorited";
+		static inline constexpr char retweeted[] = "retweeted";
+		static inline constexpr char possibly_sensitive[] = "possibly_sensitive";
+		static inline constexpr char lang[] = "lang";
+		using type = json_member_list<
+		  json_class<metadata, daw::twitter_insitu::metadata_t>,
+		  json_custom<created_at, daw::twitter_insitu::twitter_tp,
+		              daw::twitter_insitu::TimestampConverter,
+		              daw::twitter_insitu::TimestampConverter>,
+		  json_number<id, int64_t>, json_string_insitu<id_str>,
+		  json_string_insitu<text>, json_string_insitu<source>,
+		  json_bool<truncated>,
+		  json_number_null<in_reply_to_status_id, std::optional<int64_t>>,
+		  json_string_insitu_null<in_reply_to_status_id_str>,
+		  json_number_null<in_reply_to_user_id, std::optional<int64_t>>,
+		  json_string_insitu_null<in_reply_to_user_id_str>,
+		  json_string_insitu_null<in_reply_to_screen_name>,
+		  json_class<user, daw::twitter_insitu::user_t>,
+		  json_number<retweet_count, int32_t>,
+		  json_number_null<favorite_count, std::optional<int32_t>>,
+		  json_class<entities, daw::twitter_insitu::entities_t>,
+		  json_bool<favorited>, json_bool<retweeted>,
+		  json_bool_null<possibly_sensitive>, json_string_insitu<lang>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::retweeted_status_t const &value ) {
+			return std::forward_as_tuple( value.metadata,
+			                              value.created_at,
+			                              value.id,
+			                              value.id_str,
+			                              value.text,
+			                              value.source,
+			                              value.truncated,
+			                              value.in_reply_to_status_id,
+			                              value.in_reply_to_status_id_str,
+			                              value.in_reply_to_user_id,
+			                              value.in_reply_to_user_id_str,
+			                              value.in_reply_to_screen_name,
+			                              value.user,
+			                              value.retweet_count,
+			                              value.favorite_count,
+			                              value.entities,
+			                              value.favorited,
+			                              value.retweeted,
+			                              value.possibly_sensitive,
+			                              value.lang );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN
+	  json_data_contract<daw::twitter_insitu::search_metadata_t> {
+		static inline constexpr char completed_in[] = "completed_in";
+		static inline constexpr char max_id[] = "max_id";
+		static inline constexpr char max_id_str[] = "max_id_str";
+		static inline constexpr char next_results[] = "next_results";
+		static inline constexpr char query[] = "query";
+		static inline constexpr char refresh_url[] = "refresh_url";
+		static inline constexpr char count[] = "count";
+		static inline constexpr char since_id[] = "since_id";
+		static inline constexpr char since_id_str[] = "since_id_str";
+		using type = json_member_list<
+		  json_number<completed_in>, json_number<max_id, int64_t>,
+		  json_string_insitu<max_id_str>, json_string_insitu<next_results>,
+		  json_string_insitu<query>, json_string_insitu<refresh_url>,
+		  json_number<count, int64_t>, json_number<since_id, int64_t>,
+		  json_string_insitu<since_id_str>>;
+
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::search_metadata_t const &value ) {
+			return std::forward_as_tuple( value.completed_in,
+			                              value.max_id,
+			                              value.max_id_str,
+			                              value.next_results,
+			                              value.query,
+			                              value.refresh_url,
+			                              value.count,
+			                              value.since_id,
+			                              value.since_id_str );
+		}
+	};
+
+	template<>
+	struct DAW_ATTRIB_HIDDEN
+	  json_data_contract<daw::twitter_insitu::twitter_object_t> {
+		static inline constexpr char statuses[] = "statuses";
+		static inline constexpr char search_metadata[] = "search_metadata";
+		using type = json_member_list<
+		  json_array<statuses, daw::twitter_insitu::tweet_object_t>,
+		  json_class<search_metadata, daw::twitter_insitu::search_metadata_t>>;
+		[[nodiscard]] static inline DAW_JSON_CX_STRVEC auto
+		to_json_data( daw::twitter_insitu::twitter_object_t const &value ) {
+			return std::forward_as_tuple( value.statuses, value.search_metadata );
+		}
+	};
+} // namespace daw::json

--- a/tests/src/cookbook_output_flags1_test.cpp
+++ b/tests/src/cookbook_output_flags1_test.cpp
@@ -42,7 +42,7 @@ int main( ) {
 	auto v2_json = daw::json::to_json(
 	  v2,
 	  output_flags<SerializationFormat::Pretty,
-	               RestrictedStringOutput::OnlyAllow7bitsStrings> );
+	               RestrictedStringOutput::OnlyAllow7bitStrings> );
 	puts( v2_json.c_str( ) );
 	auto v2_2 = daw::json::from_json<OutputFlags1>( v2_json );
 	puts( daw::json::to_json( v2_2 ).c_str( ) );

--- a/tests/src/custom_types_string_literal_test.cpp
+++ b/tests/src/custom_types_string_literal_test.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+//  Covers options::JsonCustomTypes::String (the json_custom default) and
+//  ::Literal, mirroring the examples in docs/cookbook/custom_types.md.  Only
+//  ::Any had a test (custom_optional_number_test.cpp) prior to this.
+//
+
+#include <daw/json/daw_json_link.h>
+
+#include <daw/daw_ensure.h>
+
+#include <string>
+#include <string_view>
+
+struct Identifier {
+	int value;
+};
+
+struct IdentifierFromJson {
+	Identifier operator( )( std::string_view sv ) const {
+		return Identifier{ std::stoi( std::string( sv ) ) };
+	}
+};
+
+struct IdentifierToJson {
+	std::string operator( )( Identifier const &id ) const {
+		return std::to_string( id.value );
+	}
+};
+
+int main( ) {
+	using namespace daw::json;
+
+	// JsonCustomTypes::String (the default): the member is a JSON string, and
+	// the converter sees/produces the contents without quotes.
+	{
+		using identifier_json =
+		  json_custom_no_name<Identifier, IdentifierFromJson, IdentifierToJson>;
+		auto const id = from_json<identifier_json>( R"("42")" );
+		daw_ensure( id.value == 42 );
+		daw_ensure( to_json<identifier_json>( id ) == R"("42")" );
+	}
+	// Same, with the option spelled out explicitly.
+	{
+		using identifier_json = json_custom_no_name<
+		  Identifier, IdentifierFromJson, IdentifierToJson,
+		  options::json_custom_opt( options::JsonCustomTypes::String )>;
+		auto const id = from_json<identifier_json>( R"("42")" );
+		daw_ensure( id.value == 42 );
+		daw_ensure( to_json<identifier_json>( id ) == R"("42")" );
+	}
+
+	// JsonCustomTypes::Literal: the member is an unquoted JSON literal
+	// (number/bool/null), and the converter sees/produces it without quotes.
+	{
+		using identifier_literal_json =
+		  json_custom_lit_no_name<Identifier, IdentifierFromJson, IdentifierToJson>;
+		auto const id = from_json<identifier_literal_json>( "42" );
+		daw_ensure( id.value == 42 );
+		daw_ensure( to_json<identifier_literal_json>( id ) == "42" );
+	}
+	// Same, with the option spelled out explicitly.
+	{
+		using identifier_literal_json = json_custom_no_name<
+		  Identifier, IdentifierFromJson, IdentifierToJson,
+		  options::json_custom_opt( options::JsonCustomTypes::Literal )>;
+		auto const id = from_json<identifier_literal_json>( "42" );
+		daw_ensure( id.value == 42 );
+		daw_ensure( to_json<identifier_literal_json>( id ) == "42" );
+	}
+}

--- a/tests/src/daw_json_link_test.cpp
+++ b/tests/src/daw_json_link_test.cpp
@@ -1028,10 +1028,218 @@ namespace daw::json {
 	};
 } // namespace daw::json
 
+namespace iterator_regression_tests {
+	using namespace daw::json;
+	using iterator = json_array_iterator<int, options::CheckedParseMode::yes>;
+	using once_iterator =
+	  json_array_iterator_once<int, options::CheckedParseMode::yes>;
+
+	template<typename Iterator, typename Check>
+	void test_equality( Check const &check ) {
+		Iterator const end{ };
+		Iterator const other_end{ };
+		Iterator const live( "[1]" );
+		auto const copy = live;
+		check( end == other_end, "expected end == end to be true" );
+		check( not( end != other_end ), "expected end != end to be false" );
+		check( not( end == live ) and not( live == end ),
+		       "expected end == live and live == end to both be false" );
+		check( end != live and live != end,
+		       "expected end != live and live != end to both be true" );
+		check( live == copy and not( live != copy ),
+		       "expected a live iterator and its copy to compare equal" );
+	}
+
+	template<typename Range, typename Check>
+	void test_ranges( Check const &check ) {
+		check( Range{ }.empty( ), "expected a default range to report empty()" );
+		struct test_case {
+			char const *document;
+			unsigned count;
+		};
+		for( auto const [doc, expected] : { test_case{ "[]", 0 },
+		                                    test_case{ "[ ]", 0 },
+		                                    test_case{ "[1]", 1 },
+		                                    test_case{ "[1 ]", 1 },
+		                                    test_case{ "[1,2]", 2 },
+		                                    test_case{ " [1, 2] ", 2 },
+		                                    test_case{ "[1,]", 1 },
+		                                    test_case{ "[1, ]", 1 } } ) {
+#if defined( DAW_USE_EXCEPTIONS )
+			try {
+#endif
+				Range const range( doc );
+				check( range.empty( ) == ( expected == 0 ),
+				       expected == 0 ? "expected empty() to return true"
+				                     : "expected empty() to return false",
+				       doc );
+				unsigned count = 0;
+				for( int value : range ) {
+					++count;
+					check( value == static_cast<int>( count ),
+					       "expected values 1, 2 in array order",
+					       doc );
+					// Bound the loop so broken sentinel comparisons cannot hang.
+					if( count > expected ) {
+						break;
+					}
+				}
+				check( count == expected,
+				       expected == 0   ? "expected zero loop iterations"
+				       : expected == 1 ? "expected exactly one loop iteration"
+				                       : "expected exactly two loop iterations",
+				       doc );
+#if defined( DAW_USE_EXCEPTIONS )
+			} catch( json_exception const &ex ) {
+				(void)ex;
+				check( false,
+				       "expected valid array iteration to finish without throwing",
+				       doc );
+			}
+#endif
+		}
+	}
+
+#if defined( DAW_USE_EXCEPTIONS )
+	template<typename Iterator, typename Check>
+	void test_invalid( daw::string_view doc, bool dereference,
+	                   Check const &check ) {
+		bool rejected = false;
+		try {
+			auto it = Iterator( doc );
+			for( unsigned count = 0; it and count < 8; ++count ) {
+				if( dereference ) {
+					(void)*it;
+				}
+				++it;
+			}
+		} catch( json_exception const &ex ) {
+			(void)ex;
+			rejected = true;
+		}
+		check( rejected,
+		       "expected json_exception for a missing closing bracket or separator",
+		       doc );
+	}
+#endif
+
+	void test( ) {
+		unsigned failures = 0;
+		char const *context = "regular equality";
+		char const *iterator_type =
+		  "json_array_iterator<int, CheckedParseMode::yes>";
+		auto const check = [&]( bool success,
+		                        daw::string_view description,
+		                        daw::string_view doc = { } ) {
+			if( not success ) {
+				++failures;
+				std::cerr << "Iterator regression (" << context << ", " << iterator_type
+				          << "): " << description;
+				if( not doc.empty( ) ) {
+					std::cerr << "; input: `" << doc << '`';
+				}
+				std::cerr << '\n';
+			}
+		};
+		test_equality<iterator>( check );
+		context = "once equality";
+		iterator_type =
+		  "json_array_iterator_once<int, CheckedParseMode::yes>";
+		test_equality<once_iterator>( check );
+		context = "regular range";
+		iterator_type =
+		  "json_array_iterator<int, CheckedParseMode::yes>";
+		test_ranges<json_array_range<int, options::CheckedParseMode::yes>>( check );
+		context = "once range";
+		iterator_type =
+		  "json_array_iterator_once<int, CheckedParseMode::yes>";
+		test_ranges<json_array_range_once<int, options::CheckedParseMode::yes>>(
+		  check );
+		context = "conformance regular range";
+		iterator_type =
+		  "json_array_iterator<int, CheckedParseMode::yes, DAW_JSON_CONFORMANCE_FLAGS>";
+		test_ranges<json_array_range<int,
+		                             options::CheckedParseMode::yes,
+		                             DAW_JSON_CONFORMANCE_FLAGS>>( check );
+		context = "conformance once range";
+		iterator_type =
+		  "json_array_iterator_once<int, CheckedParseMode::yes, DAW_JSON_CONFORMANCE_FLAGS>";
+		test_ranges<json_array_range_once<int,
+		                                  options::CheckedParseMode::yes,
+		                                  DAW_JSON_CONFORMANCE_FLAGS>>( check );
+
+		context = "repeat dereference and copy";
+		iterator_type =
+		  "json_array_iterator<int, CheckedParseMode::yes>";
+		auto it = iterator( "[1,2]" );
+		check( *it == 1 and *it == 1,
+		       "expected two reads at the first position to both return 1" );
+		auto copy = it;
+		++it;
+		check( *it == 2 and *copy == 1,
+		       "expected the advanced iterator to return 2 and its unadvanced copy "
+		       "to return 1" );
+		++copy;
+		check(
+		  copy == it and *copy == 2,
+		  "expected advancing the copy to reach the same position and return 2" );
+		++it;
+		++copy;
+		check(
+		  it == iterator{ } and copy == it,
+		  "expected both exhausted copies to compare equal to the end iterator" );
+
+#if defined( DAW_USE_EXCEPTIONS )
+		for( bool dereference : { false, true } ) {
+			context = dereference ? "regular parse then advance" : "regular skip";
+			iterator_type = "json_array_iterator<int, CheckedParseMode::yes>";
+			for( auto doc : { "[", "[ ", "[1", "[1,", "[1,2", "[1 2]" } ) {
+				test_invalid<iterator>( doc, dereference, check );
+			}
+			iterator_type = "json_array_iterator<std::string, CheckedParseMode::yes>";
+			test_invalid<
+			  json_array_iterator<std::string, options::CheckedParseMode::yes>>(
+			  R"(["a" "b"])", dereference, check );
+			iterator_type = "json_array_iterator<NumberX, CheckedParseMode::yes>";
+			test_invalid<
+			  json_array_iterator<NumberX, options::CheckedParseMode::yes>>(
+			  R"([{"x":1} {"x":2}])", dereference, check );
+		}
+		// Exercise completion separately from the once iterator's comparisons.
+		context = "once final increment";
+		iterator_type =
+		  "json_array_iterator_once<int, CheckedParseMode::yes>";
+		for( auto doc : { "[1]", "[1 ]", "[1,]", "[1, ]" } ) {
+			try {
+				auto last = once_iterator( doc );
+				check( *last == 1, "expected dereference to return 1", doc );
+				++last;
+				check(
+				  not last, "expected iterator to be exhausted after final ++", doc );
+			} catch( json_exception const & ) {
+				check( false,
+				       "expected dereference followed by final ++ to complete without "
+				       "throwing",
+				       doc );
+			}
+		}
+		context = "once malformed input";
+		iterator_type =
+		  "json_array_iterator_once<int, CheckedParseMode::yes>";
+		for( auto doc : { "[", "[ ", "[1", "[1,", "[1,2", "[1 2]" } ) {
+			test_invalid<once_iterator>( doc, true, check );
+		}
+
+#endif
+		daw_ensure( failures == 0 );
+	}
+} // namespace iterator_regression_tests
+
 int main( ) {
 #if defined( DAW_USE_EXCEPTIONS )
 	try {
 #endif
+		iterator_regression_tests::test( );
 		test_deduced_empty_class( );
 		constexpr daw::string_view foo2_json =
 		  R"json( { "m1": {}, "m2": 42  } )json";

--- a/tests/src/daw_json_link_test.cpp
+++ b/tests/src/daw_json_link_test.cpp
@@ -1143,34 +1143,32 @@ namespace iterator_regression_tests {
 		};
 		test_equality<iterator>( check );
 		context = "once equality";
-		iterator_type =
-		  "json_array_iterator_once<int, CheckedParseMode::yes>";
+		iterator_type = "json_array_iterator_once<int, CheckedParseMode::yes>";
 		test_equality<once_iterator>( check );
 		context = "regular range";
-		iterator_type =
-		  "json_array_iterator<int, CheckedParseMode::yes>";
+		iterator_type = "json_array_iterator<int, CheckedParseMode::yes>";
 		test_ranges<json_array_range<int, options::CheckedParseMode::yes>>( check );
 		context = "once range";
-		iterator_type =
-		  "json_array_iterator_once<int, CheckedParseMode::yes>";
+		iterator_type = "json_array_iterator_once<int, CheckedParseMode::yes>";
 		test_ranges<json_array_range_once<int, options::CheckedParseMode::yes>>(
 		  check );
 		context = "conformance regular range";
 		iterator_type =
-		  "json_array_iterator<int, CheckedParseMode::yes, DAW_JSON_CONFORMANCE_FLAGS>";
+		  "json_array_iterator<int, CheckedParseMode::yes, "
+		  "DAW_JSON_CONFORMANCE_FLAGS>";
 		test_ranges<json_array_range<int,
 		                             options::CheckedParseMode::yes,
 		                             DAW_JSON_CONFORMANCE_FLAGS>>( check );
 		context = "conformance once range";
 		iterator_type =
-		  "json_array_iterator_once<int, CheckedParseMode::yes, DAW_JSON_CONFORMANCE_FLAGS>";
+		  "json_array_iterator_once<int, CheckedParseMode::yes, "
+		  "DAW_JSON_CONFORMANCE_FLAGS>";
 		test_ranges<json_array_range_once<int,
 		                                  options::CheckedParseMode::yes,
 		                                  DAW_JSON_CONFORMANCE_FLAGS>>( check );
 
 		context = "repeat dereference and copy";
-		iterator_type =
-		  "json_array_iterator<int, CheckedParseMode::yes>";
+		iterator_type = "json_array_iterator<int, CheckedParseMode::yes>";
 		auto it = iterator( "[1,2]" );
 		check( *it == 1 and *it == 1,
 		       "expected two reads at the first position to both return 1" );
@@ -1207,8 +1205,7 @@ namespace iterator_regression_tests {
 		}
 		// Exercise completion separately from the once iterator's comparisons.
 		context = "once final increment";
-		iterator_type =
-		  "json_array_iterator_once<int, CheckedParseMode::yes>";
+		iterator_type = "json_array_iterator_once<int, CheckedParseMode::yes>";
 		for( auto doc : { "[1]", "[1 ]", "[1,]", "[1, ]" } ) {
 			try {
 				auto last = once_iterator( doc );
@@ -1224,8 +1221,7 @@ namespace iterator_regression_tests {
 			}
 		}
 		context = "once malformed input";
-		iterator_type =
-		  "json_array_iterator_once<int, CheckedParseMode::yes>";
+		iterator_type = "json_array_iterator_once<int, CheckedParseMode::yes>";
 		for( auto doc : { "[", "[ ", "[1", "[1,", "[1,2", "[1 2]" } ) {
 			test_invalid<once_iterator>( doc, true, check );
 		}
@@ -1595,8 +1591,7 @@ int main( ) {
 #if defined( LDBL_MAX )
 		if constexpr( sizeof( double ) < sizeof( long double ) ) {
 			std::cout << "long double test\n";
-			std::cout << std::setprecision(
-			               std::numeric_limits<long double>::max_digits10 )
+			std::cout << std::setprecision( daw::max_digits10<long double> )
 			          << from_json<long double>(
 			               "11111111111111111111111111111111111111111111"
 			               "11111111111111111111111111111111111111111111"

--- a/tests/src/daw_json_link_test.cpp
+++ b/tests/src/daw_json_link_test.cpp
@@ -329,7 +329,7 @@ DAW_CONSTEXPR char const json_data_array[] =
 			"s": "yo yo yo",
 			"s2": "ho ho ho",
 			"o": 1344,
-			"dte": "2019-11-31T01:02:03.343Z"
+			"dte": "2019-11-30T01:02:03.343Z"
 	  },{
 	    "i": 55,
 	    "d": 2.2,
@@ -341,7 +341,7 @@ DAW_CONSTEXPR char const json_data_array[] =
 			"s": "yo yo yo",
 			"s2": "ho ho ho",
 			"o": 1322,
-			"dte": "2010-06-31T01:02:03.343Z"
+			"dte": "2010-06-30T01:02:03.343Z"
 	  }])";
 
 struct EmptyClassTest {
@@ -1307,6 +1307,18 @@ int main( ) {
 			daw::do_not_optimize( data2 );
 		}
 		to_json( data, std::cout ) << '\n';
+#if defined( DAW_USE_EXCEPTIONS )
+		auto const ensure_invalid_date = []( std::string_view timestamp ) {
+			bool threw = false;
+			try {
+				(void)from_json<json_date_no_name<std::chrono::system_clock::time_point>>(
+				  timestamp );
+			} catch( json_exception const & ) { threw = true; }
+			daw_ensure( threw );
+		};
+		ensure_invalid_date( R"("2019-11-31T01:02:03.343Z")" );
+		ensure_invalid_date( R"("2010-06-31T01:02:03.343Z")" );
+#endif
 		CX auto ary =
 		  from_json_array<test_001_t, daw::bounded_vector_t<test_001_t, 10>>(
 		    json_data_array );

--- a/tests/src/daw_json_writer_mapping_test.cpp
+++ b/tests/src/daw_json_writer_mapping_test.cpp
@@ -230,6 +230,17 @@ int main( ) {
 #if defined( DAW_JSON_HAS_REFLECTION )
 	ensure_write_value<json_reflected_class_no_name<ReflectedObject>>(
 	  ReflectedObject{ 7, true }, R"({"number":7,"flag":true})" );
+	// The explicit json_reflected_class(_no_name) mapping is otherwise only
+	// exercised for serialization above; confirm its parse path too, rather
+	// than relying solely on the automatic reflection-fallback deduction path
+	// exercised elsewhere (daw_json_link_reflection_test.cpp).
+	{
+		auto const parsed = daw::json::from_json<
+		  json_reflected_class_no_name<ReflectedObject>>(
+		  R"({"number":7,"flag":true})" );
+		daw_ensure( parsed.number == 7 );
+		daw_ensure( parsed.flag );
+	}
 #endif
 
 	using decimal_number =

--- a/tests/src/daw_json_writer_test.cpp
+++ b/tests/src/daw_json_writer_test.cpp
@@ -123,6 +123,19 @@ int main( ) {
 		}
 		daw_ensure( out == R"json([])json" );
 	}
+	{
+		auto out = std::string{ };
+		{
+			auto w = daw::json::json_writer<
+			  daw::json::options::OutputTrailingComma::Yes>( out );
+			w.open_object( );
+			w.add_key( "a" );
+			w.open_array( );
+			w.write_value( 1 );
+			w.close_array( );
+		}
+		daw_ensure( out == R"json({"a":[1,],})json" );
+	}
 
 	{
 		auto out = std::string{ };

--- a/tests/src/daw_json_writer_test.cpp
+++ b/tests/src/daw_json_writer_test.cpp
@@ -230,6 +230,30 @@ int main( ) {
 		daw_ensure( out == R"json({"a":{"a":42,"b":"Hello","c":[1,2,3]}})json" );
 	}
 	{
+		// A nested class value written via write_key_value must continue the
+		// writer's current indentation depth in Pretty output, rather than
+		// restarting its own members at the top-level indent.
+		auto out = std::string{ };
+		{
+			auto w =
+			  daw::json::json_writer<daw::json::options::SerializationFormat::Pretty>(
+			    out );
+			w.open_object( );
+			w.write_key_value( "a", 1 );
+			w.write_key_value( "foo", Foo{ 2, "x", { 3 } } );
+		}
+		daw_ensure( out == R"json({
+  "a": 1,
+  "foo": {
+    "a": 2,
+    "b": "x",
+    "c": [
+      3
+    ]
+  }
+})json" );
+	}
+	{
 		auto out = std::string{ };
 		{
 			auto w = daw::json::json_writer( out );

--- a/tests/src/int_array_test.cpp
+++ b/tests/src/int_array_test.cpp
@@ -11,6 +11,7 @@
 #include "daw/json/daw_json_iterator.h"
 #include "daw/json/daw_json_link.h"
 
+#include <daw/daw_arith_traits.h>
 #include <daw/daw_benchmark.h>
 #include <daw/daw_bounded_vector.h>
 #include <daw/daw_do_n.h>
@@ -54,8 +55,8 @@ static std::vector<T> const &make_int_array( ) {
 		auto result = std::vector<T>( );
 		result.reserve( N );
 		for( size_t n = 0; n < N; ++n ) {
-			result.push_back( daw::randint<T>( daw::numeric_limits<T>::min( ),
-			                                   daw::numeric_limits<T>::max( ) ) );
+			result.push_back(
+			  daw::randint<T>( daw::lowest_value<T>, daw::max_value<T> ) );
 		}
 		return result;
 	}( );
@@ -68,10 +69,9 @@ static std::string_view make_int_array_data( ) {
 		std::string result = "[";
 		result.reserve( N * 23 + 8 );
 		for( size_t n = 0; n < N; ++n ) {
-			result +=
-			  std::to_string( daw::randint<T>( daw::numeric_limits<T>::min( ),
-			                                   daw::numeric_limits<T>::max( ) ) ) +
-			  ',';
+			result += std::to_string(
+			            daw::randint<T>( daw::lowest_value<T>, daw::max_value<T> ) ) +
+			          ',';
 		}
 		result.back( ) = ']';
 		// result.shrink_to_fit( );
@@ -96,11 +96,11 @@ void test_func( ) {
 		// allocations
 		result.reserve( NUMVALUES * 23 + 8 );
 		daw::algorithm::do_n( NUMVALUES, [&result] {
-			result += "{\"a\":" +
-			          std::to_string( daw::randint<intmax_t>(
-			            daw::numeric_limits<intmax_t>::min( ),
-			            daw::numeric_limits<intmax_t>::max( ) ) ) +
-			          "},";
+			result +=
+			  "{\"a\":" +
+			  std::to_string( daw::randint<intmax_t>(
+			    daw::lowest_value<std::int64_t>, daw::max_value<std::int64_t> ) ) +
+			  "},";
 		} );
 		result.back( ) = ']';
 		return result;

--- a/tests/src/int_ptr_test.cpp
+++ b/tests/src/int_ptr_test.cpp
@@ -6,6 +6,7 @@
 // Official repository: https://github.com/beached/daw_json_link/
 //
 
+#include <daw/daw_arith_traits.h>
 #include <daw/daw_span.h>
 #include <daw/json/daw_json_link.h>
 
@@ -29,8 +30,7 @@ struct Foo {
 
 template<JSONNAMETYPE, typename T>
 struct ArrayPointerConstructor {
-	inline static thread_local std::size_t size =
-	  std::numeric_limits<std::size_t>::max( );
+	inline static thread_local std::size_t size = daw::max_value<std::size_t>;
 
 	struct SizeCtor {
 		std::size_t operator( )( std::size_t v ) const noexcept {

--- a/tests/src/int_sanity_test.cpp
+++ b/tests/src/int_sanity_test.cpp
@@ -10,6 +10,7 @@
 
 #include "daw/json/daw_json_link.h"
 
+#include <daw/daw_arith_traits.h>
 #include <daw/daw_benchmark.h>
 #include <daw/daw_random.h>
 
@@ -23,8 +24,8 @@ std::vector<T> make_random_data( ) {
 	std::vector<T> result{ };
 	result.reserve( N );
 	for( size_t n = 0; n < N; ++n ) {
-		result.push_back( daw::randint<T>( daw::numeric_limits<T>::min( ),
-		                                   daw::numeric_limits<T>::max( ) ) );
+		result.push_back(
+		  daw::randint<T>( daw::lowest_value<T>, daw::max_value<T> ) );
 	}
 	return result;
 }

--- a/tests/src/json_event_parser_handler_result_test.cpp
+++ b/tests/src/json_event_parser_handler_result_test.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+
+#include <daw/json/daw_json_event_parser.h>
+#include <daw/json/daw_json_link.h>
+
+#include <vector>
+
+namespace {
+	// Returns SkipClassArray on the value `2`: events for the rest of that
+	// array's elements must not fire, but the array's own end event still
+	// must, and parsing must resume normally with the next sibling member.
+	struct SkipArrayHandler {
+		std::vector<double> seen_numbers{};
+		int array_ends = 0;
+		int class_ends = 0;
+
+		daw::json::json_parse_handler_result handle_on_number( double d ) {
+			seen_numbers.push_back( d );
+			if( d == 2.0 ) {
+				return daw::json::json_parse_handler_result::SkipClassArray;
+			}
+			return daw::json::json_parse_handler_result::Continue;
+		}
+		daw::json::json_parse_handler_result handle_on_array_end( ) {
+			++array_ends;
+			return daw::json::json_parse_handler_result::Continue;
+		}
+		daw::json::json_parse_handler_result handle_on_class_end( ) {
+			++class_ends;
+			return daw::json::json_parse_handler_result::Continue;
+		}
+	};
+
+	// Returns SkipClassArray on the first top-level member: the rest of the
+	// root object's own members must be skipped, but its class-end event
+	// still must fire.
+	struct SkipRootHandler {
+		int numbers_seen = 0;
+		int class_ends = 0;
+
+		daw::json::json_parse_handler_result handle_on_number( double ) {
+			++numbers_seen;
+			return daw::json::json_parse_handler_result::SkipClassArray;
+		}
+		daw::json::json_parse_handler_result handle_on_class_end( ) {
+			++class_ends;
+			return daw::json::json_parse_handler_result::Continue;
+		}
+	};
+
+	// Returns Complete at the top level: parsing stops cleanly with no error.
+	struct CompleteAtRootHandler {
+		bool called = false;
+
+		daw::json::json_parse_handler_result handle_on_number( double ) {
+			called = true;
+			return daw::json::json_parse_handler_result::Complete;
+		}
+	};
+
+	// Returns Complete from a number two levels deep, inside an open array
+	// inside the root object: parsing must stop cleanly with no error, even
+	// though the array and the root object are never actually closed.
+	struct CompleteNestedHandler {
+		std::vector<double> seen_numbers{};
+
+		daw::json::json_parse_handler_result handle_on_number( double d ) {
+			seen_numbers.push_back( d );
+			if( d == 5.0 ) {
+				return daw::json::json_parse_handler_result::Complete;
+			}
+			return daw::json::json_parse_handler_result::Continue;
+		}
+	};
+} // namespace
+
+int main( ) {
+	{
+		SkipArrayHandler h;
+		daw::json::json_event_parser( R"({"a":[1,2,3],"b":[4,5,6],"c":7})", h );
+		std::vector<double> const expected{ 1, 2, 4, 5, 6, 7 };
+		daw_ensure( h.seen_numbers == expected );
+		daw_ensure( h.array_ends == 2 );
+		daw_ensure( h.class_ends == 1 );
+	}
+
+	{
+		SkipRootHandler h;
+		daw::json::json_event_parser( R"({"a":1,"b":2,"c":3})", h );
+		daw_ensure( h.numbers_seen == 1 );
+		daw_ensure( h.class_ends == 1 );
+	}
+
+	{
+		CompleteAtRootHandler h;
+		daw::json::json_event_parser( "42", h );
+		daw_ensure( h.called );
+	}
+
+	{
+		CompleteNestedHandler h;
+		daw::json::json_event_parser( R"({"a":[1,2,3],"b":[4,5,6],"c":7})", h );
+		std::vector<double> const expected{ 1, 2, 3, 4, 5 };
+		daw_ensure( h.seen_numbers == expected );
+	}
+}

--- a/tests/src/json_event_parser_max_depth_test.cpp
+++ b/tests/src/json_event_parser_max_depth_test.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+
+#include <daw/json/daw_json_event_parser.h>
+#include <daw/json/daw_json_link.h>
+
+#include <cstddef>
+#include <string>
+
+namespace {
+	struct null_handler {};
+
+	[[nodiscard]] std::string nested_array_doc( std::size_t depth ) {
+		std::string doc;
+		doc.reserve( depth * 2 + 1 );
+		for( std::size_t n = 0; n < depth; ++n ) {
+			doc += '[';
+		}
+		doc += '1';
+		for( std::size_t n = 0; n < depth; ++n ) {
+			doc += ']';
+		}
+		return doc;
+	}
+} // namespace
+
+int main( ) {
+	constexpr std::size_t depth = 50;
+	auto const doc = nested_array_doc( depth );
+
+	// Default MaxDepth is unlimited: deeply nested input parses fine.
+	{
+		null_handler h;
+		daw::json::json_event_parser( doc, h );
+	}
+
+	// A limit below the actual nesting depth throws MaxDepthExceeded.
+	{
+		null_handler h;
+		bool threw_expected_reason = false;
+		try {
+			daw::json::json_event_parser<daw::use_default, 10>( doc, h );
+		} catch( daw::json::json_exception const &e ) {
+			threw_expected_reason =
+			  e.reason_type( ) == daw::json::ErrorReason::MaxDepthExceeded;
+		}
+		daw_ensure( threw_expected_reason );
+	}
+
+	// A limit exactly matching the actual nesting depth still succeeds.
+	{
+		null_handler h;
+		daw::json::json_event_parser<daw::use_default, depth>( doc, h );
+	}
+}

--- a/tests/src/json_event_parser_max_depth_test.cpp
+++ b/tests/src/json_event_parser_max_depth_test.cpp
@@ -9,6 +9,7 @@
 #include <daw/json/daw_json_event_parser.h>
 #include <daw/json/daw_json_link.h>
 
+#if defined( DAW_USE_EXCEPTIONS )
 #include <cstddef>
 #include <string>
 
@@ -58,3 +59,6 @@ int main( ) {
 		daw::json::json_event_parser<daw::use_default, depth>( doc, h );
 	}
 }
+#else
+int main( ) {}
+#endif

--- a/tests/src/json_string_insitu_test.cpp
+++ b/tests/src/json_string_insitu_test.cpp
@@ -1,0 +1,311 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+
+#include "daw/json/daw_json_link.h"
+#include "daw/json/daw_json_link_types.h"
+#include "daw/json/daw_json_schema.h"
+
+#include <daw/daw_ensure.h>
+
+#include <array>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace {
+	using namespace daw::json;
+	using mutable_policy =
+	  BasicParsePolicy<parse_options( options::AllowStringMutation::yes )>;
+	using readonly_policy = BasicParsePolicy<>;
+
+	static_assert( std::is_same_v<mutable_policy::iterator, char *> );
+	static_assert( std::is_same_v<readonly_policy::iterator, char const *> );
+	static_assert( std::is_constructible_v<mutable_policy, char *, char *> );
+	static_assert(
+	  not std::is_constructible_v<mutable_policy, char const *, char const *> );
+	static_assert(
+	  not std::is_constructible_v<mutable_policy, char *, char const *> );
+	static_assert(
+	  not std::is_constructible_v<mutable_policy, char const *, char *> );
+	static_assert( std::is_constructible_v<readonly_policy, char *, char *> );
+	static_assert(
+	  std::is_constructible_v<readonly_policy, char const *, char const *> );
+	static_assert(
+	  std::is_constructible_v<mutable_policy, char *, char *, char *, char *> );
+	static_assert( not std::is_constructible_v<mutable_policy, char *, char *,
+	                                           char const *, char const *> );
+	static_assert( not std::is_constructible_v<mutable_policy, readonly_policy> );
+
+	using allocator = std::allocator<char>;
+	using allocated_policy = mutable_policy::with_allocator_type<allocator>;
+	static_assert(
+	  std::is_constructible_v<allocated_policy, char *, char *, allocator &> );
+	static_assert( not std::is_constructible_v<allocated_policy, char const *,
+	                                           char const *, allocator &> );
+	static_assert( std::is_constructible_v<allocated_policy, char *, char *,
+	                                       char *, char *, allocator const &> );
+	static_assert(
+	  not std::is_constructible_v<allocated_policy, char *, char *, char const *,
+	                              char const *, allocator const &> );
+	static_assert( std::is_constructible_v<mutable_policy, char *, char *, char *,
+	                                       char *, std::size_t> );
+	static_assert(
+	  not std::is_constructible_v<mutable_policy, char const *, char const *,
+	                              char const *, char const *, std::size_t> );
+
+	template<typename String>
+	constexpr bool accepts_mutable_input =
+	  std::is_constructible_v<mutable_policy,
+	                          decltype( std::data( std::declval<String &>( ) ) ),
+	                          decltype( std::data( std::declval<String &>( ) ) )>;
+
+	static_assert( accepts_mutable_input<std::string> );
+	static_assert( accepts_mutable_input<char[8]> );
+	static_assert( accepts_mutable_input<std::array<char, 8>> );
+	static_assert( not accepts_mutable_input<std::string const> );
+	static_assert( not accepts_mutable_input<char const[8]> );
+	static_assert( not accepts_mutable_input<std::array<char, 8> const> );
+	// A non-const view still exposes read-only characters.
+	static_assert( not accepts_mutable_input<std::string_view> );
+	static_assert( not accepts_mutable_input<std::string_view const> );
+
+	constexpr bool policy_mutation_test( ) {
+		char buffer[] = "123";
+		auto state = mutable_policy( buffer, buffer + 3 );
+		auto copy = state.copy( );
+		*copy.begin( ) = '4';
+		return buffer[0] == '4' and state.data( ) == buffer and
+		       state.data_end( ) == buffer + 3;
+	}
+	static_assert( policy_mutation_test( ) );
+} // namespace
+
+namespace {
+	using insitu_string = daw::json::json_string_insitu_no_name<>;
+	constexpr bool decoded_view_test( ) {
+		char buffer[] = R"("hello\nworld")";
+		auto value = daw::json::from_json_insitu<insitu_string>( buffer );
+		return value == "hello\nworld" and value.data( ) == buffer + 1;
+	}
+	static_assert( decoded_view_test( ) );
+} // namespace
+
+struct InsituRecord {
+	std::string_view text;
+	std::string_view other;
+	int number;
+	std::optional<std::string_view> optional;
+};
+
+struct MixedInsituRecord {
+	InsituRecord nested;
+	std::string owned;
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<InsituRecord> {
+		static constexpr char text[] = "text";
+		static constexpr char other[] = "other";
+		static constexpr char number[] = "number";
+		static constexpr char optional[] = "optional";
+		using type =
+		  json_member_list<json_string_insitu<text>, json_string_insitu<other>,
+		                   json_number<number, int>,
+		                   json_string_insitu_null<optional>>;
+		static auto to_json_data( InsituRecord const &v ) {
+			return std::tie( v.text, v.other, v.number, v.optional );
+		}
+	};
+	template<>
+	struct json_data_contract<MixedInsituRecord> {
+		static constexpr char nested[] = "nested";
+		static constexpr char owned[] = "owned";
+		using type =
+		  json_member_list<json_class<nested, InsituRecord>, json_string<owned>>;
+	};
+
+} // namespace daw::json
+
+namespace {
+	template<auto... Flags>
+	void
+	string_mapping_tests( daw::json::options::parse_flags_t<Flags...> flags ) {
+		using namespace daw::json;
+		struct test_case {
+			std::string_view encoded;
+			std::string_view decoded;
+		};
+		constexpr test_case cases[] = {
+		  { R"("")", "" },
+		  { R"("plain text")", "plain text" },
+		  { R"("\"\\\/\b\f\n\r\t")", "\"\\/\b\f\n\r\t" },
+		  { R"("\u0000after")", std::string_view( "\0after", 6 ) },
+		  { R"("\u007f\u0080\u07ff\u0800\uffff")",
+		    "\x7f\xc2\x80\xdf\xbf\xe0\xa0\x80\xef\xbf\xbf" },
+		  { R"("\uD800\uDC00\uDBFF\uDFFF")", "\xf0\x90\x80\x80\xf4\x8f\xbf\xbf" },
+		  { R"("\uD83D\uDE00")", "\xf0\x9f\x98\x80" },
+		  { R"("\u0041\u00e9\u20AC")", "A\xc3\xa9\xe2\x82\xac" },
+		  { "\"\xc3\xa9\"", "\xc3\xa9" },
+		  { R"("prefix\nsuffix with enough bytes to overlap the source")",
+		    "prefix\nsuffix with enough bytes to overlap the source" },
+		  { R"("\\n")", "\\n" },
+		};
+		for( auto const &tc : cases ) {
+			std::string input( tc.encoded );
+			auto const view = from_json_insitu<insitu_string>( input, flags );
+			daw_ensure( view == tc.decoded );
+			daw_ensure( view.data( ) == input.data( ) + 1 );
+			daw_ensure( daw::data_end( view ) <= daw::data_end( input ) );
+			daw_ensure( input.front( ) == '"' and *daw::data_end( view ) == '"' );
+			if( tc.encoded.find( '\\' ) == std::string_view::npos ) {
+				daw_ensure( input == tc.encoded );
+			}
+			auto const serialized = to_json<insitu_string>( view );
+			daw_ensure( from_json<std::string>( serialized ) == tc.decoded );
+		}
+		// Saved locations must preserve the original encoded bounds, even when
+		// fields are decoded in a different order from their input order.
+		for(
+		  std::string input :
+		  { R"({"text":"a\"b","other":"c\nd","number":42,"optional":"e\tf"})",
+		    R"({"optional":"e\tf","number":42,"other":"c\nd","text":"a\"b"})" } ) {
+			auto const text_pos = input.find( "a\\\"b" );
+			auto const other_pos = input.find( "c\\nd" );
+			auto const value = from_json_insitu<InsituRecord>( input, flags );
+			daw_ensure( value.text == "a\"b" and value.other == "c\nd" and
+			            value.number == 42 );
+			daw_ensure( value.optional and *value.optional == "e\tf" );
+			daw_ensure( value.text.data( ) == input.data( ) + text_pos );
+			daw_ensure( value.other.data( ) == input.data( ) + other_pos );
+			auto serialized = to_json( value );
+			auto const restored = from_json_insitu<InsituRecord>( serialized, flags );
+			daw_ensure( restored.text == value.text and
+			            restored.other == value.other );
+		}
+		for( std::string input :
+		     { R"({"text":"a","other":"b","number":42,"optional":null})",
+		       R"({"text":"a","other":"b","number":42})" } ) {
+			daw_ensure( not from_json_insitu<InsituRecord>( input, flags ).optional );
+		}
+		std::string array = R"(["a\nb","","c\"d"])";
+		using array_mapping = json_array_no_name<insitu_string>;
+		auto const values = from_json_insitu<array_mapping>( array, flags );
+		daw_ensure( values.size( ) == 3 and values[0] == "a\nb" and
+		            values[1].empty( ) and values[2] == "c\"d" );
+	}
+
+	void additional_mapping_tests( ) {
+		using namespace daw::json;
+		std::string input =
+		  R"({"owned":"own\u00e9d","unknown":[{"skip":"q\\r"}],"nested":{"text":"a\nb","other":"c","number":42}})";
+		auto const mixed = from_json_insitu<MixedInsituRecord>( input );
+		daw_ensure( mixed.owned ==
+		              "own\xc3\xa9"
+		              "d" and
+		            mixed.nested.text == "a\nb" );
+		std::string other_view_input = R"("a\tb")";
+		auto const other_view =
+		  from_json_insitu<json_string_insitu_no_name<daw::string_view>>(
+		    other_view_input );
+		daw_ensure( other_view == "a\tb" and
+		            other_view.data( ) == other_view_input.data( ) + 1 );
+		std::string optional_input = "null";
+		daw_ensure( not from_json_insitu<json_string_insitu_null_no_name<>>(
+		  optional_input ) );
+		std::string ascii_input = R"("a\n\u00e9")";
+		using ascii_mapping =
+		  json_string_insitu_no_name<std::string_view,
+		                             options::string_opt(
+		                               options::EightBitModes::DisallowHigh )>;
+		auto const ascii = from_json_insitu<ascii_mapping>( ascii_input );
+		daw_ensure( ascii == "a\n\xc3\xa9" );
+		daw_ensure( to_json<ascii_mapping>( ascii ) == R"("a\n\u00E9")" );
+		auto const schema = to_json_schema<InsituRecord>( "", "InsituRecord" );
+		daw_ensure( schema.find( R"("type":"string")" ) != std::string::npos );
+	}
+
+#if defined( DAW_USE_EXCEPTIONS )
+	void invalid_string_tests( ) {
+		using namespace daw::string_view_literals;
+		DAW_CPP23_STATIC_LOCAL constexpr std::array tests = {
+		  R"("\uDC00")"_sv,
+		  R"("\uD800")"_sv,
+		  R"("\u12")"_sv,
+		  R"("\uGGGG")"_sv,
+		  R"("\uD800\u0041")"_sv,
+		  R"("\uD800xuDC00")"_sv,
+		  R"("\q")"_sv,
+		  R"("unterminated)"_sv,
+		  R"("trailing\)"_sv,
+		  "\"raw\nnewline\""_sv };
+		for( std::size_t n = 0; n < tests.size( ); ++n ) {
+			auto const input_src = tests[n];
+			auto input = static_cast<std::string>( input_src );
+			bool rejected = false;
+			try {
+				(void)daw::json::from_json_insitu<insitu_string>(
+				  input, daw::json::ConformancePolicy );
+			} catch( daw::json::json_exception const &ex ) {
+				(void)ex;
+				rejected = true;
+			}
+			if( not rejected ) {
+				std::cerr << "Failed to reject: " << input << '\n';
+			}
+			daw_ensure( rejected );
+		}
+	}
+#endif
+} // namespace
+
+int main( ) {
+	additional_mapping_tests( );
+	string_mapping_tests( daw::json::options::parse_flags<> );
+	string_mapping_tests( daw::json::options::parse_flags<
+	                      daw::json::options::ExecModeTypes::runtime> );
+	string_mapping_tests(
+	  daw::json::options::parse_flags<daw::json::options::ExecModeTypes::simd> );
+	string_mapping_tests(
+	  daw::json::options::parse_flags<daw::json::options::CheckedParseMode::no> );
+#if defined( DAW_USE_EXCEPTIONS )
+	invalid_string_tests( );
+#endif
+
+	daw_ensure( decoded_view_test( ) );
+	std::string buffer = "42 ";
+	daw_ensure( daw::json::from_json_insitu<int>( buffer ) == 42 );
+	char boolean[] = "true ";
+	daw_ensure( daw::json::from_json_insitu<bool>( boolean ) );
+	std::array<char, 2> number = { '4', '2' };
+	daw_ensure( daw::json::from_json_insitu<int>( number ) == 42 );
+	daw_ensure( daw::json::from_json_insitu<int>(
+	              buffer,
+	              daw::json::options::parse_flags<
+	                daw::json::options::ExecModeTypes::compile_time> ) == 42 );
+	daw_ensure( ( daw::json::from_json_insitu<int, true>( number ) == 42 ) );
+	daw_ensure( daw::json::from_json<int>( std::string_view( buffer ) ) == 42 );
+	// The wrapper must preserve other flags and always enable mutation.
+	daw_ensure( daw::json::from_json_insitu<int>(
+	              number,
+	              daw::json::options::parse_flags<
+	                daw::json::options::AllowStringMutation::no> ) == 42 );
+#if defined( DAW_USE_EXCEPTIONS )
+	std::string trailing = "42 false";
+	bool rejected_trailing = false;
+	try {
+		(void)daw::json::from_json_insitu<int>(
+		  trailing,
+		  daw::json::options::parse_flags<
+		    daw::json::options::MustVerifyEndOfDataIsValid::yes> );
+	} catch( daw::json::json_exception const & ) { rejected_trailing = true; }
+	daw_ensure( rejected_trailing );
+#endif
+}

--- a/tests/src/long_double_test.cpp
+++ b/tests/src/long_double_test.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+
+#include <daw/json/daw_json_link.h>
+
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
+struct Holder {
+	long double v;
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<Holder> {
+#if defined( DAW_JSON_CNTTP_JSON_NAME )
+		using type = json_member_list<json_number<"v", long double>>;
+#else
+		static constexpr char const v[] = "v";
+		using type = json_member_list<json_number<v, long double>>;
+#endif
+	};
+} // namespace daw::json
+
+namespace {
+	// significant_digits/exponent chosen to hit both the ordinary fast path and
+	// the edge cases that force the Eisel-Lemire/strtod fallback: exponent
+	// magnitude > 22, and more significant digits than fit in a double's
+	// mantissa.
+	constexpr std::string_view cases[] = {
+	  "3.14",
+	  "-123.456e10",
+	  "1.7976931348623157e308",
+	  "2.2250738585072014e-308",
+	  "123456789012345678901234567890.123456789",
+	  "-0.0",
+	  "1e400",
+	  "1e-400",
+	};
+
+	[[nodiscard]] bool check_unknown_bounds( ) {
+		for( auto const c : cases ) {
+			auto const parsed =
+			  daw::json::from_json<long double>( daw::string_view( c ) );
+			auto const expected = std::strtold( std::string( c ).c_str( ), nullptr );
+			if( not( parsed == expected or
+			         ( parsed != parsed and expected != expected ) ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	[[nodiscard]] bool check_known_bounds( ) {
+		for( auto const c : cases ) {
+			auto const doc = "{\"v\":" + std::string( c ) + "}";
+			auto const parsed = daw::json::from_json<Holder>( doc ).v;
+			auto const expected = std::strtold( std::string( c ).c_str( ), nullptr );
+			if( not( parsed == expected or
+			         ( parsed != parsed and expected != expected ) ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+} // namespace
+
+int main( ) {
+	if( not check_unknown_bounds( ) ) {
+		return 1;
+	}
+	if( not check_known_bounds( ) ) {
+		return 1;
+	}
+}

--- a/tests/src/long_double_test.cpp
+++ b/tests/src/long_double_test.cpp
@@ -19,12 +19,8 @@ struct Holder {
 namespace daw::json {
 	template<>
 	struct json_data_contract<Holder> {
-#if defined( DAW_JSON_CNTTP_JSON_NAME )
-		using type = json_member_list<json_number<"v", long double>>;
-#else
 		static constexpr char const v[] = "v";
 		using type = json_member_list<json_number<v, long double>>;
-#endif
 	};
 } // namespace daw::json
 
@@ -46,7 +42,7 @@ namespace {
 
 	[[nodiscard]] bool check_unknown_bounds( ) {
 		for( auto const c : cases ) {
-			auto const parsed =
+			long double const parsed =
 			  daw::json::from_json<long double>( daw::string_view( c ) );
 			auto const expected = std::strtold( std::string( c ).c_str( ), nullptr );
 			if( not( parsed == expected or

--- a/tests/src/long_double_test.cpp
+++ b/tests/src/long_double_test.cpp
@@ -28,22 +28,25 @@ namespace daw::json {
 
 namespace {
 	// significant_digits/exponent chosen to hit both the ordinary fast path and
-	// the edge cases that force the Eisel-Lemire/strtod fallback: exponent
-	// magnitude > 22, and more significant digits than fit in a double's
-	// mantissa.
+	// the edge cases that force the Eisel-Lemire/strtod fallback, including more
+	// significant digits than fit in a double's mantissa.
 	constexpr std::string_view cases[] = {
-	  // power10 path (|exponent| <= 22)
+	  // ordinary power10 path
 	  "3.14",
 	  "-123.456e10",
 	  "1.23456789012345678e15",
 	  "1.23456789012345678e-15",
-	  // boundary of use_strtod trigger: exactly ±22 stays in power10, ±23 flips
-	  // to strtod
+	  // values around the legacy double-precision threshold
 	  "1e22",
 	  "1e-22",
 	  "1e23",
 	  "1e-23",
-	  // strtod/Eisel-Lemire fallback (|exponent| > 22)
+	  // 80-bit long double power10 boundary (binary128 extends this to ±48)
+	  "1e27",
+	  "1e-27",
+	  "1e28",
+	  "1e-28",
+	  // large-exponent fallback
 	  "1.7976931348623157e308",
 	  "2.2250738585072014e-308",
 	  // exponent_p1 > 0: whole-part digit count exceeds max_exponent, so digits

--- a/tests/src/long_double_test.cpp
+++ b/tests/src/long_double_test.cpp
@@ -8,7 +8,9 @@
 
 #include <daw/json/daw_json_link.h>
 
+#include <cstdio>
 #include <cstdlib>
+#include <iostream>
 #include <string>
 #include <string_view>
 
@@ -30,14 +32,37 @@ namespace {
 	// magnitude > 22, and more significant digits than fit in a double's
 	// mantissa.
 	constexpr std::string_view cases[] = {
+	  // power10 path (|exponent| <= 22)
 	  "3.14",
 	  "-123.456e10",
+	  "1.23456789012345678e15",
+	  "1.23456789012345678e-15",
+	  // boundary of use_strtod trigger: exactly ±22 stays in power10, ±23 flips
+	  // to strtod
+	  "1e22",
+	  "1e-22",
+	  "1e23",
+	  "1e-23",
+	  // strtod/Eisel-Lemire fallback (|exponent| > 22)
 	  "1.7976931348623157e308",
 	  "2.2250738585072014e-308",
+	  // exponent_p1 > 0: whole-part digit count exceeds max_exponent, so digits
+	  // are discarded and exponent_p1 is positive
+	  "12345678901234567890123e5",
+	  // discarded nonzero fractional digits: forces parse_json_real_exact path
+	  // for double/float via parse_truncated_lemire
+	  "1.23456789012345678901",
+	  // many significant digits
 	  "123456789012345678901234567890.123456789",
-	  "-0.0",
+	  // subnormal / deep-underflow long double (exercises power10 p < -max_exp
+	  // and strtod underflow)
+	  "1e-4932",
+	  "3.3621031431120935e-4932",
+	  // overflow / infinity
 	  "1e400",
 	  "1e-400",
+	  // zero and negative zero
+	  "-0.0",
 	};
 
 	[[nodiscard]] bool check_unknown_bounds( ) {
@@ -47,6 +72,8 @@ namespace {
 			auto const expected = std::strtold( std::string( c ).c_str( ), nullptr );
 			if( not( parsed == expected or
 			         ( parsed != parsed and expected != expected ) ) ) {
+				std::cerr << "unknown_bounds FAIL: " << c
+				          << "  parsed=" << parsed << " expected=" << expected << '\n';
 				return false;
 			}
 		}
@@ -60,6 +87,8 @@ namespace {
 			auto const expected = std::strtold( std::string( c ).c_str( ), nullptr );
 			if( not( parsed == expected or
 			         ( parsed != parsed and expected != expected ) ) ) {
+				std::cerr << "known_bounds FAIL: " << c
+				          << "  parsed=" << parsed << " expected=" << expected << '\n';
 				return false;
 			}
 		}

--- a/tests/src/nativejson_bench_nanobench.cpp
+++ b/tests/src/nativejson_bench_nanobench.cpp
@@ -26,14 +26,6 @@ using constexpr_checked_pol = parse_flags_t<ExecModeTypes::compile_time>;
 using constexpr_unchecked_pol =
   parse_flags_t<ExecModeTypes::compile_time, CheckedParseMode::no>;
 
-using runtime_checked_pol = parse_flags_t<ExecModeTypes::runtime>;
-using runtime_unchecked_pol =
-  parse_flags_t<ExecModeTypes::runtime, CheckedParseMode::no>;
-
-using simd_checked_pol = parse_flags_t<ExecModeTypes::simd>;
-using simd_unchecked_pol =
-  parse_flags_t<ExecModeTypes::simd, CheckedParseMode::no>;
-
 using PPair = std::pair<std::string_view, std::string_view>;
 
 template<typename ParseObj, typename ParsePolicy>
@@ -121,15 +113,6 @@ int main( int argc, char **argv ) {
 	  b1, "constexpr checked", twitter_doc, citm_doc, canada_doc );
 	bench<constexpr_unchecked_pol>(
 	  b1, "constexpr unchecked", twitter_doc, citm_doc, canada_doc );
-	bench<runtime_checked_pol>(
-	  b1, "runtime checked", twitter_doc, citm_doc, canada_doc );
-	bench<runtime_unchecked_pol>(
-	  b1, "runtime unchecked", twitter_doc, citm_doc, canada_doc );
-
-	bench<simd_checked_pol>(
-	  b1, "simd checked", twitter_doc, citm_doc, canada_doc );
-	bench<simd_unchecked_pol>(
-	  b1, "simd unchecked", twitter_doc, citm_doc, canada_doc );
 
 	if( argc > 4 ) {
 		std::string_view const fname = argv[4];

--- a/tests/src/parse_policy_options_test.cpp
+++ b/tests/src/parse_policy_options_test.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+//  Covers options::ZeroTerminatedString and options::MinifiedDocument, which
+//  are policy bits that are never explicitly set by any other existing test.
+//
+
+#include <daw/json/daw_json_link.h>
+
+#include <daw/daw_ensure.h>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+struct PolicyOptionsHolder {
+	int a;
+	std::vector<int> b;
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<PolicyOptionsHolder> {
+		static constexpr char a[] = "a";
+		static constexpr char b[] = "b";
+		using type = json_member_list<json_number<a, int>, json_array<b, int>>;
+	};
+} // namespace daw::json
+
+int main( ) {
+	using namespace daw::json;
+
+	// `from_json` only sets ZeroTerminatedString::yes automatically when the
+	// argument's *type* is std::string.  A std::string_view/char const * never
+	// gets promoted, even when its buffer happens to be zero terminated.  These
+	// two cases exercise explicitly overriding that type-based default in both
+	// directions.
+	{
+		// Override a std::string argument (would default to "yes") to "no",
+		// forcing the bounds-checked code path.
+		std::string const buf = R"({"a":1,"b":[1,2,3]})";
+		static constexpr auto policy =
+		  options::parse_flags<options::ZeroTerminatedString::no>;
+		auto const v = from_json<PolicyOptionsHolder>( buf, policy );
+		daw_ensure( v.a == 1 );
+		daw_ensure( ( v.b == std::vector<int>{ 1, 2, 3 } ) );
+	}
+	{
+		// Override a std::string_view argument (would default to "no") to
+		// "yes".  The backing buffer is genuinely zero terminated even though
+		// the argument's type does not guarantee it.
+		std::string const backing = R"({"a":4,"b":[4,5,6]})";
+		std::string_view const sv( backing.data( ), backing.size( ) );
+		static constexpr auto policy =
+		  options::parse_flags<options::ZeroTerminatedString::yes>;
+		auto const v = from_json<PolicyOptionsHolder>( sv, policy );
+		daw_ensure( v.a == 4 );
+		daw_ensure( ( v.b == std::vector<int>{ 4, 5, 6 } ) );
+	}
+
+	// MinifiedDocument::yes tells the parser to skip whitespace trimming
+	// entirely.  It is only correct when the document truly has no whitespace.
+	{
+		std::string_view const sv = R"({"a":7,"b":[7,8,9]})";
+		static constexpr auto policy =
+		  options::parse_flags<options::MinifiedDocument::yes>;
+		auto const v = from_json<PolicyOptionsHolder>( sv, policy );
+		daw_ensure( v.a == 7 );
+		daw_ensure( ( v.b == std::vector<int>{ 7, 8, 9 } ) );
+	}
+}

--- a/tests/src/serialize_policy_options_test.cpp
+++ b/tests/src/serialize_policy_options_test.cpp
@@ -140,6 +140,29 @@ int main( )
 		daw_ensure( not out.empty( ) );
 	}
 
+	// RestrictedStringOutput::OnlyAllow7bitStrings permits the full 7-bit
+	// range, including DEL (0x7F).
+	{
+		std::string value = "ok ";
+		value.push_back( static_cast<char>( 0x7F ) );
+		auto const out = to_json(
+		  RestrictedOutputHolder{ value },
+		  options::output_flags<
+		    options::RestrictedStringOutput::OnlyAllow7bitStrings> );
+		auto expected = std::string{ R"({"s":"ok )" };
+		expected.push_back( static_cast<char>( 0x7F ) );
+		expected += R"("})";
+		daw_ensure( out == expected );
+	}
+	{
+		using disallow_high_string = json_string_no_name<
+		  std::string,
+		  options::string_opt( options::EightBitModes::DisallowHigh )>;
+		std::string_view const value = "\x7F";
+		std::string_view const expected = "\"\x7F\"";
+		daw_ensure( to_json<disallow_high_string>( value ) == expected );
+	}
+
 #if defined( DAW_USE_EXCEPTIONS )
 	// RestrictedStringOutput::ErrorInvalidUTF8 throws on invalid UTF-8.
 	{

--- a/tests/src/serialize_policy_options_test.cpp
+++ b/tests/src/serialize_policy_options_test.cpp
@@ -1,0 +1,166 @@
+// Copyright (c) Darrell Wright
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/beached/daw_json_link
+//
+//  Covers serialization options that no other existing test sets:
+//  options::IndentationType (non-default values), options::NewLineDelimiter,
+//  options::OutputTrailingComma, and options::RestrictedStringOutput::None /
+//  ::ErrorInvalidUTF8.
+//
+
+#include <daw/json/daw_json_link.h>
+#include <daw/json/daw_json_writer.h>
+
+#include <daw/daw_ensure.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+struct TrailingCommaHolder {
+	std::vector<int> b;
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<TrailingCommaHolder> {
+		static constexpr char b[] = "b";
+		using type = json_member_list<json_array<b, int>>;
+
+		static auto to_json_data( TrailingCommaHolder const &v ) {
+			return std::forward_as_tuple( v.b );
+		}
+	};
+} // namespace daw::json
+
+struct RestrictedOutputHolder {
+	std::string s;
+};
+
+namespace daw::json {
+	template<>
+	struct json_data_contract<RestrictedOutputHolder> {
+		static constexpr char s[] = "s";
+		using type = json_member_list<json_string<s>>;
+
+		static auto to_json_data( RestrictedOutputHolder const &v ) {
+			return std::forward_as_tuple( v.s );
+		}
+	};
+} // namespace daw::json
+
+int main( )
+#if defined( DAW_USE_EXCEPTIONS )
+  try
+#endif
+{
+	using namespace daw::json;
+
+	// IndentationType::Tab
+	{
+		auto out = std::string{ };
+		{
+			auto w = json_writer<options::SerializationFormat::Pretty,
+			                     options::IndentationType::Tab>( out );
+			w.open_object( );
+			w.write_key_value( "a", 42 );
+			w.write_key_value( "b", { 1, 2, 3 } );
+		}
+		daw_ensure( out == "{\n\t\"a\": 42,\n\t\"b\": [\n\t\t1,\n\t\t2,\n\t\t3\n\t]\n}" );
+	}
+
+	// IndentationType::Space4 (a non-default value; Space2 is already covered
+	// elsewhere)
+	{
+		auto out = std::string{ };
+		{
+			auto w = json_writer<options::SerializationFormat::Pretty,
+			                     options::IndentationType::Space4>( out );
+			w.open_object( );
+			w.write_key_value( "a", 42 );
+		}
+		daw_ensure( out == "{\n    \"a\": 42\n}" );
+	}
+
+	// NewLineDelimiter::rn
+	{
+		auto out = std::string{ };
+		{
+			auto w = json_writer<options::SerializationFormat::Pretty,
+			                     options::NewLineDelimiter::rn>( out );
+			w.open_object( );
+			w.write_key_value( "a", 42 );
+		}
+		daw_ensure( out == "{\r\n  \"a\": 42\r\n}" );
+	}
+
+	// OutputTrailingComma::Yes
+	//
+	// Note: this option is only honored by the automatic class/array
+	// serializer (json_data_contract-based to_json), not by the manual
+	// json_writer API -- daw_json_writer.h's open_object/close_object and
+	// open_array/close_array never consult it, so a manual-writer-based test
+	// here would silently test nothing.
+	{
+		auto const v = TrailingCommaHolder{ { 1, 2, 3 } };
+		auto const out = to_json(
+		  v,
+		  options::output_flags<options::SerializationFormat::Pretty,
+		                        options::OutputTrailingComma::Yes> );
+		daw_ensure( out == "{\n  \"b\": [\n    1,\n    2,\n    3,\n  ],\n}" );
+	}
+
+	// RestrictedStringOutput::None tolerates invalid UTF-8 without throwing.
+	// (Note: despite the "default: None" comment on the enum's declaration in
+	// daw_json_serialize_options.h, the actual compiled-in default is
+	// ErrorInvalidUTF8 -- see default_json_option_value<RestrictedStringOutput>
+	// in daw_json_serialize_options_impl.h, which matches what this cookbook
+	// page documents.
+	//
+	// This must go through the automatic class serializer (to_json on a
+	// json_data_contract type with output_flags<...>), not the manual
+	// json_writer API: json_writer_t::write_value ends up calling
+	// to_json<JsonClass>(value, m_writer.get()) (daw_json_writer.h:121),
+	// and m_writer.get() strips the PolicyFlags the writer was constructed
+	// with, so the *value*-formatting flags (RestrictedStringOutput among
+	// them) silently fall back to their compiled-in defaults there -- only
+	// the structural flags used directly via m_writer (indentation, newline,
+	// used by add_indent/del_indent/next_member) actually apply. A test built
+	// on the manual writer would therefore test nothing.)
+	{
+		std::string bad = "ok ";
+		bad.push_back( static_cast<char>( 0xFF ) );
+		auto const v = RestrictedOutputHolder{ bad };
+		auto const out =
+		  to_json( v, options::output_flags<options::RestrictedStringOutput::None> );
+		daw_ensure( not out.empty( ) );
+	}
+
+#if defined( DAW_USE_EXCEPTIONS )
+	// RestrictedStringOutput::ErrorInvalidUTF8 throws on invalid UTF-8.
+	{
+		std::string bad = "ok ";
+		bad.push_back( static_cast<char>( 0xFF ) );
+		auto const v = RestrictedOutputHolder{ bad };
+		bool threw = false;
+		try {
+			(void)to_json(
+			  v,
+			  options::output_flags<options::RestrictedStringOutput::ErrorInvalidUTF8> );
+		} catch( daw::json::json_exception const & ) {
+			threw = true;
+		}
+		daw_ensure( threw );
+	}
+#endif
+}
+#if defined( DAW_USE_EXCEPTIONS )
+catch( daw::json::json_exception const &jex ) {
+	std::cerr << "Exception thrown by parser: " << jex.reason( ) << '\n';
+	exit( 1 );
+}
+#endif

--- a/tests/src/test_json_date.cpp
+++ b/tests/src/test_json_date.cpp
@@ -11,6 +11,7 @@
 #include <daw/daw_ensure.h>
 
 #include <chrono>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 
@@ -93,7 +94,43 @@ int main( ) {
 #if defined( DAW_HAS_INT128 )
 	test_wide_attosecond_duration<daw::int128_t>( );
 #endif
+	{
+		auto const parsed = daw::json::from_json<Date>(
+		  R"json({"timestamp":"2024-09-02T01:14:54+02:30"})json" );
+		auto const expected = daw::json::datetime::civil_to_time_point(
+		  2024, 9, 1, 22, 44, 54, 0 );
+		daw_ensure( parsed.timestamp == expected );
+	}
+	{
+		auto const parsed = daw::json::from_json<Date>(
+		  R"json({"timestamp":"2024-09-02T23:14:54-02:30"})json" );
+		auto const expected = daw::json::datetime::civil_to_time_point(
+		  2024, 9, 3, 1, 44, 54, 0 );
+		daw_ensure( parsed.timestamp == expected );
+	}
+	{
+		auto const parsed = daw::json::from_json<Date>(
+		  R"json({"timestamp":"2024-09-02T01:14:54+0230"})json" );
+		auto const expected = daw::json::datetime::civil_to_time_point(
+		  2024, 9, 1, 22, 44, 54, 0 );
+		daw_ensure( parsed.timestamp == expected );
+	}
 #if defined( DAW_USE_EXCEPTIONS )
+	auto const ensure_invalid_timestamp = []( std::string_view json_document ) {
+		bool success = false;
+		try {
+			(void)daw::json::from_json<Date>( json_document );
+		} catch( std::exception const & ) { success = true; }
+		daw_ensure( success );
+	};
+	ensure_invalid_timestamp(
+	  R"json({"timestamp":"2023-02-29T01:14:54Z"})json" );
+	ensure_invalid_timestamp(
+	  R"json({"timestamp":"2024-02-31T01:14:54Z"})json" );
+	ensure_invalid_timestamp(
+	  R"json({"timestamp":"2024-04-31T01:14:54Z"})json" );
+	ensure_invalid_timestamp(
+	  R"json({"timestamp":"2024-09-02T24:59:59Z"})json" );
 	{
 		bool success = false;
 		try {

--- a/tests/src/test_parse_real_lemire.cpp
+++ b/tests/src/test_parse_real_lemire.cpp
@@ -5,6 +5,7 @@
 
 #include <daw/json/impl/daw_json_parse_real_eisellemire.h>
 
+#include <daw/daw_arith_traits.h>
 #include <daw/daw_bit_cast.h>
 
 #include <array>
@@ -21,22 +22,21 @@ namespace {
 	constexpr bool append_digit_check( ) {
 		std::uint64_t value = 1844674407370955161ULL;
 		if( not try_append_digit( value, 5U ) or
-		    value != std::numeric_limits<std::uint64_t>::max( ) ) {
+		    value != daw::max_value<std::uint64_t> ) {
 			return false;
 		}
 		return not try_append_digit( value, 0U ) and
-		       value == std::numeric_limits<std::uint64_t>::max( );
+		       value == daw::max_value<std::uint64_t>;
 	}
 
 	static_assert( append_digit_check( ) );
 
 	constexpr auto multiplication_check =
 	  daw::json::json_details::eisellemire_details::full_multiplication_generic(
-	    std::numeric_limits<std::uint64_t>::max( ),
-	    std::numeric_limits<std::uint64_t>::max( ) );
+	    daw::max_value<std::uint64_t>, daw::max_value<std::uint64_t> );
 	static_assert( multiplication_check.low == 1 );
 	static_assert( multiplication_check.high ==
-	               std::numeric_limits<std::uint64_t>::max( ) - 1 );
+	               daw::max_value<std::uint64_t> - 1 );
 	static_assert( parse_real_eisellemire( false, 0, 1 ) == 1.0 );
 	static_assert( parse_real_eisellemire( true, 0, 1 ) == -1.0 );
 	static_assert( parse_real_eisellemire( false, -2, 12345 ) == 123.45 );
@@ -61,11 +61,11 @@ namespace {
 		if( negative ) {
 			*first++ = '-';
 		}
-		auto result = std::to_chars( first, buffer.data( ) + buffer.size( ) - 1,
-		                             significant_digits );
+		auto result = std::to_chars(
+		  first, buffer.data( ) + buffer.size( ) - 1, significant_digits );
 		*result.ptr++ = 'e';
-		result = std::to_chars( result.ptr, buffer.data( ) + buffer.size( ) - 1,
-		                        exponent );
+		result = std::to_chars(
+		  result.ptr, buffer.data( ) + buffer.size( ) - 1, exponent );
 		*result.ptr = '\0';
 		if constexpr( std::is_same_v<Real, float> ) {
 			return std::strtof( buffer.data( ), nullptr );
@@ -76,9 +76,8 @@ namespace {
 
 	template<typename Real>
 	[[nodiscard]] bool same_bits( Real lhs, Real rhs ) {
-		using uint_type =
-		  std::conditional_t<std::is_same_v<Real, float>, std::uint32_t,
-		                     std::uint64_t>;
+		using uint_type = std::
+		  conditional_t<std::is_same_v<Real, float>, std::uint32_t, std::uint64_t>;
 		return DAW_BIT_CAST( uint_type, lhs ) == DAW_BIT_CAST( uint_type, rhs );
 	}
 } // namespace
@@ -100,7 +99,7 @@ int main( ) {
 	  { 22250738585072014ULL, -324, false },
 	  { 17976931348623157ULL, 292, false },
 	  { 17976931348623158ULL, 292, false },
-	  { std::numeric_limits<std::uint64_t>::max( ), -342, false },
+	  { daw::max_value<std::uint64_t>, -342, false },
 	};
 
 	for( auto const &test : cases ) {
@@ -136,7 +135,7 @@ int main( ) {
 	  { 11754944, -45, false },
 	  { 34028235, 31, false },
 	  { 34028236, 31, false },
-	  { std::numeric_limits<std::uint64_t>::max( ), -64, false },
+	  { daw::max_value<std::uint64_t>, -64, false },
 	};
 	for( auto const &test : float_cases ) {
 		auto const actual = parse_real_eisellemire<float>(

--- a/tests/src/twitter_insitu_test.cpp
+++ b/tests/src/twitter_insitu_test.cpp
@@ -8,7 +8,7 @@
 #include "defines.h"
 
 #include "daw_json_benchmark.h"
-#include "twitter_test_json.h"
+#include "twitter_insitu_test_json.h"
 
 #include <daw/cpp_17.h>
 #include <daw/daw_read_file.h>
@@ -32,7 +32,7 @@ using namespace daw::json::options;
 
 inline namespace {
 	template<ExecModeTypes ExecMode>
-	void test( std::string_view json_data, bool do_asserts )
+	void test( std::string json_data, bool do_asserts )
 #if defined( DAW_USE_EXCEPTIONS )
 	  try
 #endif
@@ -40,15 +40,16 @@ inline namespace {
 		auto const sz = json_data.size( );
 		std::cout << "Using " << to_string( ExecMode )
 		          << " exec model\n*********************************************\n";
-		std::optional<daw::twitter::twitter_object_t> twitter_result;
+		std::optional<daw::twitter_insitu::twitter_object_t> twitter_result;
 		// ******************************
 		(void)daw::json::benchmark::benchmark(
 		  DAW_NUM_RUNS,
 		  sz,
 		  "twitter bench(checked)",
 		  [&twitter_result]( auto f1 ) {
-			  twitter_result = daw::json::from_json<daw::twitter::twitter_object_t>(
-			    f1, parse_flags<ExecMode> );
+			  twitter_result =
+			    daw::json::from_json_insitu<daw::twitter_insitu::twitter_object_t>(
+			      f1, parse_flags<ExecMode> );
 			  daw::do_not_optimize( twitter_result );
 		  },
 		  json_data );
@@ -66,8 +67,9 @@ inline namespace {
 		  sz,
 		  "twitter bench(unchecked)",
 		  [&twitter_result]( auto f1 ) {
-			  twitter_result = daw::json::from_json<daw::twitter::twitter_object_t>(
-			    f1, parse_flags<CheckedParseMode::no, ExecMode> );
+			  twitter_result =
+			    daw::json::from_json_insitu<daw::twitter_insitu::twitter_object_t>(
+			      f1, parse_flags<CheckedParseMode::no, ExecMode> );
 			  daw::do_not_optimize( twitter_result );
 		  },
 		  json_data );
@@ -84,8 +86,9 @@ inline namespace {
 		  sz,
 		  "twitter bench(cpp comments)",
 		  [&twitter_result]( auto f1 ) {
-			  twitter_result = daw::json::from_json<daw::twitter::twitter_object_t>(
-			    f1, parse_flags<ExecMode, PolicyCommentTypes::cpp> );
+			  twitter_result =
+			    daw::json::from_json_insitu<daw::twitter_insitu::twitter_object_t>(
+			      f1, parse_flags<ExecMode, PolicyCommentTypes::cpp> );
 			  daw::do_not_optimize( twitter_result );
 		  },
 		  json_data );
@@ -103,11 +106,12 @@ inline namespace {
 		  sz,
 		  "twitter bench(cpp comments, unchecked)",
 		  [&twitter_result]( auto f1 ) {
-			  twitter_result = daw::json::from_json<daw::twitter::twitter_object_t>(
-			    f1,
-			    parse_flags<ExecMode,
-			                CheckedParseMode::no,
-			                PolicyCommentTypes::cpp> );
+			  twitter_result =
+			    daw::json::from_json_insitu<daw::twitter_insitu::twitter_object_t>(
+			      f1,
+			      parse_flags<ExecMode,
+			                  CheckedParseMode::no,
+			                  PolicyCommentTypes::cpp> );
 			  daw::do_not_optimize( twitter_result );
 		  },
 		  json_data );
@@ -126,7 +130,8 @@ inline namespace {
 		  "twitter bench(hash comments)",
 		  [&twitter_result]( auto f1 ) {
 			  twitter_result =
-			    daw::json::from_json<daw::twitter::twitter_object_t>( f1 );
+			    daw::json::from_json_insitu<daw::twitter_insitu::twitter_object_t>(
+			      f1 );
 			  daw::do_not_optimize( twitter_result,
 			                        parse_flags<ExecMode, PolicyCommentTypes::hash> );
 		  },
@@ -145,11 +150,12 @@ inline namespace {
 		  sz,
 		  "twitter bench(hash comments, unchecked)",
 		  [&twitter_result]( auto f1 ) {
-			  twitter_result = daw::json::from_json<daw::twitter::twitter_object_t>(
-			    f1,
-			    parse_flags<ExecMode,
-			                CheckedParseMode::no,
-			                PolicyCommentTypes::hash> );
+			  twitter_result =
+			    daw::json::from_json_insitu<daw::twitter_insitu::twitter_object_t>(
+			      f1,
+			      parse_flags<ExecMode,
+			                  CheckedParseMode::no,
+			                  PolicyCommentTypes::hash> );
 			  daw::do_not_optimize( twitter_result );
 		  },
 		  json_data );
@@ -168,8 +174,9 @@ inline namespace {
 		  sz,
 		  "twitter bench(checked, escaped names)",
 		  [&twitter_result]( auto f1 ) {
-			  twitter_result = daw::json::from_json<daw::twitter::twitter_object_t>(
-			    f1, parse_flags<ExecMode, AllowEscapedNames::yes> );
+			  twitter_result =
+			    daw::json::from_json_insitu<daw::twitter_insitu::twitter_object_t>(
+			      f1, parse_flags<ExecMode, AllowEscapedNames::yes> );
 			  daw::do_not_optimize( twitter_result );
 		  },
 		  json_data );
@@ -187,12 +194,13 @@ inline namespace {
 		  sz,
 		  "twitter bench(unchecked, escaped names)",
 		  [&twitter_result]( auto f1 ) {
-			  twitter_result = daw::json::from_json<daw::twitter::twitter_object_t>(
-			    f1,
-			    parse_flags<ExecMode,
-			                CheckedParseMode::no,
-			                PolicyCommentTypes::cpp,
-			                AllowEscapedNames::yes> );
+			  twitter_result =
+			    daw::json::from_json_insitu<daw::twitter_insitu::twitter_object_t>(
+			      f1,
+			      parse_flags<ExecMode,
+			                  CheckedParseMode::no,
+			                  PolicyCommentTypes::cpp,
+			                  AllowEscapedNames::yes> );
 			  daw::do_not_optimize( twitter_result );
 		  },
 		  json_data );
@@ -236,7 +244,7 @@ int main( int argc, char **argv )
 		}
 		return true;
 	}( );
-	std::string const json_data = [argv] {
+	std::string json_data = [argv] {
 		auto const mmf = daw::read_file( argv[1] ).value( );
 		test_assert( mmf.size( ) > 2, "Minimum json data size is 2 '{}'" );
 		return std::string( mmf.data( ), mmf.size( ) );
@@ -249,8 +257,9 @@ int main( int argc, char **argv )
 
 	// ******************************
 	// Test serialization
-	std::optional<daw::twitter::twitter_object_t> twitter_result =
-	  daw::json::from_json<daw::twitter::twitter_object_t>( json_data );
+	std::optional<daw::twitter_insitu::twitter_object_t> twitter_result =
+	  daw::json::from_json_insitu<daw::twitter_insitu::twitter_object_t>(
+	    json_data );
 	std::string str{ };
 	(void)daw::json::benchmark::benchmark(
 	  DAW_NUM_RUNS,
@@ -267,7 +276,7 @@ int main( int argc, char **argv )
 	}
 	daw::do_not_optimize( str );
 	auto const twitter_result2 =
-	  daw::json::from_json<daw::twitter::twitter_object_t>( str );
+	  daw::json::from_json_insitu<daw::twitter_insitu::twitter_object_t>( str );
 	daw::do_not_optimize( twitter_result2 );
 }
 #if defined( DAW_USE_EXCEPTIONS )


### PR DESCRIPTION
* Added insitu string parsing support that allows json_string_insitu and related mappings to write directly to a writeable json buffer.
* Added more tests to ensure errors on invalid inputs and test correct inputs on more paths
* Fixed bugs in things like iso8601 parsing and output  formatting of json_writer